### PR TITLE
🐛(backend) race condition creation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to
 
 - 🐛(backend) fix create document via s2s if sub unknown but email found #543
 - 🐛(frontend) hide search and create doc button if not authenticated #555
+- 🐛(backend) race condition creation issue #556
 
 ## [1.10.0] - 2024-12-17
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -201,7 +201,7 @@ class DocumentSerializer(ListDocumentSerializer):
             "abilities",
             "created_at",
             "creator",
-            "is_avorite",
+            "is_favorite",
             "link_role",
             "link_reach",
             "nb_accesses",

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -676,7 +676,7 @@ class DocumentViewSet(
 
         # Fetch the document and check if the user has access
         try:
-            document, _created = models.Document.objects.get_or_create(pk=pk)
+            document = models.Document.objects.get(pk=pk)
         except models.Document.DoesNotExist as exc:
             logger.debug("Document with ID '%s' does not exist", pk)
             raise drf.exceptions.PermissionDenied() from exc


### PR DESCRIPTION
## Purpose

3 requests we able to create a document:
- POST document
- GET collaboration-auth
- GET media-auth

If the 2 last were faster than the first, a document was created without the necessary informations.

## Proposal

- [x] 🐛(backend) creation race condition
- [x] ✏️(backend) fix read_only_fields is_favorite
