### PR TITLE
Fix create document for user when sub does not match but email does

### DIFF
--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -7,7 +7,7 @@ UNSET_USER=0
 
 TERRAFORM_DIRECTORY="./env.d/terraform"
 COMPOSE_FILE="${REPO_DIR}/docker-compose.yml"
-COMPOSE_PROJECT="impress"
+COMPOSE_PROJECT="docs"
 
 
 # _set_user: set (or unset) default user id used to run docker commands

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -264,12 +264,16 @@ class ServerCreateDocumentSerializer(serializers.Serializer):
         """Create the document and associate it with the user or send an invitation."""
         language = validated_data.get("language", settings.LANGUAGE_CODE)
 
-        # Get the user based on the sub (unique identifier)
+        # Get the user on its sub (unique identifier). Default on email if allowed in settings
         try:
             user = models.User.objects.get(sub=validated_data["sub"])
-        except (models.User.DoesNotExist, KeyError):
-            user = None
+        except (models.User.DoesNotExist, KeyError) as err:
+            if not settings.OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION:
+                raise serializers.ValidationError(
+                    {"sub": ["Could not find user with this sub."]}
+                ) from err
             email = validated_data["email"]
+            user = models.User.objects.filter(email=email).first()
         else:
             email = user.email
             language = user.language or language
@@ -279,7 +283,9 @@ class ServerCreateDocumentSerializer(serializers.Serializer):
                 validated_data["content"]
             )
         except ConversionError as err:
-            raise exceptions.APIException(detail="could not convert content") from err
+            raise serializers.ValidationError(
+                {"content": ["Could not convert content"]}
+            ) from err
 
         document = models.Document.objects.create(
             title=validated_data["title"],
@@ -302,7 +308,11 @@ class ServerCreateDocumentSerializer(serializers.Serializer):
                 role=models.RoleChoices.OWNER,
             )
 
-        # Notify the user about the newly created document
+        self._send_email_notification(document, validated_data, email, language)
+        return document
+
+    def _send_email_notification(self, document, validated_data, email, language):
+        """Notify the user about the newly created document."""
         subject = validated_data.get("subject") or _(
             "A new document was created on your behalf!"
         )
@@ -312,8 +322,6 @@ class ServerCreateDocumentSerializer(serializers.Serializer):
             "title": subject,
         }
         document.send_email(subject, [email], context, language)
-
-        return document
 
     def update(self, instance, validated_data):
         """

--- a/src/backend/core/tests/documents/test_api_documents_create_for_owner.py
+++ b/src/backend/core/tests/documents/test_api_documents_create_for_owner.py
@@ -13,6 +13,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from core import factories
+from core.api.serializers import ServerCreateDocumentSerializer
 from core.models import Document, Invitation, User
 from core.services.converter_services import ConversionError, YdocConverter
 
@@ -20,7 +21,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def mock_convert_markdown():
+def mock_convert_md():
     """Mock YdocConverter.convert_markdown to return a converted content."""
     with patch.object(
         YdocConverter,
@@ -169,8 +170,11 @@ def test_api_documents_create_for_owner_invalid_sub():
 
 
 @override_settings(SERVER_TO_SERVER_API_TOKENS=["DummyToken"])
-def test_api_documents_create_for_owner_existing(mock_convert_markdown):
-    """It should be possible to create a document on behalf of a pre-existing user."""
+def test_api_documents_create_for_owner_existing(mock_convert_md):
+    """
+    It should be possible to create a document on behalf of a pre-existing user
+    by passing their sub and email.
+    """
     user = factories.UserFactory(language="en-us")
 
     data = {
@@ -189,7 +193,7 @@ def test_api_documents_create_for_owner_existing(mock_convert_markdown):
 
     assert response.status_code == 201
 
-    mock_convert_markdown.assert_called_once_with("Document content")
+    mock_convert_md.assert_called_once_with("Document content")
 
     document = Document.objects.get()
     assert response.json() == {"id": str(document.id)}
@@ -213,7 +217,7 @@ def test_api_documents_create_for_owner_existing(mock_convert_markdown):
 
 
 @override_settings(SERVER_TO_SERVER_API_TOKENS=["DummyToken"])
-def test_api_documents_create_for_owner_new_user(mock_convert_markdown):
+def test_api_documents_create_for_owner_new_user(mock_convert_md):
     """
     It should be possible to create a document on behalf of new users by
     passing only their email address.
