### PR TITLE
📈(frontend) abstract analytics classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- 🚩(frontend) feature flag analytic on copy as html #649
 - ✨(frontend) Custom block divider with export #698
 
 ## Changed

--- a/src/frontend/apps/impress/jest.config.ts
+++ b/src/frontend/apps/impress/jest.config.ts
@@ -23,6 +23,7 @@ const jestConfig = async () => {
       '\\.svg$': '<rootDir>/jest/mocks/svg.js',
       '^.+\\.svg\\?url$': `<rootDir>/jest/mocks/fileMock.js`,
       BlockNoteEditor: `<rootDir>/jest/mocks/ComponentMock.js`,
+      'custom-blocks': `<rootDir>/jest/mocks/ComponentMock.js`,
       ...nextJestConfig.moduleNameMapper,
     },
   };

--- a/src/frontend/apps/impress/src/core/config/ConfigProvider.tsx
+++ b/src/frontend/apps/impress/src/core/config/ConfigProvider.tsx
@@ -3,8 +3,9 @@ import { PropsWithChildren, useEffect } from 'react';
 
 import { Box } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
-import { useLanguageSynchronizer } from '@/features/language/hooks/useLanguageSynchronizer';
-import { CrispProvider, PostHogProvider } from '@/services';
+import { useLanguageSynchronizer } from '@/features/language/';
+import { useAnalytics } from '@/libs';
+import { CrispProvider, PostHogAnalytic } from '@/services';
 import { useSentryStore } from '@/stores/useSentryStore';
 
 import { useConfig } from './api/useConfig';
