### PR TITLE
♻️(front) improve table pdf rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ## Changed
@@ -15,6 +14,9 @@ and this project adheres to
 - 📝(doc) minor README.md formatting and wording enhancements
 - ♻️Stop setting a default title on doc creation #634
 
+## Fixed
+
+- ♻️(frontend) improve table pdf rendering
 
 ## [2.2.0] - 2025-02-10
 
@@ -35,7 +37,6 @@ and this project adheres to
 - 🐛(frontend) fix cursor breakline #609
 - 🐛(frontend) fix style pdf export #609
 
-
 ## [2.1.0] - 2025-01-29
 
 ## Added
@@ -51,7 +52,7 @@ and this project adheres to
 ## Changed
 
 - 💄(frontend) add abilities on doc row #581
-- 💄(frontend) improve DocsGridItem responsive padding  #582
+- 💄(frontend) improve DocsGridItem responsive padding #582
 - 🔧(backend) Bump maximum page size to 200 #516
 - 📝(doc) Improve Read me #558
 
@@ -62,7 +63,6 @@ and this project adheres to
 ## Removed
 
 - 🔥(backend) remove "content" field from list serializer # 516
-
 
 ## [2.0.1] - 2025-01-17
 
@@ -118,11 +118,10 @@ and this project adheres to
 
 - ⚡️(e2e) reduce flakiness on e2e tests #511
 
-
 ## Fixed
+
 - 🐛(frontend) update doc editor height #481
 - 💄(frontend) add doc search #485
-
 
 ## [1.9.0] - 2024-12-11
 
@@ -145,20 +144,17 @@ and this project adheres to
 - 🐛(frontend) Fix hidden menu on Firefox #468
 - 🐛(backend) fix sanitize problem IA #490
 
-
 ## [1.8.2] - 2024-11-28
 
 ## Changed
 
 - ♻️(SW) change strategy html caching #460
 
-
 ## [1.8.1] - 2024-11-27
 
 ## Fixed
 
 - 🐛(frontend) link not clickable and flickering firefox #457
-
 
 ## [1.8.0] - 2024-11-25
 
@@ -188,7 +184,6 @@ and this project adheres to
 - 🐛(frontend) users have view access when revoked #387
 - 🐛(frontend) fix placeholder editable when double clicks #454
 
-
 ## [1.7.0] - 2024-10-24
 
 ## Added
@@ -216,7 +211,6 @@ and this project adheres to
 
 - 🔥(helm) remove infra related codes #366
 
-
 ## [1.6.0] - 2024-10-17
 
 ## Added
@@ -238,7 +232,6 @@ and this project adheres to
 - 🐛(backend) Fix dysfunctional permissions on document create #329
 - 🐛(backend) fix nginx docker container #340
 - 🐛(frontend) fix copy paste firefox #353
-
 
 ## [1.5.1] - 2024-10-10
 
@@ -274,7 +267,6 @@ and this project adheres to
 - 🔧(backend) fix configuration to avoid different ssl warning #297
 - 🐛(frontend) fix editor break line not working #302
 
-
 ## [1.4.0] - 2024-09-17
 
 ## Added
@@ -294,7 +286,6 @@ and this project adheres to
 
 - 🐛(backend) Fix forcing ID when creating a document via API endpoint #234
 - 🐛 Rebuild frontend dev container from makefile #248
-
 
 ## [1.3.0] - 2024-09-05
 
@@ -320,14 +311,12 @@ and this project adheres to
 
 - 🔥(frontend) remove saving modal #213
 
-
 ## [1.2.1] - 2024-08-23
 
 ## Changed
 
 - ♻️ Change ordering docs datagrid #195
 - 🔥(helm) use scaleway email #194
-
 
 ## [1.2.0] - 2024-08-22
 
@@ -352,14 +341,14 @@ and this project adheres to
 - ⚡️(CI) only e2e chrome mandatory #177
 
 ## Removed
-- 🔥(helm) remove htaccess #181
 
+- 🔥(helm) remove htaccess #181
 
 ## [1.1.0] - 2024-07-15
 
 ## Added
 
-- 🤡(demo) generate dummy documents on dev users #120 
+- 🤡(demo) generate dummy documents on dev users #120
 - ✨(frontend) create side modal component #134
 - ✨(frontend) Doc grid actions (update / delete) #136
 - ✨(frontend) Doc editor header information #137
@@ -370,12 +359,11 @@ and this project adheres to
 - ♻️(frontend) create a doc from a modal #132
 - ♻️(frontend) manage members from the share modal #140
 
-
 ## [1.0.0] - 2024-07-02
 
 ## Added
 