@@ -234,7 +238,7 @@ def test_api_documents_create_for_owner_new_user(mock_convert_markdown):
 
     assert response.status_code == 201
 
-    mock_convert_markdown.assert_called_once_with("Document content")
+    mock_convert_md.assert_called_once_with("Document content")
 
     document = Document.objects.get()
     assert response.json() == {"id": str(document.id)}
@@ -264,8 +268,124 @@ def test_api_documents_create_for_owner_new_user(mock_convert_markdown):
     assert document.creator == user
 
 
+@override_settings(
+    SERVER_TO_SERVER_API_TOKENS=["DummyToken"],
+    OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION=True,
+)
+def test_api_documents_create_for_owner_existing_user_email_no_sub_fallback(
+    mock_convert_md,
+):
+    """
+    It should be possible to create a document on behalf of a pre-existing user for
+    who the sub was not found if the settings allow it. This edge case should not
+    happen in a healthy OIDC federation but can be usefull if an OIDC provider modifies
+    users sub on each login for example...
+    """
+    user = factories.UserFactory()
+
+    data = {
+        "title": "My Document",
+        "content": "Document content",
+        "sub": "123",
+        "email": user.email,
+    }
+
+    response = APIClient().post(
+        "/api/v1.0/documents/create-for-owner/",
+        data,
+        format="json",
+        HTTP_AUTHORIZATION="Bearer DummyToken",
+    )
+
+    assert response.status_code == 201
+
+    mock_convert_md.assert_called_once_with("Document content")
+
+    document = Document.objects.get()
+    assert response.json() == {"id": str(document.id)}
+
+    assert document.title == "My Document"
+    assert document.content == "Converted document content"
+    assert document.creator == user
+    assert document.accesses.filter(user=user, role="owner").exists()
+
+    assert Invitation.objects.exists() is False
+
+    assert len(mail.outbox) == 1
+    email = mail.outbox[0]
+    assert email.to == [user.email]
+    assert email.subject == "A new document was created on your behalf!"
+    email_content = " ".join(email.body.split())
+    assert "A new document was created on your behalf!" in email_content
+    assert (
+        "You have been granted ownership of a new document: My Document"
+    ) in email_content
+
+
+@override_settings(
+    SERVER_TO_SERVER_API_TOKENS=["DummyToken"],
+    OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION=False,
+)
+def test_api_documents_create_for_owner_existing_user_email_no_sub_no_fallback(
+    mock_convert_md,
+):
+    """
+    It should be possible to create a document on behalf of a pre-existing user for
+    who the sub was not found if the settings allow it. This edge case should not
+    happen in a healthy OIDC federation but can be usefull if an OIDC provider modifies
+    users sub on each login for example...
+    """
+    user = factories.UserFactory()
+
+    data = {
+        "title": "My Document",
+        "content": "Document content",
+        "sub": "123",
+        "email": user.email,
+    }
+
+    response = APIClient().post(
+        "/api/v1.0/documents/create-for-owner/",
+        data,
+        format="json",
+        HTTP_AUTHORIZATION="Bearer DummyToken",
+    )
+    assert response.status_code == 400
+
+    assert response.json() == {"sub": ["Could not find user with this sub."]}
+    assert mock_convert_md.called is False
+    assert Document.objects.exists() is False
+    assert Invitation.objects.exists() is False
+    assert len(mail.outbox) == 0
+
+
+@patch.object(ServerCreateDocumentSerializer, "_send_email_notification")
+@override_settings(SERVER_TO_SERVER_API_TOKENS=["DummyToken"], LANGUAGE_CODE="de-de")
+def test_api_documents_create_for_owner_with_default_language(
+    mock_send, mock_convert_md
+):
+    """The default language from settings should apply by default."""
+    data = {
+        "title": "My Document",
+        "content": "Document content",
+        "sub": "123",
+        "email": "john.doe@example.com",
+    }
+
+    response = APIClient().post(
+        "/api/v1.0/documents/create-for-owner/",
+        data,
+        format="json",
+        HTTP_AUTHORIZATION="Bearer DummyToken",
+    )
+    assert response.status_code == 201
+
+    mock_convert_md.assert_called_once_with("Document content")
+    assert mock_send.call_args[0][3] == "de-de"
+
+
 @override_settings(SERVER_TO_SERVER_API_TOKENS=["DummyToken"])
