### PR TITLE
✨(frontend) Add export page break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - 📝(doc) Add security.md and codeofconduct.md #604
 - ✨(frontend) add home page #553
 - ✨(frontend) cursor display on activity #609
+- ✨(frontend) Add export page break #623
 
 ## Fixed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -1,4 +1,9 @@
-import { Dictionary, locales } from '@blocknote/core';
+import {
+  BlockNoteSchema,
+  Dictionary,
+  locales,
+  withPageBreak,
+} from '@blocknote/core';
 import '@blocknote/core/fonts/inter.css';
 import { BlockNoteView } from '@blocknote/mantine';
 import '@blocknote/mantine/style.css';
@@ -19,6 +24,7 @@ import useSaveDoc from '../hook/useSaveDoc';
 import { useEditorStore } from '../stores';
 import { randomColor } from '../utils';
 
+import { BlockNoteSuggestionMenu } from './BlockNoteSuggestionMenu';
 import { BlockNoteToolbar } from './BlockNoteToolbar';
 
 const cssEditor = (readonly: boolean) => css`
@@ -142,6 +148,8 @@ const cssEditor = (readonly: boolean) => css`
   }
 `;
 
+export const blockNoteSchema = withPageBreak(BlockNoteSchema.create());
+
 interface BlockNoteEditorProps {
   doc: Doc;
   provider: HocuspocusProvider;
@@ -217,6 +225,7 @@ export const BlockNoteEditor = ({ doc, provider }: BlockNoteEditorProps) => {
       },
       dictionary: locales[lang as keyof typeof locales] as Dictionary,
       uploadFile,
+      schema: blockNoteSchema,
     },
     [collabName, lang, provider, uploadFile],
   );
@@ -249,10 +258,12 @@ export const BlockNoteEditor = ({ doc, provider }: BlockNoteEditorProps) => {
       <BlockNoteView
         editor={editor}
         formattingToolbar={false}
+        slashMenu={false}
         editable={!readOnly}
         theme="light"
       >
         <BlockNoteToolbar />
+        <BlockNoteSuggestionMenu />
       </BlockNoteView>
     </Box>
   );
@@ -277,6 +288,7 @@ export const BlockNoteEditorVersion = ({
         },
         provider: undefined,
       },
+      schema: blockNoteSchema,
     },
     [initialContent],
   );

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -11,7 +11,6 @@ import { useCreateBlockNote } from '@blocknote/react';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { css } from 'styled-components';
 import * as Y from 'yjs';
 
 import { Box, TextErrors } from '@/components';
@@ -22,131 +21,11 @@ import { useUploadFile } from '../hook';
 import { useHeadings } from '../hook/useHeadings';
 import useSaveDoc from '../hook/useSaveDoc';
 import { useEditorStore } from '../stores';
+import { cssEditor } from '../styles';
 import { randomColor } from '../utils';
 
 import { BlockNoteSuggestionMenu } from './BlockNoteSuggestionMenu';
 import { BlockNoteToolbar } from './BlockNoteToolbar';
-
-const cssEditor = (readonly: boolean) => css`
-  &,
-  & > .bn-container,
-  & .ProseMirror {
-    height: 100%;
-
-    .collaboration-cursor-custom__base {
-      position: relative;
-    }
-    .collaboration-cursor-custom__caret {
-      position: absolute;
-      height: 85%;
-      width: 2px;
-      bottom: 4%;
-      left: -1px;
-    }
-
-    .collaboration-cursor-custom__label {
-      color: #0d0d0d;
-      font-size: 12px;
-      font-weight: 600;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      user-select: none;
-      position: absolute;
-      top: -17px;
-      padding: 0px 6px;
-      border-radius: 0px;
-      white-space: nowrap;
-      transition: clip-path 0.3s ease-in-out;
-      border-radius: 4px 4px 4px 0;
-      box-shadow: inset -2px 2px 6px #ffffff88;
-      clip-path: polygon(0 100%, 0 100%, 0 100%, 0% 100%);
-    }
-
-    .collaboration-cursor-custom__base[data-active]
-      .collaboration-cursor-custom__label {
-      pointer-events: none;
-      clip-path: polygon(0 0, 100% 0%, 100% 100%, 0% 100%);
-    }
-
-    .bn-side-menu[data-block-type='heading'][data-level='1'] {
-      height: 50px;
-    }
-    .bn-side-menu[data-block-type='heading'][data-level='2'] {
-      height: 43px;
-    }
-    .bn-side-menu[data-block-type='heading'][data-level='3'] {
-      height: 35px;
-    }
-    h1 {
-      font-size: 1.875rem;
-    }
-    h2 {
-      font-size: 1.5rem;
-    }
-    h3 {
-      font-size: 1.25rem;
-    }
-    a {
-      color: var(--c--theme--colors--greyscale-500);
-      cursor: pointer;
-    }
-    .bn-block-group
-      .bn-block-group
-      .bn-block-outer:not([data-prev-depth-changed]):before {
-      border-left: none;
-    }
-  }
-
-  .bn-editor {
-    color: var(--c--theme--colors--greyscale-700);
-  }
-
-  .bn-block-outer:not(:first-child) {
-    &:has(h1) {
-      padding-top: 32px;
-    }
-    &:has(h2) {
-      padding-top: 24px;
-    }
-    &:has(h3) {
-      padding-top: 16px;
-    }
-  }
-
-  & .bn-inline-content code {
-    background-color: gainsboro;
-    padding: 2px;
-    border-radius: 4px;
-  }
-
-  @media screen and (width <= 560px) {
-    & .bn-editor {
-      ${readonly && `padding-left: 10px;`}
-    }
-    .bn-side-menu[data-block-type='heading'][data-level='1'] {
-      height: 46px;
-    }
-    .bn-side-menu[data-block-type='heading'][data-level='2'] {
-      height: 40px;
-    }
-    .bn-side-menu[data-block-type='heading'][data-level='3'] {
-      height: 40px;
-    }
-    & .bn-editor h1 {
-      font-size: 1.6rem;
-    }
-    & .bn-editor h2 {
-      font-size: 1.35rem;
-    }
-    & .bn-editor h3 {
-      font-size: 1.2rem;
-    }
-    .bn-block-content[data-is-empty-and-focused][data-content-type='paragraph']
-      .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {
-      font-size: 14px;
-    }
-  }
-`;
 
 export const blockNoteSchema = withPageBreak(BlockNoteSchema.create());
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteSuggestionMenu.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteSuggestionMenu.tsx
@@ -1,0 +1,35 @@
+import { combineByGroup, filterSuggestionItems } from '@blocknote/core';
+import '@blocknote/mantine/style.css';
+import {
+  SuggestionMenuController,
+  getDefaultReactSlashMenuItems,
+  getPageBreakReactSlashMenuItems,
+  useBlockNoteEditor,
+} from '@blocknote/react';
+import React, { useMemo } from 'react';
+
+import { DocsBlockNoteEditor } from '../types';
+
+export const BlockNoteSuggestionMenu = () => {
+  const editor = useBlockNoteEditor() as DocsBlockNoteEditor;
+
+  const getSlashMenuItems = useMemo(() => {
+    return async (query: string) =>
+      Promise.resolve(
+        filterSuggestionItems(
+          combineByGroup(
+            getDefaultReactSlashMenuItems(editor),
+            getPageBreakReactSlashMenuItems(editor),
+          ),
+          query,
+        ),
+      );
+  }, [editor]);
+
+  return (
+    <SuggestionMenuController
+      triggerCharacter="/"
+      getItems={getSlashMenuItems}
+    />
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useHeadings.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useHeadings.tsx
@@ -1,9 +1,9 @@
-import { BlockNoteEditor } from '@blocknote/core';
 import { useEffect } from 'react';
 
 import { useHeadingStore } from '../stores';
+import { DocsBlockNoteEditor } from '../types';
 
-export const useHeadings = (editor: BlockNoteEditor) => {
+export const useHeadings = (editor: DocsBlockNoteEditor) => {
   const { setHeadings, resetHeadings } = useHeadingStore();
 
   useEffect(() => {

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/stores/useEditorStore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/stores/useEditorStore.tsx
@@ -1,9 +1,10 @@
-import { BlockNoteEditor } from '@blocknote/core';
 import { create } from 'zustand';
 
+import { DocsBlockNoteEditor } from '../types';
+
 export interface UseEditorstore {
-  editor?: BlockNoteEditor;
-  setEditor: (editor: BlockNoteEditor | undefined) => void;
+  editor?: DocsBlockNoteEditor;
+  setEditor: (editor: DocsBlockNoteEditor | undefined) => void;
 }
 
 export const useEditorStore = create<UseEditorstore>((set) => ({

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/stores/useHeadingStore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/stores/useHeadingStore.tsx
@@ -1,7 +1,6 @@
-import { BlockNoteEditor } from '@blocknote/core';
 import { create } from 'zustand';
 
-import { HeadingBlock } from '../types';
+import { DocsBlockNoteEditor, HeadingBlock } from '../types';
 
 const recursiveTextContent = (content: HeadingBlock['content']): string => {
   if (!content) {
@@ -21,7 +20,7 @@ const recursiveTextContent = (content: HeadingBlock['content']): string => {
 
 export interface UseHeadingStore {
   headings: HeadingBlock[];
-  setHeadings: (editor: BlockNoteEditor) => void;
+  setHeadings: (editor: DocsBlockNoteEditor) => void;
   resetHeadings: () => void;
 }
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -1,0 +1,120 @@
+import { css } from 'styled-components';
+
+export const cssEditor = (readonly: boolean) => css`
+  &,
+  & > .bn-container,
+  & .ProseMirror {
+    height: 100%;
+
+    .collaboration-cursor-custom__base {
+      position: relative;
+    }
+    .collaboration-cursor-custom__caret {
+      position: absolute;
+      height: 85%;
+      width: 2px;
+      bottom: 4%;
+      left: -1px;
+    }
+    .collaboration-cursor-custom__label {
+      color: #0d0d0d;
+      font-size: 12px;
+      font-weight: 600;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      user-select: none;
+      position: absolute;
+      top: -17px;
+      padding: 0px 6px;
+      border-radius: 0px;
+      white-space: nowrap;
+      transition: clip-path 0.3s ease-in-out;
+      border-radius: 4px 4px 4px 0;
+      box-shadow: inset -2px 2px 6px #ffffff88;
+      clip-path: polygon(0 100%, 0 100%, 0 100%, 0% 100%);
+    }
+    .collaboration-cursor-custom__base[data-active]
+      .collaboration-cursor-custom__label {
+      pointer-events: none;
+      clip-path: polygon(0 0, 100% 0%, 100% 100%, 0% 100%);
+    }
+
+    .bn-side-menu[data-block-type='heading'][data-level='1'] {
+      height: 50px;
+    }
+    .bn-side-menu[data-block-type='heading'][data-level='2'] {
+      height: 43px;
+    }
+    .bn-side-menu[data-block-type='heading'][data-level='3'] {
+      height: 35px;
+    }
+    h1 {
+      font-size: 1.875rem;
+    }
+    h2 {
+      font-size: 1.5rem;
+    }
+    h3 {
+      font-size: 1.25rem;
+    }
+    a {
+      color: var(--c--theme--colors--greyscale-500);
+      cursor: pointer;
+    }
+    .bn-block-group
+      .bn-block-group
+      .bn-block-outer:not([data-prev-depth-changed]):before {
+      border-left: none;
+    }
+  }
+
+  .bn-editor {
+    color: var(--c--theme--colors--greyscale-700);
+  }
+
+  .bn-block-outer:not(:first-child) {
+    &:has(h1) {
+      padding-top: 32px;
+    }
+    &:has(h2) {
+      padding-top: 24px;
+    }
+    &:has(h3) {
+      padding-top: 16px;
+    }
+  }
+
+  & .bn-inline-content code {
+    background-color: gainsboro;
+    padding: 2px;
+    border-radius: 4px;
+  }
+
+  @media screen and (width <= 560px) {
+    & .bn-editor {
+      ${readonly && `padding-left: 10px;`}
+    }
+    .bn-side-menu[data-block-type='heading'][data-level='1'] {
+      height: 46px;
+    }
+    .bn-side-menu[data-block-type='heading'][data-level='2'] {
+      height: 40px;
+    }
+    .bn-side-menu[data-block-type='heading'][data-level='3'] {
+      height: 40px;
+    }
+    & .bn-editor h1 {
+      font-size: 1.6rem;
+    }
+    & .bn-editor h2 {
+      font-size: 1.35rem;
+    }
+    & .bn-editor h3 {
+      font-size: 1.2rem;
+    }
+    .bn-block-content[data-is-empty-and-focused][data-content-type='paragraph']
+      .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {
+      font-size: 14px;
+    }
+  }
+`;

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -30,12 +30,13 @@ export const cssEditor = (readonly: boolean) => css`
       white-space: nowrap;
       transition: clip-path 0.3s ease-in-out;
       border-radius: 4px 4px 4px 0;