-- 🛂(frontend) Manage the document's right (#75) 
+- 🛂(frontend) Manage the document's right (#75)
 - ✨(frontend) Update document (#68)
 - ✨(frontend) Remove document (#68)
 - 🐳(docker) dockerize dev frontend (#63)
@@ -409,14 +397,12 @@ and this project adheres to
 - 💚(CI) Remove trigger workflow on push tags on CI (#68)
 - 🔥(frontend) Remove coming soon page (#121)
 
-
 ## [0.1.0] - 2024-05-24
 
 ## Added
 
 - ✨(frontend) Coming Soon page (#67)
 - 🚀 Impress, project to manage your documents easily and collaboratively.
-
 
 [unreleased]: https://github.com/numerique-gouv/impress/compare/v2.2.0...main
 [v2.2.0]: https://github.com/numerique-gouv/impress/releases/v2.2.0

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -15,6 +15,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@ag-media/react-pdf-table": "2.0.1",
     "@blocknote/core": "0.23.2",
     "@blocknote/mantine": "0.23.2",
     "@blocknote/react": "0.23.2",

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/ModalExport.tsx
@@ -27,6 +27,8 @@ import { Doc } from '@/features/docs/doc-management';
 import { TemplatesOrdering, useTemplates } from '../api/useTemplates';
 import { downloadFile, exportResolveFileUrl } from '../utils';
 
+import { Table } from './blocks/Table';
+
 enum DocDownloadFormat {
   PDF = 'pdf',
   DOCX = 'docx',
@@ -114,6 +116,7 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
                     : 1.17;
               return (
                 <PDFText
+                  key={block.id}
                   style={{
                     fontSize: fontSizeEM * FONT_SIZE * PIXELS_PER_POINT,
                     fontWeight: 700,
@@ -150,6 +153,9 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
                   {exporter.transformInlineContent(block.content)}
                 </PDFText>
               );
+            },
+            table: (block, transformer) => {
+              return <Table data={block.content} transformer={transformer} />;
             },
           },
         },

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/blocks/Table.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/blocks/Table.tsx
@@ -1,0 +1,76 @@
+import { TD, TH, TR, Table as TablePDF } from '@ag-media/react-pdf-table';
+import {
+  DefaultBlockSchema,
+  Exporter,
+  InlineContentSchema,
+  StyleSchema,
+  TableContent,
+} from '@blocknote/core';
+import { View } from '@react-pdf/renderer';
+import { ReactNode } from 'react';
+
+export const Table = (props: {
+  data: TableContent<InlineContentSchema>;
+  transformer: Exporter<
+    DefaultBlockSchema,
+    InlineContentSchema,
+    StyleSchema,
+    unknown,
+    unknown,
+    unknown,
+    unknown
+  >;
+}) => {
+  return (
+    <TablePDF>
+      {props.data.rows.map((row, index) => {
+        if (index === 0) {
+          return (
+            <TH key={index}>
+              {row.cells.map((cell, index) => {
+                // Make empty cells are rendered.
+                if (cell.length === 0) {
+                  cell.push({
+                    styles: {},
+                    text: ' ',
+                    type: 'text',
+                  });
+                }
+                return (
+                  <TD key={index}>
+                    {props.transformer.transformInlineContent(cell)}
+                  </TD>
+                );
+              })}
+            </TH>
+          );
+        }
+        return (
+          <TR key={index}>
+            {row.cells.map((cell, index) => {
+              // Make empty cells are rendered.
+              if (cell.length === 0) {
+                cell.push({
+                  styles: {},
+                  text: ' ',
+                  type: 'text',
+                });
+              }
+              return (
+                <TD key={index}>
+                  <View>
+                    {
+                      props.transformer.transformInlineContent(
+                        cell,
+                      ) as ReactNode
+                    }
+                  </View>
+                </TD>
+              );
+            })}
+          </TR>
+        );
+      })}
+    </TablePDF>
+  );
+};

--- a/src/frontend/apps/impress/src/types/@ag-media/react-pdf-table.d.ts
+++ b/src/frontend/apps/impress/src/types/@ag-media/react-pdf-table.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// This file is used to declare the types for the @ag-media/react-pdf-table package
+// This library does not export its types in the "exports" field in the package.json.
+declare module '@ag-media/react-pdf-table' {
+  export const TD: React.FC<any>;
+  export const TH: React.FC<any>;
+  export const TR: React.FC<any>;
+  export const Table: React.FC<any>;
+}

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.1.tgz#2447a230bfe072c1659e6815129c03cf170710e3"
   integrity sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==
 
+"@ag-media/react-pdf-table@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@ag-media/react-pdf-table/-/react-pdf-table-2.0.1.tgz#609e51992faed54bcf379a376442997c6bac53cc"
+  integrity sha512-UMNdGYAfuI6L1wLRziYmwcp/8I2JgbwX+PY7bHXGb2+P6MwgFJH8W71qZO1bxfxrmVUTP8YblQwl1PkXG2m6Rg==
+
 "@ampproject/remapping@^2.2.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"


### PR DESCRIPTION
## Purpose

The previous way of rendering table was causing issues when tables could not fit on one page. I then came accross this discussion https://github.com/diegomura/react-pdf/issues/2343. The author created a lib to improve the rendering of table, it's better, but still not perfect maybe.

> Improving PDF is quite cumbersome, so I encourage you to test on your side to see if the rendering is correct. Otherwise we'll need to put more effort into this by going deep in the implementation, not sure we want to put that much of energy in it. Let's try this lib before :)

## Proposal


### The Doc
<img width="646" alt="Capture d’écran 2025-02-14 à 15 32 46" src="https://github.com/user-attachments/assets/75ff190d-eea4-4183-879e-74fd23441100" />

### Before 
<img width="835" alt="Capture d’écran 2025-02-14 à 15 32 22" src="https://github.com/user-attachments/assets/06a0b218-68e9-433f-b9f7-2e26ca69b9a4" />

### After
<img width="696" alt="Capture d’écran 2025-02-14 à 15 33 05" src="https://github.com/user-attachments/assets/f3bc9bbf-df7a-4cda-8e94-4d3c239732e1" />
