### PR TITLE
✨(frontend) add crisp chatbot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 - ✨(backend) config endpoint #425
 - ✨(frontend) config endpoint #424
 - ✨(frontend) add sentry #424
+- ✨(frontend) add crisp chatbot #273
 
 ## Changed
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -902,6 +902,7 @@ class ConfigView(views.APIView):
         """
         array_settings = [
             "COLLABORATION_SERVER_URL",
+            "CRISP_WEBSITE_ID",
             "ENVIRONMENT",
             "FRONTEND_THEME",
             "MEDIA_BASE_URL",

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -17,47 +17,29 @@ pytestmark = pytest.mark.django_db
 
 @override_settings(
     COLLABORATION_SERVER_URL="http://testcollab/",
+    CRISP_WEBSITE_ID="123",
     FRONTEND_THEME="test-theme",
     MEDIA_BASE_URL="http://testserver/",
     SENTRY_DSN="https://sentry.test/123",
 )
-def test_api_config_anonymous():
+@pytest.mark.parametrize("is_authenticated", [False, True])
+def test_api_config(is_authenticated):
     """Anonymous users should be allowed to get the configuration."""
     client = APIClient()
-    response = client.get("/api/v1.0/config/")
-    assert response.status_code == HTTP_200_OK
-    assert response.json() == {
-        "COLLABORATION_SERVER_URL": "http://testcollab/",
-        "ENVIRONMENT": "test",
-        "FRONTEND_THEME": "test-theme",
-        "LANGUAGES": [["en-us", "English"], ["fr-fr", "French"], ["de-de", "German"]],
-        "LANGUAGE_CODE": "en-us",
-        "MEDIA_BASE_URL": "http://testserver/",
-        "SENTRY_DSN": "https://sentry.test/123",
-    }
 
-
-@override_settings(
-    COLLABORATION_SERVER_URL="http://testcollab/",
-    FRONTEND_THEME="test-theme",
-    MEDIA_BASE_URL="http://testserver/",
-    SENTRY_DSN="https://sentry.test/123",
-)
-def test_api_config_authenticated():
-    """Authenticated users should be allowed to get the configuration."""
-    user = factories.UserFactory()
-
-    client = APIClient()
-    client.force_login(user)
+    if is_authenticated:
+        user = factories.UserFactory()
+        client.force_login(user)
 
     response = client.get("/api/v1.0/config/")
     assert response.status_code == HTTP_200_OK
     assert response.json() == {
         "COLLABORATION_SERVER_URL": "http://testcollab/",
+        "CRISP_WEBSITE_ID": "123",
         "ENVIRONMENT": "test",
         "FRONTEND_THEME": "test-theme",
-        "MEDIA_BASE_URL": "http://testserver/",
         "LANGUAGES": [["en-us", "English"], ["fr-fr", "French"], ["de-de", "German"]],
         "LANGUAGE_CODE": "en-us",
+        "MEDIA_BASE_URL": "http://testserver/",
         "SENTRY_DSN": "https://sentry.test/123",
     }

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -381,6 +381,11 @@ class Base(Configuration):
         None, environ_name="FRONTEND_THEME", environ_prefix=None
     )
 
+    # Crisp
+    CRISP_WEBSITE_ID = values.Value(
+        None, environ_name="CRISP_WEBSITE_ID", environ_prefix=None
+    )
+
     # Easy thumbnails
     THUMBNAIL_EXTENSION = "webp"
     THUMBNAIL_TRANSPARENCY_EXTENSION = "webp"

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -23,6 +23,7 @@
     "@openfun/cunningham-react": "2.9.4",
     "@sentry/nextjs": "8.40.0",
     "@tanstack/react-query": "5.61.3",
+    "crisp-sdk-web": "1.0.25",
     "i18next": "24.0.0",
     "i18next-browser-languagedetector": "8.0.0",
     "idb": "8.0.0",

--- a/src/frontend/apps/impress/src/core/auth/__tests__/useAuthStore.test.tsx
+++ b/src/frontend/apps/impress/src/core/auth/__tests__/useAuthStore.test.tsx
@@ -1,0 +1,40 @@
+import { Crisp } from 'crisp-sdk-web';
+import fetchMock from 'fetch-mock';
+
+import { useAuthStore } from '../useAuthStore';
+
+jest.mock('crisp-sdk-web', () => ({
+  ...jest.requireActual('crisp-sdk-web'),
+  Crisp: {
+    isCrispInjected: jest.fn().mockReturnValue(true),
+    setTokenId: jest.fn(),
+    user: {
+      setEmail: jest.fn(),
+    },
+    session: {
+      reset: jest.fn(),
+    },
+  },
+}));
+
+describe('useAuthStore', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it('checks support session is terminated when logout', () => {
+    window.$crisp = true;
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...window.location,
+        replace: jest.fn(),
+      },
+      writable: true,
+    });
+
+    useAuthStore.getState().logout();
+
+    expect(Crisp.session.reset).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/apps/impress/src/core/auth/useAuthStore.tsx
+++ b/src/frontend/apps/impress/src/core/auth/useAuthStore.tsx
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 
 import { baseApiUrl } from '@/api';
+import { terminateCrispSession } from '@/services';
 
 import { User, getMe } from './api';
 import { PATH_AUTH_LOCAL_STORAGE } from './conf';
@@ -42,6 +43,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     window.location.replace(`${baseApiUrl()}authenticate/`);
   },
   logout: () => {
+    terminateCrispSession();
     window.location.replace(`${baseApiUrl()}logout/`);
   },
   // If we try to access a specific page and we are not authenticated

--- a/src/frontend/apps/impress/src/core/config/ConfigProvider.tsx
+++ b/src/frontend/apps/impress/src/core/config/ConfigProvider.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren, useEffect } from 'react';
 
 import { Box } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
+import { configureCrispSession } from '@/services';
 import { useSentryStore } from '@/stores/useSentryStore';
 
 import { useConfig } from './api/useConfig';
@@ -27,6 +28,14 @@ export const ConfigProvider = ({ children }: PropsWithChildren) => {
 
     setTheme(conf.FRONTEND_THEME);
   }, [conf?.FRONTEND_THEME, setTheme]);
+
+  useEffect(() => {
+    if (!conf?.CRISP_WEBSITE_ID) {
+      return;
+    }
+
+    configureCrispSession(conf.CRISP_WEBSITE_ID);
+  }, [conf?.CRISP_WEBSITE_ID]);
 
   if (!conf) {
     return (

--- a/src/frontend/apps/impress/src/core/config/api/useConfig.tsx
+++ b/src/frontend/apps/impress/src/core/config/api/useConfig.tsx
@@ -4,13 +4,14 @@ import { APIError, errorCauses, fetchAPI } from '@/api';
 import { Theme } from '@/cunningham/';
 
 interface ConfigResponse {
-  SENTRY_DSN: string;
-  COLLABORATION_SERVER_URL: string;
-  ENVIRONMENT: string;
-  FRONTEND_THEME: Theme;
   LANGUAGES: [string, string][];
   LANGUAGE_CODE: string;
-  MEDIA_BASE_URL: string;
+  ENVIRONMENT: string;
+  COLLABORATION_SERVER_URL?: string;
+  CRISP_WEBSITE_ID?: string;
+  FRONTEND_THEME?: Theme;
+  MEDIA_BASE_URL?: string;
+  SENTRY_DSN?: string;
 }
 
 export const getConfig = async (): Promise<ConfigResponse> => {

--- a/src/frontend/apps/impress/src/services/Crisp.tsx
+++ b/src/frontend/apps/impress/src/services/Crisp.tsx
@@ -1,0 +1,30 @@
+/**
+ * Configure Crisp chat for real-time support across all pages.
+ */
+
+import { Crisp } from 'crisp-sdk-web';
+
+import { User } from '@/core';
+
+export const initializeCrispSession = (user: User) => {
+  if (!Crisp.isCrispInjected()) {
+    return;
+  }
+  Crisp.setTokenId(`impress-${user.id}`);
+  Crisp.user.setEmail(user.email);
+};
+
+export const configureCrispSession = (websiteId: string) => {
+  if (Crisp.isCrispInjected()) {
+    return;
+  }
+  Crisp.configure(websiteId);
+};
+
+export const terminateCrispSession = () => {
+  if (!Crisp.isCrispInjected()) {
+    return;
+  }
+  Crisp.setTokenId();
+  Crisp.session.reset();
+};

--- a/src/frontend/apps/impress/src/services/index.ts
+++ b/src/frontend/apps/impress/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './Crisp';

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -5930,6 +5930,11 @@ crelt@^1.0.0:
   resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
   integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
 
+crisp-sdk-web@1.0.25:
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/crisp-sdk-web/-/crisp-sdk-web-1.0.25.tgz#5566227dfcc018435b228db2f998d66581e5fdef"
+  integrity sha512-CWTHFFeHRV0oqiXoPh/aIAKhFs6xcIM4NenGPnClAMCZUDQgQsF1OWmZWmnVNjJriXUmWRgDfeUxcxygS0dCRA==
+
 cross-env@*, cross-env@7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"


### PR DESCRIPTION
## Purpose

We want to add crisp chatbot to allow for easy user interaction with support team.

## Proposal

We add the chatbot component using crisp-web-sdk. We initialize the chatbot with the user email to allow for follow-up.
