### PR TITLE
♻️(back) extract ancestor deleted_at directly from db in restore method

### DIFF
--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -794,9 +794,11 @@ class Document(MP_Node, BaseModel):
         ancestors_deleted_at = (
             self.get_ancestors()
             .filter(deleted_at__isnull=False)
+            .order_by("deleted_at")
             .values_list("deleted_at", flat=True)
+            .first()
         )
-        self.ancestors_deleted_at = min(ancestors_deleted_at, default=None)
+        self.ancestors_deleted_at = ancestors_deleted_at
         self.save()
 
         # Update descendants excluding those who were deleted prior to the deletion of the


### PR DESCRIPTION
## Purpose

In the restore method, all the ancestors with a deleted_at date set are extracted from the database and then the oldest value is extracted using the min python function. This usage of min can be removed by sorting directly the deleted_at at the database level and then fetching the first one. It's faster and easier to maintain.


## Proposal

- [x] extract ancestor deleted_at directly from db in restore method