@@ -13,6 +14,7 @@ export const ConfigProvider = ({ children }: PropsWithChildren) => {
   const { data: conf } = useConfig();
   const { setSentry } = useSentryStore();
   const { setTheme } = useCunninghamTheme();
+  const { AnalyticsProvider } = useAnalytics();
   const { synchronizeLanguage } = useLanguageSynchronizer();
 
   useEffect(() => {
@@ -35,6 +37,14 @@ export const ConfigProvider = ({ children }: PropsWithChildren) => {
     void synchronizeLanguage();
   }, [synchronizeLanguage]);
 
+  useEffect(() => {
+    if (!conf?.POSTHOG_KEY) {
+      return;
+    }
+
+    new PostHogAnalytic(conf.POSTHOG_KEY);
+  }, [conf?.POSTHOG_KEY]);
+
   if (!conf) {
     return (
       <Box $height="100vh" $width="100vw" $align="center" $justify="center">
@@ -44,10 +54,10 @@ export const ConfigProvider = ({ children }: PropsWithChildren) => {
   }
 
   return (
-    <PostHogProvider conf={conf.POSTHOG_KEY}>
+    <AnalyticsProvider>
       <CrispProvider websiteId={conf?.CRISP_WEBSITE_ID}>
         {children}
       </CrispProvider>
-    </PostHogProvider>
+    </AnalyticsProvider>
   );
 };

--- a/src/frontend/apps/impress/src/features/auth/hooks/__tests__/useAuth.test.tsx
+++ b/src/frontend/apps/impress/src/features/auth/hooks/__tests__/useAuth.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { Fragment } from 'react';
+
+import { AbstractAnalytic } from '@/libs';
+import { AppWrapper } from '@/tests/utils';
+
+import { useAuth } from '../useAuth';
+
+const trackEventMock = jest.fn();
+const flag = true;
+class TestAnalytic extends AbstractAnalytic {
+  public constructor() {
+    super();
+  }
+
+  public Provider() {
+    return <Fragment />;
+  }
+
+  public trackEvent(props: any) {
+    trackEventMock(props);
+  }
+
+  public isFeatureFlagActivated(flagName: string): boolean {
+    if (flagName === 'CopyAsHTML') {
+      return flag;
+    }
+
+    return true;
+  }
+}
+
+jest.mock('next/router', () => ({
+  ...jest.requireActual('next/router'),
+  useRouter: () => ({
+    pathname: '/dashboard',
+    replace: jest.fn(),
+  }),
+}));
+
+const dummyUser = { id: '123', email: 'test@example.com' };
+
+describe('useAuth hook - trackEvent effect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  test('calls trackEvent when user exists, isSuccess is true, and event was not tracked yet', async () => {
+    new TestAnalytic();
+
+    fetchMock.get('http://test.jest/api/v1.0/users/me/', {
+      body: JSON.stringify(dummyUser),
+    });
+
+    renderHook(() => useAuth(), {
+      wrapper: AppWrapper,
+    });
+
+    await waitFor(() => {
+      expect(trackEventMock).toHaveBeenCalledWith({
+        eventName: 'user',
+        id: dummyUser.id,
+        email: dummyUser.email,
+      });
+    });
+  });
+
+  test('does not call trackEvent if already tracked', () => {
+    fetchMock.get('http://test.jest/api/v1.0/users/me/', {
+      body: JSON.stringify(dummyUser),
+    });
+
+    renderHook(() => useAuth(), {
+      wrapper: AppWrapper,
+    });
+
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/apps/impress/src/features/docs/doc-header/__tests__/DocToolBox.spec.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/__tests__/DocToolBox.spec.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { Fragment } from 'react';
+
+import { AbstractAnalytic, Analytics } from '@/libs';
+import { AppWrapper } from '@/tests/utils';
+
+import { DocToolBox } from '../components/DocToolBox';
+
+let flag = true;
+class TestAnalytic extends AbstractAnalytic {
+  public constructor() {
+    super();
+  }
+
+  public Provider() {
+    return <Fragment />;
+  }
+
+  public trackEvent() {}
+
+  public isFeatureFlagActivated(flagName: string): boolean {
+    if (flagName === 'CopyAsHTML') {
+      return flag;
+    }
+
+    return true;
+  }
+}
+
+jest.mock('@/features/docs/doc-export/', () => ({
+  ModalExport: () => <span>ModalExport</span>,
+}));
+
+const doc = {
+  nb_accesses: 1,
+  abilities: {
+    versions_list: true,
+    destroy: true,
+  },
+};
+
+beforeEach(() => {
+  Analytics.clearAnalytics();
+});
+
+describe('DocToolBox "Copy as HTML" option', () => {
+  test('renders "Copy as HTML" option when feature flag is enabled', async () => {
+    new TestAnalytic();
+
+    render(<DocToolBox doc={doc as any} />, {
+      wrapper: AppWrapper,
+    });
+    const optionsButton = screen.getByLabelText('Open the document options');
+    await userEvent.click(optionsButton);
+    expect(await screen.findByText('Copy as HTML')).toBeInTheDocument();
+  });
+
+  test('does not render "Copy as HTML" option when feature flag is disabled', async () => {
+    flag = false;
+    new TestAnalytic();
+
+    render(<DocToolBox doc={doc as any} />, {
+      wrapper: AppWrapper,
+    });
+    const optionsButton = screen.getByLabelText('Open the document options');
+    await userEvent.click(optionsButton);
+    expect(screen.queryByText('Copy as HTML')).not.toBeInTheDocument();
+  });
+
+  test('render "Copy as HTML" option when we did not add analytics', async () => {
+    render(<DocToolBox doc={doc as any} />, {
+      wrapper: AppWrapper,
+    });
+    const optionsButton = screen.getByLabelText('Open the document options');
+    await userEvent.click(optionsButton);
+    expect(screen.getByText('Copy as HTML')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
@@ -29,6 +29,7 @@ import {
   KEY_LIST_DOC_VERSIONS,
   ModalSelectVersion,
 } from '@/features/docs/doc-versioning';
+import { useAnalytics } from '@/libs';
 import { useResponsiveStore } from '@/stores';
 
 interface DocToolBoxProps {
@@ -54,6 +55,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
   const { editor } = useEditorStore();
   const { toast } = useToastProvider();
   const copyDocLink = useCopyDocLink(doc.id);
+  const { isFeatureFlagActivated } = useAnalytics();
 
   const options: DropdownMenuOption[] = [
     ...(isSmallMobile
@@ -101,6 +103,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
       callback: () => {
         void copyCurrentEditorToClipboard('html');
       },
+      show: isFeatureFlagActivated('CopyAsHTML'),
     },
     {
       label: t('Delete document'),

--- a/src/frontend/apps/impress/src/features/language/index.ts
+++ b/src/frontend/apps/impress/src/features/language/index.ts
@@ -1,1 +1,2 @@
+export * from './hooks/useLanguageSynchronizer';
 export * from './LanguagePicker';

--- a/src/frontend/apps/impress/src/libs/Analytics.tsx
+++ b/src/frontend/apps/impress/src/libs/Analytics.tsx
@@ -1,0 +1,85 @@
+import { JSX, PropsWithChildren, ReactNode } from 'react';
+
+type AnalyticEventClick = {
+  eventName: 'click';
+};
+type AnalyticEventUser = {
+  eventName: 'user';
+  id: string;
+  email: string;
+};
+
+export type AnalyticEvent = AnalyticEventClick | AnalyticEventUser;
+
+export abstract class AbstractAnalytic {
+  public constructor() {
+    Analytics.registerAnalytic(this);
+  }
+
+  public abstract Provider(children?: ReactNode): JSX.Element;
+
+  public abstract trackEvent(evt: AnalyticEvent): void;
+
+  public abstract isFeatureFlagActivated(flagName: string): boolean;
+}
+
+export class Analytics {
+  private static instance: Analytics;
+  private static analytics: AbstractAnalytic[] = [];
+
+  private constructor() {}
+
+  public static getInstance(): Analytics {
+    if (!Analytics.instance) {
+      Analytics.instance = new Analytics();
+    }
+
+    return Analytics.instance;
+  }
+
+  public static clearAnalytics(): void {
+    Analytics.analytics = [];
+  }
+
+  public static registerAnalytic(analytic: AbstractAnalytic): void {
+    Analytics.analytics.push(analytic);
+  }
+
+  public static trackEvent(evt: AnalyticEvent): void {
+    Analytics.analytics.forEach((analytic) => analytic.trackEvent(evt));
+  }
+
+  public static providers(children: ReactNode) {
+    return Analytics.analytics.reduceRight(
+      (acc, analytic) => analytic.Provider(acc),
+      children,
+    );
+  }
+
+  /**
+   * Check if a feature flag is activated
+   *
+   * Feature flags are activated if at least one analytic is activated
+   * because we don't want to hide feature if the user does not
+   * use analytics (AB testing, etc)
+   */
+  public static isFeatureFlagActivated(flagName: string): boolean {
+    if (!Analytics.analytics.length) {
+      return true;
+    }
+
+    return Analytics.analytics.some((analytic) =>
+      analytic.isFeatureFlagActivated(flagName),
+    );
+  }
+}
+
+export const useAnalytics = () => {
+  return {
+    AnalyticsProvider: ({ children }: PropsWithChildren) =>
+      Analytics.providers(children),
+    isFeatureFlagActivated: (flagName: string) =>
+      Analytics.isFeatureFlagActivated(flagName),
+    trackEvent: (evt: AnalyticEvent) => Analytics.trackEvent(evt),
+  };
+};

--- a/src/frontend/apps/impress/src/libs/index.ts
+++ b/src/frontend/apps/impress/src/libs/index.ts
@@ -1,0 +1,1 @@
+export * from './Analytics';

--- a/src/frontend/apps/impress/src/services/PosthogAnalytic.tsx
+++ b/src/frontend/apps/impress/src/services/PosthogAnalytic.tsx
@@ -1,7 +1,36 @@
 import { Router } from 'next/router';
 import posthog from 'posthog-js';
 import { PostHogProvider as PHProvider } from 'posthog-js/react';
-import { PropsWithChildren, useEffect } from 'react';
+import { JSX, PropsWithChildren, ReactNode, useEffect } from 'react';
+
+import { AbstractAnalytic } from '@/libs/';
+
+export class PostHogAnalytic extends AbstractAnalytic {
+  private conf?: PostHogConf = undefined;
+
+  public constructor(conf?: PostHogConf) {
+    super();
+
+    this.conf = conf;
+  }
+
+  public Provider(children?: ReactNode): JSX.Element {
+    return <PostHogProvider conf={this.conf}>{children}</PostHogProvider>;
+  }
+
+  public trackEvent(): void {}
+
+  public isFeatureFlagActivated(flagName: string): boolean {
+    if (
+      posthog.featureFlags.getFlags().includes(flagName) &&
+      posthog.isFeatureEnabled(flagName) === false
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}
 
 export interface PostHogConf {
   id: string;

--- a/src/frontend/apps/impress/src/services/PosthogAnalytic.tsx
+++ b/src/frontend/apps/impress/src/services/PosthogAnalytic.tsx
@@ -3,7 +3,7 @@ import posthog from 'posthog-js';
 import { PostHogProvider as PHProvider } from 'posthog-js/react';
 import { JSX, PropsWithChildren, ReactNode, useEffect } from 'react';
 
-import { AbstractAnalytic } from '@/libs/';
+import { AbstractAnalytic, AnalyticEvent } from '@/libs/';
 
 export class PostHogAnalytic extends AbstractAnalytic {
   private conf?: PostHogConf = undefined;
@@ -18,7 +18,11 @@ export class PostHogAnalytic extends AbstractAnalytic {
     return <PostHogProvider conf={this.conf}>{children}</PostHogProvider>;
   }
 
-  public trackEvent(): void {}
+  public trackEvent(evt: AnalyticEvent): void {
+    if (evt.eventName === 'user') {
+      posthog.identify(evt.id, { email: evt.email });
+    }
+  }
 
   public isFeatureFlagActivated(flagName: string): boolean {
     if (

--- a/src/frontend/apps/impress/src/services/index.ts
+++ b/src/frontend/apps/impress/src/services/index.ts
@@ -1,2 +1,2 @@
 export * from './Crisp';
-export * from './Posthog';
+export * from './PosthogAnalytic';


### PR DESCRIPTION
## Purpose

Add abstract classes for analytics services.
We will be able to add easily any analytic services.
Our first analytic service use case is Posthog.

## Proposal

- [x] 📈(frontend) abstract analytics classes
- [x] 📈(frontend) get user analytics
- [x] 🚩(frontend) add feature flag on "Copy as HTML"

## Demo

https://github.com/suitenumerique/docs/blob/09cd10222b4992789a9a159b9bfb5e3f6d650171/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx#L91-L98

![image](https://github.com/user-attachments/assets/59cc5ff7-dd1f-4ac1-9cfe-eb6a69147dbd)

