### PR TITLE
🔖(minor) release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+
+## [2.1.0] - 2025-01-29
+
 ## Added
 
 - ✨(backend) add soft delete and restore API endpoints to documents #516
@@ -23,14 +26,17 @@ and this project adheres to
 
 - 💄(frontend) add abilities on doc row #581
 - 💄(frontend) improve DocsGridItem responsive padding  #582
+- 🔧(backend) Bump maximum page size to 200 #516
+- 📝(doc) Improve Read me #558
 
-## Changed
+## Fixed
 
-- 🔧(backend) Bump page size to 200 #516
+- 🐛Fix invitations #575
 
 ## Removed
 
 - 🔥(backend) remove "content" field from list serializer # 516
+
 
 ## [2.0.1] - 2025-01-17
 
@@ -386,7 +392,8 @@ and this project adheres to
 - 🚀 Impress, project to manage your documents easily and collaboratively.
 
 
-[unreleased]: https://github.com/numerique-gouv/impress/compare/v2.0.1...main
+[unreleased]: https://github.com/numerique-gouv/impress/compare/v2.1.0...main
+[v2.1.0]: https://github.com/numerique-gouv/impress/releases/v2.1.0
 [v2.0.1]: https://github.com/numerique-gouv/impress/releases/v2.0.1
 [v2.0.0]: https://github.com/numerique-gouv/impress/releases/v2.0.0
 [v1.10.0]: https://github.com/numerique-gouv/impress/releases/v1.10.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impress"
-version = "2.0.1"
+version = "2.1.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts",

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-impress",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "private": true,
   "workspaces": {
     "packages": [

--- a/src/frontend/packages/eslint-config-impress/package.json
+++ b/src/frontend/packages/eslint-config-impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-impress",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint --ext .js ."

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "extract-translation": "yarn extract-translation:impress",

--- a/src/frontend/servers/y-provider/package.json
+++ b/src/frontend/servers/y-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-y-provider",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Y.js provider for docs",
   "repository": "https://github.com/numerique-gouv/impress",
   "license": "MIT",

--- a/src/helm/helmfile.yaml
+++ b/src/helm/helmfile.yaml
@@ -93,4 +93,4 @@ releases:
 environments:
   dev:
     values:
-      - version: 2.0.1
+      - version: 2.1.0

--- a/src/helm/impress/Chart.yaml
+++ b/src/helm/impress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: docs
-version: 2.0.1-beta.8
+version: 2.1.0
 appVersion: latest

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Added

- ✨(backend) add soft delete and restore API endpoints to documents #516
- ✨(backend) allow organizing documents in a tree structure #516
- ✨(backend) add "excerpt" field to document list serializer #516
- ✨(backend) add github actions to manage Crowdin workflow #559 & #563
- 📈Integrate Posthog #540
- 🏷️(backend) add content-type to uploaded files #552
- ✨(frontend) export pdf docx front side #537

## Changed

- 💄(frontend) add abilities on doc row #581
- 💄(frontend) improve DocsGridItem responsive padding  #582
- 🔧(backend) Bump maximum page size to 200 #516
- 📝(doc) Improve Read me #558

## Fixed

- 🐛Fix invitations #575

## Removed

- 🔥(backend) remove "content" field from list serializer #516

---

**Full Changelog:** https://github.com/numerique-gouv/impress/compare/v2.0.1...v2.1.0
