### PR TITLE
Fix user search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 
 ## Fixed
 
+- 🐛(backend) stop returning inactive users on the list endpoint #635
 - 🔒️(backend) require at least 5 characters to search for users #635
 
 ## [2.2.0] - 2025-02-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- 🔒️(backend) require at least 5 characters to search for users #635
+
 ## [2.2.0] - 2025-02-10
 
 ## Added

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -160,8 +160,8 @@ class UserViewSet(
         if document_id := self.request.GET.get("document_id", ""):
             queryset = queryset.exclude(documentaccess__document_id=document_id)
 
-        if not (query := self.request.GET.get("q", "")):
-            return queryset
+        if not (query := self.request.GET.get("q", "")) or len(query) < 5:
+            return queryset.none()
 
         # For emails, match emails by Levenstein distance to prevent typing errors
         if "@" in query:

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -141,7 +141,7 @@ class UserViewSet(
     """User ViewSet"""
 
     permission_classes = [permissions.IsSelf]
-    queryset = models.User.objects.all()
+    queryset = models.User.objects.filter(is_active=True)
     serializer_class = serializers.UserSerializer
 
     def get_queryset(self):

--- a/src/backend/core/tests/test_api_users.py
+++ b/src/backend/core/tests/test_api_users.py
@@ -154,6 +154,22 @@ def test_api_users_list_query_short_queries():
     assert len(response.json()["results"]) == 2
 
 
+def test_api_users_list_query_inactive():
+    """Inactive users should not be listed."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    factories.UserFactory(email="john.doe@example.com", is_active=False)
+    lennon = factories.UserFactory(email="john.lennon@example.com")
+
+    response = client.get("/api/v1.0/users/?q=john.")
+
+    assert response.status_code == 200
+    user_ids = [user["id"] for user in response.json()["results"]]
+    assert user_ids == [str(lennon.id)]
+
+
 def test_api_users_retrieve_me_anonymous():
     """Anonymous users should not be allowed to list users."""
     factories.UserFactory.create_batch(2)


### PR DESCRIPTION
## Purpose

We don't want user search to be triggered for very short query strings.
Also, we are currently returning users who have been disabled which is dysfunctional.

## Proposal

- [x] require a query string of minimum 5 characters for a user search
- [x] Filter inactive users out of search results 