### PR TITLE
🔧(helm) add option to configure deployment annotations

### DIFF
--- a/src/helm/helmfile.yaml
+++ b/src/helm/helmfile.yaml
@@ -77,7 +77,7 @@ releases:
     installed: {{ eq .Environment.Name "dev" | toYaml }}
     namespace: {{ .Namespace }}
     chart: bitnami/redis
-    version: 18.19.2
+    version: 20.6.2
     values:
       - auth:
           password: pass

--- a/src/helm/impress/Chart.yaml
+++ b/src/helm/impress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: docs
-version: 0.0.1
+version: 0.0.2
 appVersion: latest

--- a/src/helm/impress/README.md
+++ b/src/helm/impress/README.md
@@ -4,125 +4,224 @@
 
 ### General configuration
 
-| Name                                       | Description                                          | Value                    |
-| ------------------------------------------ | ---------------------------------------------------- | ------------------------ |
-| `image.repository`                         | Repository to use to pull impress's container image     | `lasuite/impress-backend` |
-| `image.tag`                                | impress's container tag                                 | `latest`                 |
-| `image.pullPolicy`                         | Container image pull policy                          | `IfNotPresent`           |
-| `image.credentials.username`               | Username for container registry authentication       |                          |
-| `image.credentials.password`               | Password for container registry authentication       |                          |
-| `image.credentials.registry`               | Registry url for which the credentials are specified |                          |
-| `image.credentials.name`                   | Name of the generated secret for imagePullSecrets    |                          |
-| `nameOverride`                             | Override the chart name                              | `""`                     |
-| `fullnameOverride`                         | Override the full application name                   | `""`                     |
-| `ingress.enabled`                          | whether to enable the Ingress or not                 | `false`                  |
-| `ingress.className`                        | IngressClass to use for the Ingress                  | `nil`                    |
-| `ingress.host`                             | Host for the Ingress                                 | `impress.example.com`       |
-| `ingress.path`                             | Path to use for the Ingress                          | `/`                      |
-| `ingress.hosts`                            | Additional host to configure for the Ingress         | `[]`                     |
-| `ingress.tls.enabled`                      | Weather to enable TLS for the Ingress                | `true`                   |
-| `ingress.tls.additional[].secretName`      | Secret name for additional TLS config                |                          |
-| `ingress.tls.additional[].hosts[]`         | Hosts for additional TLS config                      |                          |
-| `ingress.customBackends`                   | Add custom backends to ingress                       | `[]`                     |
-| `ingressAdmin.enabled`                     | whether to enable the Ingress or not                 | `false`                  |
-| `ingressAdmin.className`                   | IngressClass to use for the Ingress                  | `nil`                    |
-| `ingressAdmin.host`                        | Host for the Ingress                                 | `impress.example.com`       |
-| `ingressAdmin.path`                        | Path to use for the Ingress                          | `/admin`                 |
-| `ingressAdmin.hosts`                       | Additional host to configure for the Ingress         | `[]`                     |
-| `ingressAdmin.tls.enabled`                 | Weather to enable TLS for the Ingress                | `true`                   |
-| `ingressAdmin.tls.additional[].secretName` | Secret name for additional TLS config                |                          |
-| `ingressAdmin.tls.additional[].hosts[]`    | Hosts for additional TLS config                      |                          |
+| Name                                                                                   | Description                                          | Value                                                                |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
+| `image.repository`                                                                     | Repository to use to pull impress's container image  | `lasuite/impress-backend`                                            |
+| `image.tag`                                                                            | impress's container tag                              | `latest`                                                             |
+| `image.pullPolicy`                                                                     | Container image pull policy                          | `IfNotPresent`                                                       |
+| `image.credentials.username`                                                           | Username for container registry authentication       |                                                                      |
+| `image.credentials.password`                                                           | Password for container registry authentication       |                                                                      |
+| `image.credentials.registry`                                                           | Registry url for which the credentials are specified |                                                                      |
+| `image.credentials.name`                                                               | Name of the generated secret for imagePullSecrets    |                                                                      |
+| `nameOverride`                                                                         | Override the chart name                              | `""`                                                                 |
+| `fullnameOverride`                                                                     | Override the full application name                   | `""`                                                                 |
+| `ingress.enabled`                                                                      | whether to enable the Ingress or not                 | `false`                                                              |
+| `ingress.className`                                                                    | IngressClass to use for the Ingress                  | `nil`                                                                |
+| `ingress.host`                                                                         | Host for the Ingress                                 | `impress.example.com`                                                |
+| `ingress.path`                                                                         | Path to use for the Ingress                          | `/`                                                                  |
+| `ingress.hosts`                                                                        | Additional host to configure for the Ingress         | `[]`                                                                 |
+| `ingress.tls.enabled`                                                                  | Weather to enable TLS for the Ingress                | `true`                                                               |
+| `ingress.tls.secretName`                                                               | Secret name for TLS config                           | `nil`                                                                |
+| `ingress.tls.additional[].secretName`                                                  | Secret name for additional TLS config                |                                                                      |
+| `ingress.tls.additional[].hosts[]`                                                     | Hosts for additional TLS config                      |                                                                      |
+| `ingress.customBackends`                                                               | Add custom backends to ingress                       | `[]`                                                                 |
+| `ingressCollaborationWS.enabled`                                                       | whether to enable the Ingress or not                 | `false`                                                              |
+| `ingressCollaborationWS.className`                                                     | IngressClass to use for the Ingress                  | `nil`                                                                |
+| `ingressCollaborationWS.host`                                                          | Host for the Ingress                                 | `impress.example.com`                                                |
+| `ingressCollaborationWS.path`                                                          | Path to use for the Ingress                          | `/collaboration/ws/`                                                 |
+| `ingressCollaborationWS.hosts`                                                         | Additional host to configure for the Ingress         | `[]`                                                                 |
+| `ingressCollaborationWS.tls.enabled`                                                   | Weather to enable TLS for the Ingress                | `true`                                                               |
+| `ingressCollaborationWS.tls.secretName`                                                | Secret name for TLS config                           | `nil`                                                                |
+| `ingressCollaborationWS.tls.additional[].secretName`                                   | Secret name for additional TLS config                |                                                                      |
+| `ingressCollaborationWS.tls.additional[].hosts[]`                                      | Hosts for additional TLS config                      |                                                                      |
+| `ingressCollaborationWS.customBackends`                                                | Add custom backends to ingress                       | `[]`                                                                 |
+| `ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/auth-response-headers` |                                                      | `Authorization, X-Can-Edit, X-User-Id`                               |
+| `ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/auth-url`              |                                                      | `https://impress.example.com/api/v1.0/documents/collaboration-auth/` |
+| `ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/enable-websocket`      |                                                      | `true`                                                               |
+| `ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/proxy-read-timeout`    |                                                      | `86400`                                                              |
+| `ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/proxy-send-timeout`    |                                                      | `86400`                                                              |
+| `ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/upstream-hash-by`      |                                                      | `$arg_room`                                                          |
+| `ingressCollaborationApi.enabled`                                                      | whether to enable the Ingress or not                 | `false`                                                              |
+| `ingressCollaborationApi.className`                                                    | IngressClass to use for the Ingress                  | `nil`                                                                |
+| `ingressCollaborationApi.host`                                                         | Host for the Ingress                                 | `impress.example.com`                                                |
+| `ingressCollaborationApi.path`                                                         | Path to use for the Ingress                          | `/collaboration/api/`                                                |
+| `ingressCollaborationApi.hosts`                                                        | Additional host to configure for the Ingress         | `[]`                                                                 |
+| `ingressCollaborationApi.tls.enabled`                                                  | Weather to enable TLS for the Ingress                | `true`                                                               |
+| `ingressCollaborationApi.tls.secretName`                                               | Secret name for TLS config                           | `nil`                                                                |
+| `ingressCollaborationApi.tls.additional[].secretName`                                  | Secret name for additional TLS config                |                                                                      |
+| `ingressCollaborationApi.tls.additional[].hosts[]`                                     | Hosts for additional TLS config                      |                                                                      |
+| `ingressCollaborationApi.customBackends`                                               | Add custom backends to ingress                       | `[]`                                                                 |
+| `ingressCollaborationApi.annotations.nginx.ingress.kubernetes.io/upstream-hash-by`     |                                                      | `$arg_room`                                                          |
+| `ingressAdmin.enabled`                                                                 | whether to enable the Ingress or not                 | `false`                                                              |
+| `ingressAdmin.className`                                                               | IngressClass to use for the Ingress                  | `nil`                                                                |
+| `ingressAdmin.host`                                                                    | Host for the Ingress                                 | `impress.example.com`                                                |
+| `ingressAdmin.path`                                                                    | Path to use for the Ingress                          | `/admin`                                                             |
+| `ingressAdmin.hosts`                                                                   | Additional host to configure for the Ingress         | `[]`                                                                 |
+| `ingressAdmin.tls.enabled`                                                             | Weather to enable TLS for the Ingress                | `true`                                                               |
+| `ingressAdmin.tls.secretName`                                                          | Secret name for TLS config                           | `nil`                                                                |
+| `ingressAdmin.tls.additional[].secretName`                                             | Secret name for additional TLS config                |                                                                      |
+| `ingressAdmin.tls.additional[].hosts[]`                                                | Hosts for additional TLS config                      |                                                                      |
+| `ingressMedia.enabled`                                                                 | whether to enable the Ingress or not                 | `false`                                                              |
+| `ingressMedia.className`                                                               | IngressClass to use for the Ingress                  | `nil`                                                                |
+| `ingressMedia.host`                                                                    | Host for the Ingress                                 | `impress.example.com`                                                |
+| `ingressMedia.path`                                                                    | Path to use for the Ingress                          | `/media/(.*)`                                                        |
+| `ingressMedia.hosts`                                                                   | Additional host to configure for the Ingress         | `[]`                                                                 |
+| `ingressMedia.tls.enabled`                                                             | Weather to enable TLS for the Ingress                | `true`                                                               |
+| `ingressMedia.tls.secretName`                                                          | Secret name for TLS config                           | `nil`                                                                |
+| `ingressMedia.tls.additional[].secretName`                                             | Secret name for additional TLS config                |                                                                      |
+| `ingressMedia.tls.additional[].hosts[]`                                                | Hosts for additional TLS config                      |                                                                      |
+| `ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-url`                        |                                                      | `https://impress.example.com/api/v1.0/documents/media-auth/`         |
+| `ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-response-headers`           |                                                      | `Authorization, X-Amz-Date, X-Amz-Content-SHA256`                    |
+| `ingressMedia.annotations.nginx.ingress.kubernetes.io/upstream-vhost`                  |                                                      | `minio.impress.svc.cluster.local:9000`                               |
+| `serviceMedia.host`                                                                    |                                                      | `minio.impress.svc.cluster.local`                                    |
+| `serviceMedia.port`                                                                    |                                                      | `9000`                                                               |
+| `serviceMedia.annotations`                                                             |                                                      | `{}`                                                                 |
 
 ### backend
 
