### PR TITLE
🐛(front) improve text rendering in pdf

### DIFF
--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/ModalExport.tsx
@@ -15,7 +15,7 @@ import {
   VariantType,
   useToastProvider,
 } from '@openfun/cunningham-react';
-import { pdf } from '@react-pdf/renderer';
+import { Text as PDFText, pdf } from '@react-pdf/renderer';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
@@ -113,7 +113,7 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
                     ? 1.5
                     : 1.17;
               return (
-                <Text
+                <PDFText
                   style={{
                     fontSize: fontSizeEM * FONT_SIZE * PIXELS_PER_POINT,
                     fontWeight: 700,
@@ -122,7 +122,7 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
                   }}
                 >
                   {exporter.transformInlineContent(block.content)}
-                </Text>
+                </PDFText>
               );
             },
             paragraph: (block, exporter) => {
@@ -146,9 +146,9 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
                 }
               }
               return (
-                <Text key={block.id}>
+                <PDFText key={block.id}>
                   {exporter.transformInlineContent(block.content)}
-                </Text>
+                </PDFText>
               );
             },
           },


### PR DESCRIPTION
## Purpose

The rendered text had unwanted line breaks in middle of them. It was because we were not using the appropriate Text component, the one to be used in the one from react-pdf.



## The doc

<img width="978" alt="Capture d’écran 2025-02-17 à 10 58 05" src="https://github.com/user-attachments/assets/7cf55f7f-e17f-4d7b-a375-c7a536024593" />

## PDF Before

<img width="885" alt="Capture d’écran 2025-02-17 à 10 58 23" src="https://github.com/user-attachments/assets/9acda7d0-1eaf-477a-a71e-a875eb56ed68" />

## PDF After

<img width="928" alt="Capture d’écran 2025-02-17 à 10 58 31" src="https://github.com/user-attachments/assets/35358450-559c-4fdf-8ad5-d7e267cc24f5" />