-      box-shadow: inset -2px 2px 6px #ffffff88;
-      clip-path: polygon(0 100%, 0 100%, 0 100%, 0% 100%);
+      box-shadow: inset -2px 2px 6px #ffffff00;
+      clip-path: polygon(0 85%, 4% 85%, 4% 100%, 0% 100%);
     }
     .collaboration-cursor-custom__base[data-active]
       .collaboration-cursor-custom__label {
       pointer-events: none;
+      box-shadow: inset -2px 2px 6px #ffffff88;
       clip-path: polygon(0 0, 100% 0%, 100% 100%, 0% 100%);
     }
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/types.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/types.tsx
@@ -1,3 +1,7 @@
+import { BlockNoteEditor } from '@blocknote/core';
+
+import { blockNoteSchema } from './components/BlockNoteEditor';
+
 export interface DocAttachment {
   file: string;
 }
@@ -12,3 +16,9 @@ export type HeadingBlock = {
     level: number;
   };
 };
+
+export type DocsBlockNoteEditor = BlockNoteEditor<
+  typeof blockNoteSchema.blockSchema,
+  typeof blockNoteSchema.inlineContentSchema,
+  typeof blockNoteSchema.styleSchema
+>;

--- a/src/frontend/apps/impress/src/features/docs/doc-table-content/components/Heading.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-table-content/components/Heading.tsx
@@ -1,8 +1,8 @@
-import { BlockNoteEditor } from '@blocknote/core';
 import { useState } from 'react';
 
 import { BoxButton, Text } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
+import { DocsBlockNoteEditor } from '@/features/docs/doc-editor';
 import { useResponsiveStore } from '@/stores';
 
 const leftPaddingMap: { [key: number]: string } = {
@@ -17,7 +17,7 @@ export type HeadingsHighlight = {
 }[];
 
 interface HeadingProps {
-  editor: BlockNoteEditor;
+  editor: DocsBlockNoteEditor;
   level: number;
   text: string;
   headingId: string;


### PR DESCRIPTION
## Purpose

Recent upgrade of Blocknote.js add the export `PageBreak` block. 
This PR add this feature to our editor.

## Proposal

- [x] ✨(frontend) add export page break
- [x] 🚚(frontend) move Blocknote styles

## Demo

[scrnli_XXGTCdUYLylzAi.webm](https://github.com/user-attachments/assets/9b60d5a1-efa5-4e1a-b5c7-4611530bba39)