-| Name                                                  | Description                                                                        | Value                                           |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `backend.command`                                     | Override the backend container command                                             | `[]`                                            |
-| `backend.args`                                        | Override the backend container args                                                | `[]`                                            |
-| `backend.replicas`                                    | Amount of backend replicas                                                         | `3`                                             |
-| `backend.shareProcessNamespace`                       | Enable share process namespace between containers                                  | `false`                                         |
-| `backend.sidecars`                                    | Add sidecars containers to backend deployment                                      | `[]`                                            |
-| `backend.securityContext`                             | Configure backend Pod security context                                             | `nil`                                           |
-| `backend.envVars`                                     | Configure backend container environment variables                                  | `undefined`                                     |
-| `backend.envVars.BY_VALUE`                            | Example environment variable by setting value directly                             |                                                 |
-| `backend.envVars.FROM_CONFIGMAP.configMapKeyRef.name` | Name of a ConfigMap when configuring env vars from a ConfigMap                     |                                                 |
-| `backend.envVars.FROM_CONFIGMAP.configMapKeyRef.key`  | Key within a ConfigMap when configuring env vars from a ConfigMap                  |                                                 |
-| `backend.envVars.FROM_SECRET.secretKeyRef.name`       | Name of a Secret when configuring env vars from a Secret                           |                                                 |
-| `backend.envVars.FROM_SECRET.secretKeyRef.key`        | Key within a Secret when configuring env vars from a Secret                        |                                                 |
-| `backend.podAnnotations`                              | Annotations to add to the backend Pod                                              | `{}`                                            |
-| `backend.service.type`                                | backend Service type                                                               | `ClusterIP`                                     |
-| `backend.service.port`                                | backend Service listening port                                                     | `80`                                            |
-| `backend.service.targetPort`                          | backend container listening port                                                   | `8000`                                          |
-| `backend.service.annotations`                         | Annotations to add to the backend Service                                          | `{}`                                            |
-| `backend.migrate.command`                             | backend migrate command                                                            | `["python","manage.py","migrate","--no-input"]` |
-| `backend.migrate.restartPolicy`                       | backend migrate job restart policy                                                 | `Never`                                         |
-| `backend.probes.liveness.path`                        | Configure path for backend HTTP liveness probe                                     | `/__heartbeat__`                                |
-| `backend.probes.liveness.targetPort`                  | Configure port for backend HTTP liveness probe                                     | `undefined`                                     |
-| `backend.probes.liveness.initialDelaySeconds`         | Configure initial delay for backend liveness probe                                 | `10`                                            |
-| `backend.probes.liveness.initialDelaySeconds`         | Configure timeout for backend liveness probe                                       | `10`                                            |
-| `backend.probes.startup.path`                         | Configure path for backend HTTP startup probe                                      | `undefined`                                     |
-| `backend.probes.startup.targetPort`                   | Configure port for backend HTTP startup probe                                      | `undefined`                                     |
-| `backend.probes.startup.initialDelaySeconds`          | Configure initial delay for backend startup probe                                  | `undefined`                                     |
-| `backend.probes.startup.initialDelaySeconds`          | Configure timeout for backend startup probe                                        | `undefined`                                     |
-| `backend.probes.readiness.path`                       | Configure path for backend HTTP readiness probe                                    | `/__lbheartbeat__`                              |
-| `backend.probes.readiness.targetPort`                 | Configure port for backend HTTP readiness probe                                    | `undefined`                                     |
-| `backend.probes.readiness.initialDelaySeconds`        | Configure initial delay for backend readiness probe                                | `10`                                            |
-| `backend.probes.readiness.initialDelaySeconds`        | Configure timeout for backend readiness probe                                      | `10`                                            |
-| `backend.resources`                                   | Resource requirements for the backend container                                    | `{}`                                            |
-| `backend.nodeSelector`                                | Node selector for the backend Pod                                                  | `{}`                                            |
-| `backend.tolerations`                                 | Tolerations for the backend Pod                                                    | `[]`                                            |
-| `backend.affinity`                                    | Affinity for the backend Pod                                                       | `{}`                                            |
-| `backend.persistence`                                 | Additional volumes to create and mount on the backend. Used for debugging purposes | `{}`                                            |
-| `backend.persistence.volume-name.size`                | Size of the additional volume                                                      |                                                 |
-| `backend.persistence.volume-name.type`                | Type of the additional volume, persistentVolumeClaim or emptyDir                   |                                                 |
-| `backend.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                         |                                                 |
-| `backend.extraVolumeMounts`                           | Additional volumes to mount on the backend.                                        | `[]`                                            |
-| `backend.extraVolumes`                                | Additional volumes to mount on the backend.                                        | `[]`                                            |
+| Name                                                  | Description                                                                        | Value                                                                                                                         |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `backend.command`                                     | Override the backend container command                                             | `[]`                                                                                                                          |
+| `backend.args`                                        | Override the backend container args                                                | `[]`                                                                                                                          |
+| `backend.replicas`                                    | Amount of backend replicas                                                         | `3`                                                                                                                           |
+| `backend.shareProcessNamespace`                       | Enable share process namespace between containers                                  | `false`                                                                                                                       |
+| `backend.sidecars`                                    | Add sidecars containers to backend deployment                                      | `[]`                                                                                                                          |
+| `backend.migrateJobAnnotations`                       | Annotations for the migrate job                                                    | `{}`                                                                                                                          |
+| `backend.securityContext`                             | Configure backend Pod security context                                             | `nil`                                                                                                                         |
+| `backend.envVars`                                     | Configure backend container environment variables                                  | `undefined`                                                                                                                   |
+| `backend.envVars.BY_VALUE`                            | Example environment variable by setting value directly                             |                                                                                                                               |
+| `backend.envVars.FROM_CONFIGMAP.configMapKeyRef.name` | Name of a ConfigMap when configuring env vars from a ConfigMap                     |                                                                                                                               |
+| `backend.envVars.FROM_CONFIGMAP.configMapKeyRef.key`  | Key within a ConfigMap when configuring env vars from a ConfigMap                  |                                                                                                                               |
+| `backend.envVars.FROM_SECRET.secretKeyRef.name`       | Name of a Secret when configuring env vars from a Secret                           |                                                                                                                               |
+| `backend.envVars.FROM_SECRET.secretKeyRef.key`        | Key within a Secret when configuring env vars from a Secret                        |                                                                                                                               |
+| `backend.podAnnotations`                              | Annotations to add to the backend Pod                                              | `{}`                                                                                                                          |
+| `backend.dpAnnotations`                               | Annotations to add to the backend Deployment                                       | `{}`                                                                                                                          |
+| `backend.service.type`                                | backend Service type                                                               | `ClusterIP`                                                                                                                   |
+| `backend.service.port`                                | backend Service listening port                                                     | `80`                                                                                                                          |
+| `backend.service.targetPort`                          | backend container listening port                                                   | `8000`                                                                                                                        |
+| `backend.service.annotations`                         | Annotations to add to the backend Service                                          | `{}`                                                                                                                          |
+| `backend.migrate.command`                             | backend migrate command                                                            | `["python","manage.py","migrate","--no-input"]`                                                                               |
+| `backend.migrate.restartPolicy`                       | backend migrate job restart policy                                                 | `Never`                                                                                                                       |
+| `backend.createsuperuser.command`                     | backend migrate command                                                            | `["/bin/sh","-c","python manage.py createsuperuser --email $DJANGO_SUPERUSER_EMAIL --password $DJANGO_SUPERUSER_PASSWORD\n"]` |
+| `backend.createsuperuser.restartPolicy`               | backend migrate job restart policy                                                 | `Never`                                                                                                                       |
+| `backend.probes.liveness.path`                        | Configure path for backend HTTP liveness probe                                     | `/__heartbeat__`                                                                                                              |
+| `backend.probes.liveness.targetPort`                  | Configure port for backend HTTP liveness probe                                     | `undefined`                                                                                                                   |
+| `backend.probes.liveness.initialDelaySeconds`         | Configure initial delay for backend liveness probe                                 | `10`                                                                                                                          |
+| `backend.probes.liveness.initialDelaySeconds`         | Configure timeout for backend liveness probe                                       | `10`                                                                                                                          |
+| `backend.probes.startup.path`                         | Configure path for backend HTTP startup probe                                      | `undefined`                                                                                                                   |
+| `backend.probes.startup.targetPort`                   | Configure port for backend HTTP startup probe                                      | `undefined`                                                                                                                   |
+| `backend.probes.startup.initialDelaySeconds`          | Configure initial delay for backend startup probe                                  | `undefined`                                                                                                                   |
+| `backend.probes.startup.initialDelaySeconds`          | Configure timeout for backend startup probe                                        | `undefined`                                                                                                                   |
+| `backend.probes.readiness.path`                       | Configure path for backend HTTP readiness probe                                    | `/__lbheartbeat__`                                                                                                            |
+| `backend.probes.readiness.targetPort`                 | Configure port for backend HTTP readiness probe                                    | `undefined`                                                                                                                   |
+| `backend.probes.readiness.initialDelaySeconds`        | Configure initial delay for backend readiness probe                                | `10`                                                                                                                          |
+| `backend.probes.readiness.initialDelaySeconds`        | Configure timeout for backend readiness probe                                      | `10`                                                                                                                          |
+| `backend.resources`                                   | Resource requirements for the backend container                                    | `{}`                                                                                                                          |
+| `backend.nodeSelector`                                | Node selector for the backend Pod                                                  | `{}`                                                                                                                          |
+| `backend.tolerations`                                 | Tolerations for the backend Pod                                                    | `[]`                                                                                                                          |
+| `backend.affinity`                                    | Affinity for the backend Pod                                                       | `{}`                                                                                                                          |
+| `backend.persistence`                                 | Additional volumes to create and mount on the backend. Used for debugging purposes | `{}`                                                                                                                          |
+| `backend.persistence.volume-name.size`                | Size of the additional volume                                                      |                                                                                                                               |
+| `backend.persistence.volume-name.type`                | Type of the additional volume, persistentVolumeClaim or emptyDir                   |                                                                                                                               |
+| `backend.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                         |                                                                                                                               |
+| `backend.extraVolumeMounts`                           | Additional volumes to mount on the backend.                                        | `[]`                                                                                                                          |
+| `backend.extraVolumes`                                | Additional volumes to mount on the backend.                                        | `[]`                                                                                                                          |
 
 ### frontend
 
