### PR TITLE
♻️(compose) set compose name in the docker-compose file

### DIFF
--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -7,7 +7,6 @@ UNSET_USER=0
 
 TERRAFORM_DIRECTORY="./env.d/terraform"
 COMPOSE_FILE="${REPO_DIR}/docker-compose.yml"
-COMPOSE_PROJECT="docs"
 
 
 # _set_user: set (or unset) default user id used to run docker commands
@@ -40,9 +39,8 @@ function _set_user() {
 # ARGS   : docker compose command arguments
 function _docker_compose() {
 
-    echo "🐳(compose) project: '${COMPOSE_PROJECT}' file: '${COMPOSE_FILE}'"
+    echo "🐳(compose) file: '${COMPOSE_FILE}'"
     docker compose \
-        -p "${COMPOSE_PROJECT}" \
         -f "${COMPOSE_FILE}" \
         --project-directory "${REPO_DIR}" \
         "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: docs
+
 services:
   postgresql:
     image: postgres:16


### PR DESCRIPTION
## Purpose

The helper bin/compose was using the option -p to set the compose project name but this option is not used in the Makefile. This can lead to different way to use the docker compose file definition with different project name. In order to have a consistent name everywhere and for everybody, we set the name in the docker compose file itself.


## Proposal

- [x] set compose name in the docker-compose file
