### PR TITLE
♻️(backend) rename required claims to essential claims as per spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to
 
 ## Added
 
-🔧(backend) add option to configure list of required OIDC claims #525
-🔧(helm) add option to disable default tls setting by @dominikkaminski #519
+- 🔧(backend) add option to configure list of essential OIDC claims #525 & #531
+- 🔧(helm) add option to disable default tls setting by @dominikkaminski #519
 
 ## Changed
 

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -134,4 +134,4 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         )
         if has_changed:
             updated_claims = {key: value for key, value in claims.items() if value}
-            self.UserModel.objects.filter(sub=user.sub).update(**updated_claims)
+            self.UserModel.objects.filter(id=user.id).update(**updated_claims)

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -1,5 +1,7 @@
 """Authentication Backends for the Impress core app."""
 
+import logging
+
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.utils.translation import gettext_lazy as _
@@ -10,6 +12,8 @@ from mozilla_django_oidc.auth import (
 )
 
 from core.models import User
+
+logger = logging.getLogger(__name__)
 
 
 class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
@@ -57,24 +61,31 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
                     _("Invalid response format or token verification failed")
                 ) from e
 
-        # Validate required claims
-        missing_claims = [
-            claim
-            for claim in settings.USER_OIDC_REQUIRED_CLAIMS
-            if claim not in userinfo
-        ]
-        if missing_claims:
-            raise SuspiciousOperation(
-                _("Missing required claims in user info: %(claims)s")
-                % {"claims": ", ".join(missing_claims)}
-            )
-
         return userinfo
+
+    def verify_claims(self, claims):
+        """
+        Verify the presence of essential claims and the "sub" (which is mandatory as defined
+        by the OIDC specification) to decide if authentication should be allowed.
+        """
+        essential_claims = settings.USER_OIDC_ESSENTIAL_CLAIMS
+        missing_claims = [claim for claim in essential_claims if claim not in claims]
+
+        if missing_claims:
+            logger.error("Missing essential claims: %s", missing_claims)
+            return False
+
+        return True
 
     def get_or_create_user(self, access_token, id_token, payload):
         """Return a User based on userinfo. Create a new user if no match is found."""
 
         user_info = self.get_userinfo(access_token, id_token, payload)
+
+        if not self.verify_claims(user_info):
+            raise SuspiciousOperation("Claims verification failed.")
+
+        sub = user_info["sub"]
         email = user_info.get("email")
 
         # Get user's full name from OIDC fields defined in settings
@@ -86,12 +97,6 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
             "full_name": full_name,
             "short_name": short_name,
         }
-
-        sub = user_info.get("sub")
-        if not sub:
-            raise SuspiciousOperation(
-                _("User info contained no recognizable user identification")
-            )
 
         user = self.get_existing_user(sub, email)
 
@@ -113,15 +118,13 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         return full_name or None
 
     def get_existing_user(self, sub, email):
-        """Fetch existing user by sub or email."""
+        """Fetch an existing user by sub (or email as a fallback respecting fallback setting."""
         try:
             return User.objects.get(sub=sub)
         except User.DoesNotExist:
             if email and settings.OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION:
-                try:
-                    return User.objects.get(email=email)
-                except User.DoesNotExist:
-                    pass
+                return User.objects.filter(email=email).first()
+
         return None
 
     def update_user_if_needed(self, user, claims):

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -474,8 +474,8 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
-    USER_OIDC_REQUIRED_CLAIMS = values.ListValue(
-        default=[], environ_name="USER_OIDC_REQUIRED_CLAIMS", environ_prefix=None
+    USER_OIDC_ESSENTIAL_CLAIMS = values.ListValue(
+        default=[], environ_name="USER_OIDC_ESSENTIAL_CLAIMS", environ_prefix=None
     )
     USER_OIDC_FIELDS_TO_FULLNAME = values.ListValue(
         default=["first_name", "last_name"],


### PR DESCRIPTION
## Purpose

It was [pointed by @lebaudantoine](https://github.com/numerique-gouv/impress/pull/525/files) that the OIDC specification uses the term "essential claims" for what we called "required claims".

Further more, the Mozilla OIDC library that we use, validates claims in a method called "verify_claims".
Let's do it in the same method by overriding it.

## Proposal

- [x] rename "required claims" to "essential claims"
- [x] make use of the "verify_claims" method to validate that all essential claims are included in user infos
- [x] ensure that "sub" is always mandatory as per OIDC specification 
- [x] add tests to cover edge cases