-| Name                                                   | Description                                                                         | Value                     |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------- | ------------------------- |
-| `frontend.image.repository`                            | Repository to use to pull impress's frontend container image                           | `lasuite/impress-frontend` |
-| `frontend.image.tag`                                   | impress's frontend container tag                                                       | `latest`                  |
-| `frontend.image.pullPolicy`                            | frontend container image pull policy                                                | `IfNotPresent`            |
-| `frontend.command`                                     | Override the frontend container command                                             | `[]`                      |
-| `frontend.args`                                        | Override the frontend container args                                                | `[]`                      |
-| `frontend.replicas`                                    | Amount of frontend replicas                                                         | `3`                       |
-| `frontend.shareProcessNamespace`                       | Enable share process namefrontend between containers                                | `false`                   |
-| `frontend.sidecars`                                    | Add sidecars containers to frontend deployment                                      | `[]`                      |
-| `frontend.securityContext`                             | Configure frontend Pod security context                                             | `nil`                     |
-| `frontend.envVars`                                     | Configure frontend container environment variables                                  | `undefined`               |
-| `frontend.envVars.BY_VALUE`                            | Example environment variable by setting value directly                              |                           |
-| `frontend.envVars.FROM_CONFIGMAP.configMapKeyRef.name` | Name of a ConfigMap when configuring env vars from a ConfigMap                      |                           |
-| `frontend.envVars.FROM_CONFIGMAP.configMapKeyRef.key`  | Key within a ConfigMap when configuring env vars from a ConfigMap                   |                           |
-| `frontend.envVars.FROM_SECRET.secretKeyRef.name`       | Name of a Secret when configuring env vars from a Secret                            |                           |
-| `frontend.envVars.FROM_SECRET.secretKeyRef.key`        | Key within a Secret when configuring env vars from a Secret                         |                           |
-| `frontend.podAnnotations`                              | Annotations to add to the frontend Pod                                              | `{}`                      |
-| `frontend.service.type`                                | frontend Service type                                                               | `ClusterIP`               |
-| `frontend.service.port`                                | frontend Service listening port                                                     | `80`                      |
-| `frontend.service.targetPort`                          | frontend container listening port                                                   | `8080`                    |
-| `frontend.service.annotations`                         | Annotations to add to the frontend Service                                          | `{}`                      |
-| `frontend.probes`                                      | Configure probe for frontend                                                        | `{}`                      |
-| `frontend.probes.liveness.path`                        | Configure path for frontend HTTP liveness probe                                     |                           |
-| `frontend.probes.liveness.targetPort`                  | Configure port for frontend HTTP liveness probe                                     |                           |
-| `frontend.probes.liveness.initialDelaySeconds`         | Configure initial delay for frontend liveness probe                                 |                           |
-| `frontend.probes.liveness.initialDelaySeconds`         | Configure timeout for frontend liveness probe                                       |                           |
-| `frontend.probes.startup.path`                         | Configure path for frontend HTTP startup probe                                      |                           |
-| `frontend.probes.startup.targetPort`                   | Configure port for frontend HTTP startup probe                                      |                           |
-| `frontend.probes.startup.initialDelaySeconds`          | Configure initial delay for frontend startup probe                                  |                           |
-| `frontend.probes.startup.initialDelaySeconds`          | Configure timeout for frontend startup probe                                        |                           |
-| `frontend.probes.readiness.path`                       | Configure path for frontend HTTP readiness probe                                    |                           |
-| `frontend.probes.readiness.targetPort`                 | Configure port for frontend HTTP readiness probe                                    |                           |
-| `frontend.probes.readiness.initialDelaySeconds`        | Configure initial delay for frontend readiness probe                                |                           |
-| `frontend.probes.readiness.initialDelaySeconds`        | Configure timeout for frontend readiness probe                                      |                           |
-| `frontend.resources`                                   | Resource requirements for the frontend container                                    | `{}`                      |
-| `frontend.nodeSelector`                                | Node selector for the frontend Pod                                                  | `{}`                      |
-| `frontend.tolerations`                                 | Tolerations for the frontend Pod                                                    | `[]`                      |
-| `frontend.affinity`                                    | Affinity for the frontend Pod                                                       | `{}`                      |
-| `frontend.persistence`                                 | Additional volumes to create and mount on the frontend. Used for debugging purposes | `{}`                      |
-| `frontend.persistence.volume-name.size`                | Size of the additional volume                                                       |                           |
-| `frontend.persistence.volume-name.type`                | Type of the additional volume, persistentVolumeClaim or emptyDir                    |                           |
-| `frontend.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                          |                           |
-| `frontend.extraVolumeMounts`                           | Additional volumes to mount on the frontend.                                        | `[]`                      |
-| `frontend.extraVolumes`                                | Additional volumes to mount on the frontend.                                        | `[]`                      |
+| Name                                                   | Description                                                                         | Value                      |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------- | -------------------------- |
+| `frontend.image.repository`                            | Repository to use to pull impress's frontend container image                        | `lasuite/impress-frontend` |
+| `frontend.image.tag`                                   | impress's frontend container tag                                                    | `latest`                   |
+| `frontend.image.pullPolicy`                            | frontend container image pull policy                                                | `IfNotPresent`             |
+| `frontend.command`                                     | Override the frontend container command                                             | `[]`                       |
+| `frontend.args`                                        | Override the frontend container args                                                | `[]`                       |
+| `frontend.replicas`                                    | Amount of frontend replicas                                                         | `3`                        |
+| `frontend.shareProcessNamespace`                       | Enable share process namefrontend between containers                                | `false`                    |
+| `frontend.sidecars`                                    | Add sidecars containers to frontend deployment                                      | `[]`                       |
+| `frontend.securityContext`                             | Configure frontend Pod security context                                             | `nil`                      |
+| `frontend.envVars`                                     | Configure frontend container environment variables                                  | `undefined`                |
+| `frontend.envVars.BY_VALUE`                            | Example environment variable by setting value directly                              |                            |
+| `frontend.envVars.FROM_CONFIGMAP.configMapKeyRef.name` | Name of a ConfigMap when configuring env vars from a ConfigMap                      |                            |
+| `frontend.envVars.FROM_CONFIGMAP.configMapKeyRef.key`  | Key within a ConfigMap when configuring env vars from a ConfigMap                   |                            |
+| `frontend.envVars.FROM_SECRET.secretKeyRef.name`       | Name of a Secret when configuring env vars from a Secret                            |                            |
+| `frontend.envVars.FROM_SECRET.secretKeyRef.key`        | Key within a Secret when configuring env vars from a Secret                         |                            |
+| `frontend.podAnnotations`                              | Annotations to add to the frontend Pod                                              | `{}`                       |
+| `frontend.dpAnnotations`                               | Annotations to add to the frontend Deployment                                       | `{}`                       |
+| `frontend.service.type`                                | frontend Service type                                                               | `ClusterIP`                |
+| `frontend.service.port`                                | frontend Service listening port                                                     | `80`                       |
+| `frontend.service.targetPort`                          | frontend container listening port                                                   | `8080`                     |
+| `frontend.service.annotations`                         | Annotations to add to the frontend Service                                          | `{}`                       |
+| `frontend.probes`                                      | Configure probe for frontend                                                        | `{}`                       |
+| `frontend.probes.liveness.path`                        | Configure path for frontend HTTP liveness probe                                     |                            |
+| `frontend.probes.liveness.targetPort`                  | Configure port for frontend HTTP liveness probe                                     |                            |
+| `frontend.probes.liveness.initialDelaySeconds`         | Configure initial delay for frontend liveness probe                                 |                            |
+| `frontend.probes.liveness.initialDelaySeconds`         | Configure timeout for frontend liveness probe                                       |                            |
+| `frontend.probes.startup.path`                         | Configure path for frontend HTTP startup probe                                      |                            |
+| `frontend.probes.startup.targetPort`                   | Configure port for frontend HTTP startup probe                                      |                            |
+| `frontend.probes.startup.initialDelaySeconds`          | Configure initial delay for frontend startup probe                                  |                            |
+| `frontend.probes.startup.initialDelaySeconds`          | Configure timeout for frontend startup probe                                        |                            |
+| `frontend.probes.readiness.path`                       | Configure path for frontend HTTP readiness probe                                    |                            |
+| `frontend.probes.readiness.targetPort`                 | Configure port for frontend HTTP readiness probe                                    |                            |
+| `frontend.probes.readiness.initialDelaySeconds`        | Configure initial delay for frontend readiness probe                                |                            |
+| `frontend.probes.readiness.initialDelaySeconds`        | Configure timeout for frontend readiness probe                                      |                            |
+| `frontend.resources`                                   | Resource requirements for the frontend container                                    | `{}`                       |
+| `frontend.nodeSelector`                                | Node selector for the frontend Pod                                                  | `{}`                       |
+| `frontend.tolerations`                                 | Tolerations for the frontend Pod                                                    | `[]`                       |
+| `frontend.affinity`                                    | Affinity for the frontend Pod                                                       | `{}`                       |
+| `frontend.persistence`                                 | Additional volumes to create and mount on the frontend. Used for debugging purposes | `{}`                       |
+| `frontend.persistence.volume-name.size`                | Size of the additional volume                                                       |                            |
+| `frontend.persistence.volume-name.type`                | Type of the additional volume, persistentVolumeClaim or emptyDir                    |                            |
+| `frontend.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                          |                            |
+| `frontend.extraVolumeMounts`                           | Additional volumes to mount on the frontend.                                        | `[]`                       |
+| `frontend.extraVolumes`                                | Additional volumes to mount on the frontend.                                        | `[]`                       |
+
+### yProvider
+
+| Name                                                    | Description                                                                          | Value                        |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------- |
+| `yProvider.image.repository`                            | Repository to use to pull impress's yProvider container image                        | `lasuite/impress-y-provider` |
+| `yProvider.image.tag`                                   | impress's yProvider container tag                                                    | `latest`                     |
+| `yProvider.image.pullPolicy`                            | yProvider container image pull policy                                                | `IfNotPresent`               |
+| `yProvider.command`                                     | Override the yProvider container command                                             | `[]`                         |
+| `yProvider.args`                                        | Override the yProvider container args                                                | `[]`                         |
+| `yProvider.replicas`                                    | Amount of yProvider replicas                                                         | `3`                          |
+| `yProvider.shareProcessNamespace`                       | Enable share process nameyProvider between containers                                | `false`                      |
+| `yProvider.sidecars`                                    | Add sidecars containers to yProvider deployment                                      | `[]`                         |
+| `yProvider.securityContext`                             | Configure yProvider Pod security context                                             | `nil`                        |
+| `yProvider.envVars`                                     | Configure yProvider container environment variables                                  | `undefined`                  |
+| `yProvider.envVars.BY_VALUE`                            | Example environment variable by setting value directly                               |                              |
+| `yProvider.envVars.FROM_CONFIGMAP.configMapKeyRef.name` | Name of a ConfigMap when configuring env vars from a ConfigMap                       |                              |
+| `yProvider.envVars.FROM_CONFIGMAP.configMapKeyRef.key`  | Key within a ConfigMap when configuring env vars from a ConfigMap                    |                              |
+| `yProvider.envVars.FROM_SECRET.secretKeyRef.name`       | Name of a Secret when configuring env vars from a Secret                             |                              |
+| `yProvider.envVars.FROM_SECRET.secretKeyRef.key`        | Key within a Secret when configuring env vars from a Secret                          |                              |
+| `yProvider.podAnnotations`                              | Annotations to add to the yProvider Pod                                              | `{}`                         |
+| `yProvider.dpAnnotations`                               | Annotations to add to the yProvider Deployment                                       | `{}`                         |
+| `yProvider.service.type`                                | yProvider Service type                                                               | `ClusterIP`                  |
+| `yProvider.service.port`                                | yProvider Service listening port                                                     | `443`                        |
+| `yProvider.service.targetPort`                          | yProvider container listening port                                                   | `4444`                       |
+| `yProvider.service.annotations`                         | Annotations to add to the yProvider Service                                          | `{}`                         |
+| `yProvider.probes.liveness.path`                        | Configure path for yProvider HTTP liveness probe                                     |                              |
+| `yProvider.probes.liveness.targetPort`                  | Configure port for yProvider HTTP liveness probe                                     |                              |
+| `yProvider.probes.liveness.initialDelaySeconds`         | Configure initial delay for yProvider liveness probe                                 |                              |
+| `yProvider.probes.liveness.initialDelaySeconds`         | Configure timeout for yProvider liveness probe                                       |                              |
+| `yProvider.probes.startup.path`                         | Configure path for yProvider HTTP startup probe                                      |                              |
+| `yProvider.probes.startup.targetPort`                   | Configure port for yProvider HTTP startup probe                                      |                              |
+| `yProvider.probes.startup.initialDelaySeconds`          | Configure initial delay for yProvider startup probe                                  |                              |
+| `yProvider.probes.startup.initialDelaySeconds`          | Configure timeout for yProvider startup probe                                        |                              |
+| `yProvider.probes.readiness.path`                       | Configure path for yProvider HTTP readiness probe                                    |                              |
+| `yProvider.probes.readiness.targetPort`                 | Configure port for yProvider HTTP readiness probe                                    |                              |
+| `yProvider.probes.readiness.initialDelaySeconds`        | Configure initial delay for yProvider readiness probe                                |                              |
+| `yProvider.probes.readiness.initialDelaySeconds`        | Configure timeout for yProvider readiness probe                                      |                              |
+| `yProvider.probes.liveness.path`                        |                                                                                      | `/ping`                      |
+| `yProvider.probes.liveness.initialDelaySeconds`         |                                                                                      | `10`                         |
+| `yProvider.resources`                                   | Resource requirements for the yProvider container                                    | `{}`                         |
+| `yProvider.nodeSelector`                                | Node selector for the yProvider Pod                                                  | `{}`                         |
+| `yProvider.tolerations`                                 | Tolerations for the yProvider Pod                                                    | `[]`                         |
+| `yProvider.affinity`                                    | Affinity for the yProvider Pod                                                       | `{}`                         |
+| `yProvider.persistence`                                 | Additional volumes to create and mount on the yProvider. Used for debugging purposes | `{}`                         |
+| `yProvider.persistence.volume-name.size`                | Size of the additional volume                                                        |                              |
+| `yProvider.persistence.volume-name.type`                | Type of the additional volume, persistentVolumeClaim or emptyDir                     |                              |
+| `yProvider.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                           |                              |
+| `yProvider.extraVolumeMounts`                           | Additional volumes to mount on the yProvider.                                        | `[]`                         |
+| `yProvider.extraVolumes`                                | Additional volumes to mount on the yProvider.                                        | `[]`                         |

--- a/src/helm/impress/generate-readme.sh
+++ b/src/helm/impress/generate-readme.sh
@@ -2,9 +2,9 @@
 
 docker image ls | grep readme-generator-for-helm
 if [ "$?" -ne "0" ]; then
-	git clone https://github.com/bitnami/readme-generator-for-helm.git /tmp/readme-generator-for-helm
-	cd /tmp/readme-generator-for-helm
-	docker build -t readme-generator-for-helm:latest .
-	cd $(dirname -- "${BASH_SOURCE[0]}")
+  git clone https://github.com/bitnami/readme-generator-for-helm.git /tmp/readme-generator-for-helm
+  cd /tmp/readme-generator-for-helm
+  docker build -t readme-generator-for-helm:latest .
+  cd $(dirname -- "${BASH_SOURCE[0]}")
 fi
-docker run --rm -it -v ./values.yaml:/app/values.yaml -v ./README.md:/app/README.md readme-generator-for-helm:latest readme-generator -v values.yaml -r README.md
+docker run --rm -it -v .:/source -w /source readme-generator-for-helm:latest readme-generator -v values.yaml -r README.md

--- a/src/helm/impress/templates/backend_deployment.yaml
+++ b/src/helm/impress/templates/backend_deployment.yaml
@@ -6,6 +6,10 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    {{- with .Values.backend.dpAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "impress.common.labels" (list . $component) | nindent 4 }}
 spec:

--- a/src/helm/impress/templates/frontend_deployment.yaml
+++ b/src/helm/impress/templates/frontend_deployment.yaml
@@ -6,6 +6,10 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    {{- with .Values.backend.dpAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "impress.common.labels" (list . $component) | nindent 4 }}
 spec:

--- a/src/helm/impress/templates/yprovider_deployment.yaml
+++ b/src/helm/impress/templates/yprovider_deployment.yaml
@@ -6,6 +6,10 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    {{- with .Values.backend.dpAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "impress.common.labels" (list . $component) | nindent 4 }}
 spec:

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -59,7 +59,7 @@ ingressCollaborationWS:
   className: null
   host: impress.example.com
   path: /collaboration/ws/
-  ## @param ingress.hosts Additional host to configure for the Ingress
+  ## @param ingressCollaborationWS.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
   ## @param ingressCollaborationWS.tls.enabled Weather to enable TLS for the Ingress
@@ -75,6 +75,12 @@ ingressCollaborationWS:
   ## @param ingressCollaborationWS.customBackends Add custom backends to ingress
   customBackends: []
 
+  ## @param ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/auth-response-headers
+  ## @param ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/auth-url
+  ## @param ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/enable-websocket
+  ## @param ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/proxy-read-timeout
+  ## @param ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/proxy-send-timeout
+  ## @param ingressCollaborationWS.annotations.nginx.ingress.kubernetes.io/upstream-hash-by
   annotations:
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Can-Edit, X-User-Id"
     nginx.ingress.kubernetes.io/auth-url: https://impress.example.com/api/v1.0/documents/collaboration-auth/
@@ -92,7 +98,7 @@ ingressCollaborationApi:
   className: null
   host: impress.example.com
   path: /collaboration/api/
-  ## @param ingress.hosts Additional host to configure for the Ingress
+  ## @param ingressCollaborationApi.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
   ## @param ingressCollaborationApi.tls.enabled Weather to enable TLS for the Ingress
@@ -108,6 +114,7 @@ ingressCollaborationApi:
   ## @param ingressCollaborationApi.customBackends Add custom backends to ingress
   customBackends: []
 
+  ## @param ingressCollaborationApi.annotations.nginx.ingress.kubernetes.io/upstream-hash-by
   annotations:
     nginx.ingress.kubernetes.io/upstream-hash-by: $arg_room
 
@@ -156,11 +163,17 @@ ingressMedia:
     secretName: null
     additional: []
 
+  ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-url
+  ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-response-headers
+  ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/upstream-vhost
   annotations:
     nginx.ingress.kubernetes.io/auth-url: https://impress.example.com/api/v1.0/documents/media-auth/
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
     nginx.ingress.kubernetes.io/upstream-vhost: minio.impress.svc.cluster.local:9000
 
+## @param serviceMedia.host
+## @param serviceMedia.port
+## @param serviceMedia.annotations
 serviceMedia:
   host: minio.impress.svc.cluster.local
   port: 9000
@@ -204,6 +217,9 @@ backend:
 
   ## @param backend.podAnnotations Annotations to add to the backend Pod
   podAnnotations: {}
+
+  ## @param backend.dpAnnotations Annotations to add to the backend Deployment
+  dpAnnotations: {}
 
   ## @param backend.service.type backend Service type
   ## @param backend.service.port backend Service listening port
@@ -322,6 +338,9 @@ frontend:
   ## @param frontend.podAnnotations Annotations to add to the frontend Pod
   podAnnotations: {}
 
+  ## @param frontend.dpAnnotations Annotations to add to the frontend Deployment
+  dpAnnotations: {}
+
   ## @param frontend.service.type frontend Service type
   ## @param frontend.service.port frontend Service listening port
   ## @param frontend.service.targetPort frontend container listening port
@@ -413,6 +432,9 @@ yProvider:
   ## @param yProvider.podAnnotations Annotations to add to the yProvider Pod
   podAnnotations: {}
 
+  ## @param yProvider.dpAnnotations Annotations to add to the yProvider Deployment
+  dpAnnotations: {}
+
   ## @param yProvider.service.type yProvider Service type
   ## @param yProvider.service.port yProvider Service listening port
   ## @param yProvider.service.targetPort yProvider container listening port
@@ -423,7 +445,6 @@ yProvider:
     targetPort: 4444
     annotations: {}
 
-  ## @param yProvider.probes Configure probe for yProvider
   ## @extra yProvider.probes.liveness.path Configure path for yProvider HTTP liveness probe
   ## @extra yProvider.probes.liveness.targetPort Configure port for yProvider HTTP liveness probe
   ## @extra yProvider.probes.liveness.initialDelaySeconds Configure initial delay for yProvider liveness probe
@@ -438,6 +459,8 @@ yProvider:
   ## @extra yProvider.probes.readiness.initialDelaySeconds Configure timeout for yProvider readiness probe
   probes:
     liveness:
+      ## @param yProvider.probes.liveness.path
+      ## @param yProvider.probes.liveness.initialDelaySeconds
       path: /ping
       initialDelaySeconds: 10
 


### PR DESCRIPTION
We need to be abble to add specific annotations on Deployment in order to use a reloader when external-secret sync new secrets
