### PR TITLE
⚗️(backend) Text to yjs base64

### DIFF
--- a/src/backend/core/tests/test_utils.py
+++ b/src/backend/core/tests/test_utils.py
@@ -10,7 +10,7 @@ from django.core import mail
 
 import pytest
 
-from core.utils import email_invitation, yjs_base64_to_text
+from core.utils import email_invitation, text_to_yjs_base64, yjs_base64_to_text
 
 pytestmark = pytest.mark.django_db
 
@@ -110,4 +110,9 @@ def test_yjs_base64_to_text():
         "dGV4dENvbG9yAXcHZGVmYXVsdCgA9e7y1Q4eD2JhY2tncm91bmRDb2xvcgF3B2RlZmF1bHQA"
     )
 
+    assert yjs_base64_to_text(base64_string) == "Hello world"
+
+
+def test_text_to_yjs_base64():
+    base64_string = text_to_yjs_base64("Hello world")
     assert yjs_base64_to_text(base64_string) == "Hello world"

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -56,3 +56,23 @@ def yjs_base64_to_text(base64_string):
 
     soup = BeautifulSoup(blocknote_structure, "html.parser")
     return soup.get_text(separator=" ").strip()
+
+
+def text_to_yjs_base64(text: str) -> str:
+    """Convert plain text to a base64-encoded Yjs document"""
+    doc = Y.YDoc()
+
+    # Insert the paragraph text into the document
+    with doc.begin_transaction() as txn:
+        xml_fragment = doc.get_xml_element('document-store')
+
+        xml_element = xml_fragment.push_xml_element(txn, 'paragraph')
+
+        xml_text = xml_element.push_xml_text(txn)
+        xml_text.push(txn, text)
+
+    # Encode the document as a Uint8Array
+    update = Y.encode_state_as_update(doc)
+
+    # Encode the result to base64
+    return base64.b64encode(update).decode('utf-8')

--- a/src/backend/demo/management/commands/create_demo.py
+++ b/src/backend/demo/management/commands/create_demo.py
@@ -12,7 +12,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from faker import Faker
 
-from core import models
+from core import models, utils
 
 from demo import defaults
 
@@ -127,17 +127,14 @@ def create_demo(stdout):
 
     with Timeit(stdout, "Creating documents"):
         for _ in range(defaults.NB_OBJECTS["docs"]):
-            queue.push(
-                models.Document(
-                    title=fake.sentence(nb_words=4),
-                    link_reach=models.LinkReachChoices.AUTHENTICATED
-                    if random_true_with_probability(0.5)
-                    else random.choice(models.LinkReachChoices.values),
-                )
-            )
-
-        queue.flush()
-
+            models.Document(
+                title=fake.sentence(nb_words=4),
+                content=utils.text_to_yjs_base64(fake.text()),
+                link_reach=models.LinkReachChoices.AUTHENTICATED
+                if random_true_with_probability(0.5)
+                else random.choice(models.LinkReachChoices.values),
+            ).save()
+            
     with Timeit(stdout, "Creating docs accesses"):
         docs_ids = list(models.Document.objects.values_list("id", flat=True))
         users_ids = list(models.User.objects.values_list("id", flat=True))


### PR DESCRIPTION
## Purpose

We want to be able to convert text to yjs base64 to be able to save it to a document.
This format will be readable by the Blocknote editor.

## Proposal

Create the function `text_to_yjs_base64`.

## Demo

By doing `make demo FLUSH_ARGS='--no-input'` you can see the function in action.