-def test_api_documents_create_for_owner_with_custom_language(mock_convert_markdown):
+def test_api_documents_create_for_owner_with_custom_language(mock_convert_md):
     """
     Test creating a document with a specific language.
     Useful if the remote server knows the user's language.
@@ -287,7 +407,7 @@ def test_api_documents_create_for_owner_with_custom_language(mock_convert_markdo
 
     assert response.status_code == 201
 
-    mock_convert_markdown.assert_called_once_with("Document content")
+    mock_convert_md.assert_called_once_with("Document content")
 
     assert len(mail.outbox) == 1
     email = mail.outbox[0]
@@ -302,7 +422,7 @@ def test_api_documents_create_for_owner_with_custom_language(mock_convert_markdo
 
 @override_settings(SERVER_TO_SERVER_API_TOKENS=["DummyToken"])
 def test_api_documents_create_for_owner_with_custom_subject_and_message(
-    mock_convert_markdown,
+    mock_convert_md,
 ):
     """It should be possible to customize the subject and message of the invitation email."""
     data = {
@@ -323,7 +443,7 @@ def test_api_documents_create_for_owner_with_custom_subject_and_message(
 
     assert response.status_code == 201
 
-    mock_convert_markdown.assert_called_once_with("Document content")
+    mock_convert_md.assert_called_once_with("Document content")
 
     assert len(mail.outbox) == 1
     email = mail.outbox[0]
@@ -336,11 +456,11 @@ def test_api_documents_create_for_owner_with_custom_subject_and_message(
 
 @override_settings(SERVER_TO_SERVER_API_TOKENS=["DummyToken"])
 def test_api_documents_create_for_owner_with_converter_exception(
-    mock_convert_markdown,
+    mock_convert_md,
 ):
-    """It should be possible to customize the subject and message of the invitation email."""
+    """In case of converter error, a 400 error should be raised."""
 
-    mock_convert_markdown.side_effect = ConversionError("Conversion failed")
+    mock_convert_md.side_effect = ConversionError("Conversion failed")
 
     data = {
         "title": "My Document",
@@ -357,8 +477,33 @@ def test_api_documents_create_for_owner_with_converter_exception(
         format="json",
         HTTP_AUTHORIZATION="Bearer DummyToken",
     )
+    mock_convert_md.assert_called_once_with("Document content")
 
-    mock_convert_markdown.assert_called_once_with("Document content")
+    assert response.status_code == 400
+    assert response.json() == {"content": ["Could not convert content"]}
 
-    assert response.status_code == 500
-    assert response.json() == {"detail": "could not convert content"}
+
+@override_settings(SERVER_TO_SERVER_API_TOKENS=["DummyToken"])
+def test_api_documents_create_for_owner_with_empty_content():
+    """The content should not be empty or a 400 error should be raised."""
+
+    data = {
+        "title": "My Document",
+        "content": "  ",
+        "sub": "123",
+        "email": "john.doe@example.com",
+    }
+
+    response = APIClient().post(
+        "/api/v1.0/documents/create-for-owner/",
+        data,
+        format="json",
+        HTTP_AUTHORIZATION="Bearer DummyToken",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "content": [
+            "This field may not be blank.",
+        ],
+    }


### PR DESCRIPTION
## Purpose

When creating a document on behalf of a user via the server-to-server API, a special edge case was broken that should should never happen but happens in our OIDC federation because one of the provider modifies the users "sub" each time they login.
    
We ended-up with existing users for who the email matches but not the sub. They were not correctly handled.

## Proposal

Get the user by its email like we do during authentication if activated in settings.
    
Made a few additional fixes and improvements to the endpoint.
