### PR TITLE
✨(helm) add pdbs to deployments

### DIFF
--- a/src/helm/impress/Chart.yaml
+++ b/src/helm/impress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: docs
-version: 2.1.0
+version: 2.1.0-beta-1
 appVersion: latest

--- a/src/helm/impress/README.md
+++ b/src/helm/impress/README.md
@@ -131,6 +131,7 @@
 | `backend.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                         |                                                                                                                               |
 | `backend.extraVolumeMounts`                           | Additional volumes to mount on the backend.                                        | `[]`                                                                                                                          |
 | `backend.extraVolumes`                                | Additional volumes to mount on the backend.                                        | `[]`                                                                                                                          |
+| `backend.pdb.enabled`                                 | Enable pdb on backend                                                              | `true`                                                                                                                        |
 
 ### frontend
 
@@ -180,6 +181,7 @@
 | `frontend.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                          |                            |
 | `frontend.extraVolumeMounts`                           | Additional volumes to mount on the frontend.                                        | `[]`                       |
 | `frontend.extraVolumes`                                | Additional volumes to mount on the frontend.                                        | `[]`                       |
+| `frontend.pdb.enabled`                                 | Enable pdb on frontend                                                              | `true`                     |
 
 ### posthog
 
@@ -261,3 +263,4 @@
 | `yProvider.persistence.volume-name.mountPath`           | Path where the volume should be mounted to                                           |                              |
 | `yProvider.extraVolumeMounts`                           | Additional volumes to mount on the yProvider.                                        | `[]`                         |
 | `yProvider.extraVolumes`                                | Additional volumes to mount on the yProvider.                                        | `[]`                         |
+| `yProvider.pdb.enabled`                                 | Enable pdb on yProvider                                                              | `true`                       |

--- a/src/helm/impress/generate-readme.sh
+++ b/src/helm/impress/generate-readme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker image ls | grep readme-generator-for-helm
 if [ "$?" -ne "0" ]; then

--- a/src/helm/impress/templates/backend_deployment.yaml
+++ b/src/helm/impress/templates/backend_deployment.yaml
@@ -138,3 +138,16 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+---
+{{ if .Values.backend.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "impress.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/impress/templates/frontend_deployment.yaml
+++ b/src/helm/impress/templates/frontend_deployment.yaml
@@ -138,3 +138,16 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+---
+{{ if .Values.frontend.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "impress.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/impress/templates/yprovider_deployment.yaml
+++ b/src/helm/impress/templates/yprovider_deployment.yaml
@@ -138,3 +138,16 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+---
+{{ if .Values.yProvider.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "impress.common.selectorLabels" (list . $component) | nindent 6 }}
+{{ end }}

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -308,6 +308,9 @@ backend:
   ## @param backend.extraVolumes Additional volumes to mount on the backend.
   extraVolumes: []
 
+  ## @param backend.pdb.enabled Enable pdb on backend
+  pdb:
+    enabled: true
 
 ## @section frontend
 
@@ -402,6 +405,10 @@ frontend:
 
   ## @param frontend.extraVolumes Additional volumes to mount on the frontend.
   extraVolumes: []
+
+  ## @param frontend.pdb.enabled Enable pdb on frontend
+  pdb:
+    enabled: true
 
 ## @section posthog
 
@@ -571,3 +578,7 @@ yProvider:
 
   ## @param yProvider.extraVolumes Additional volumes to mount on the yProvider.
   extraVolumes: []
+
+  ## @param yProvider.pdb.enabled Enable pdb on yProvider
+  pdb:
+    enabled: true


### PR DESCRIPTION
In order to avoid a service interruption during a Kubernetes (k8s) upgrade, we add a Pod Disruption Budget (PDB) to deployments.
