### PR TITLE
🛂(frontend) Restore version visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 
 ## Changed
 
+- 🛂(frontend) Restore version visibility #629
 - 📝(doc) minor README.md formatting and wording enhancements
 - ♻️Stop setting a default title on doc creation #634
 

--- a/src/frontend/apps/impress/src/features/docs/doc-versioning/components/ModalSelectVersion.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-versioning/components/ModalSelectVersion.tsx
@@ -36,8 +36,9 @@ export const ModalSelectVersion = ({
   const { t } = useTranslation();
   const [selectedVersionId, setSelectedVersionId] =
     useState<Versions['version_id']>();
-
+  const canRestore = doc.abilities.partial_update;
   const restoreModal = useModal();
+
   return (
     <>
       <Modal
@@ -127,21 +128,23 @@ export const ModalSelectVersion = ({
                 selectedVersionId={selectedVersionId}
               />
             </Box>
-            <Box
-              $padding="xs"
-              $css={css`
-                border-top: 1px solid var(--c--theme--colors--greyscale-200);
-              `}
-            >
-              <Button
-                fullWidth
-                disabled={!selectedVersionId}
-                onClick={restoreModal.open}
-                color="primary"
+            {canRestore && (
+              <Box
+                $padding="xs"
+                $css={css`
+                  border-top: 1px solid var(--c--theme--colors--greyscale-200);
+                `}
               >
-                {t('Restore')}
-              </Button>
-            </Box>
+                <Button
+                  fullWidth
+                  disabled={!selectedVersionId}
+                  onClick={restoreModal.open}
+                  color="primary"
+                >
+                  {t('Restore')}
+                </Button>
+              </Box>
+            )}
           </Box>
         </Box>
       </Modal>


### PR DESCRIPTION
## Purpose

When you are a reader member, you have the right to see the version but you cannot restore them. 
So, we hide the restore button when you are a reader.

## Proposal

- [x] 🩹(docker-compose) remove comment
- [x] 🛂(frontend) hide version restore button when reader

## Where

![image](https://github.com/user-attachments/assets/c5f9724d-9f87-4f4a-b083-96522f8eb3a9)
