### PR TITLE
⚡️Improve AI translations formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to
 - 📝(doc) minor README.md formatting and wording enhancements
 - ♻️Stop setting a default title on doc creation #634
 - ♻️(frontend) misc ui improvements #644
+- ♻️(frontend) Improve AI translations #478
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
 
 - ✨(frontend) synchronize language-choice #401
 - ✨(frontend) add Beautify action to AI transform #478
+- ✨(frontend) add Emojify action to AI transform #478
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,12 @@ and this project adheres to
 ## Added
 
 - ✨(frontend) synchronize language-choice #401
+- ✨(frontend) add Beautify action to AI transform #478
 
 ## Changed
 
 - Use sentry tags instead of extra scope
+- ♻️(frontend) Improve AI translations #478
 
 ## Fixed
 
@@ -56,7 +58,6 @@ and this project adheres to
 - 📝(doc) minor README.md formatting and wording enhancements
 - ♻️Stop setting a default title on doc creation #634
 - ♻️(frontend) misc ui improvements #644
-- ♻️(frontend) Improve AI translations #478
 
 ## Fixed
 

--- a/src/backend/core/services/ai_services.py
+++ b/src/backend/core/services/ai_services.py
@@ -31,6 +31,11 @@ AI_ACTIONS = {
         "Do not provide any other information. "
         "Preserve the language."
     ),
+    "beautify": (
+        "Add formatting to the text to make it more readable. "
+        "Do not provide any other information."
+        "Preserve the language."
+    ),
 }
 
 AI_TRANSLATE = (

--- a/src/backend/core/services/ai_services.py
+++ b/src/backend/core/services/ai_services.py
@@ -33,7 +33,12 @@ AI_ACTIONS = {
     ),
     "beautify": (
         "Add formatting to the text to make it more readable. "
-        "Do not provide any other information."
+        "Do not provide any other information. "
+        "Preserve the language."
+    ),
+    "emojify": (
+        "Add emojis to the important parts of the text. "
+        "Do not provide any other information. "
         "Preserve the language."
     ),
 }

--- a/src/backend/core/tests/documents/test_api_documents_ai_transform.py
+++ b/src/backend/core/tests/documents/test_api_documents_ai_transform.py
@@ -71,9 +71,8 @@ def test_api_documents_ai_transform_anonymous_success(mock_create):
     """
     document = factories.DocumentFactory(link_reach="public", link_role="editor")
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Salut"))]
     )
 
     url = f"/api/v1.0/documents/{document.id!s}/ai-transform/"
@@ -83,17 +82,15 @@ def test_api_documents_ai_transform_anonymous_success(mock_create):
     assert response.json() == {"answer": "Salut"}
     mock_create.assert_called_once_with(
         model="llama",
-        response_format={"type": "json_object"},
         messages=[
             {
                 "role": "system",
                 "content": (
                     "Summarize the markdown text, preserving language and markdown formatting. "
-                    'Return JSON: {"answer": "your markdown summary"}. Do not provide any other '
-                    "information."
+                    "Do not provide any other information. Preserve the language."
                 ),
             },
-            {"role": "user", "content": '{"markdown_input": "Hello"}'},
+            {"role": "user", "content": "Hello"},
         ],
     )
 
@@ -170,9 +167,8 @@ def test_api_documents_ai_transform_authenticated_success(mock_create, reach, ro
 
     document = factories.DocumentFactory(link_reach=reach, link_role=role)
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Salut"))]
     )
 
     url = f"/api/v1.0/documents/{document.id!s}/ai-transform/"
@@ -182,16 +178,15 @@ def test_api_documents_ai_transform_authenticated_success(mock_create, reach, ro
     assert response.json() == {"answer": "Salut"}
     mock_create.assert_called_once_with(
         model="llama",
-        response_format={"type": "json_object"},
         messages=[
             {
                 "role": "system",
                 "content": (
-                    'Answer the prompt in markdown format. Return JSON: {"answer": '
-                    '"Your markdown answer"}. Do not provide any other information.'
+                    "Answer the prompt in markdown format. Preserve the language and markdown "
+                    "formatting. Do not provide any other information. Preserve the language."
                 ),
             },
-            {"role": "user", "content": '{"markdown_input": "Hello"}'},
+            {"role": "user", "content": "Hello"},
         ],
     )
 
@@ -246,9 +241,8 @@ def test_api_documents_ai_transform_success(mock_create, via, role, mock_user_te
             document=document, team="lasuite", role=role
         )
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Salut"))]
     )
 
     url = f"/api/v1.0/documents/{document.id!s}/ai-transform/"
@@ -258,16 +252,15 @@ def test_api_documents_ai_transform_success(mock_create, via, role, mock_user_te
     assert response.json() == {"answer": "Salut"}
     mock_create.assert_called_once_with(
         model="llama",
-        response_format={"type": "json_object"},
         messages=[
             {
                 "role": "system",
                 "content": (
-                    'Answer the prompt in markdown format. Return JSON: {"answer": '
-                    '"Your markdown answer"}. Do not provide any other information.'
+                    "Answer the prompt in markdown format. Preserve the language and markdown "
+                    "formatting. Do not provide any other information. Preserve the language."
                 ),
             },
-            {"role": "user", "content": '{"markdown_input": "Hello"}'},
+            {"role": "user", "content": "Hello"},
         ],
     )
 
@@ -315,9 +308,8 @@ def test_api_documents_ai_transform_throttling_document(mock_create):
     client = APIClient()
     document = factories.DocumentFactory(link_reach="public", link_role="editor")
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Salut"))]
     )
 
     url = f"/api/v1.0/documents/{document.id!s}/ai-transform/"
@@ -350,9 +342,8 @@ def test_api_documents_ai_transform_throttling_user(mock_create):
     client = APIClient()
     client.force_login(user)
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Salut"))]
     )
 
     for _ in range(3):

--- a/src/backend/core/tests/documents/test_api_documents_ai_translate.py
+++ b/src/backend/core/tests/documents/test_api_documents_ai_translate.py
@@ -91,29 +91,28 @@ def test_api_documents_ai_translate_anonymous_success(mock_create):
     """
     document = factories.DocumentFactory(link_reach="public", link_role="editor")
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Ola"))]
     )
 
     url = f"/api/v1.0/documents/{document.id!s}/ai-translate/"
     response = APIClient().post(url, {"text": "Hello", "language": "es"})
 
     assert response.status_code == 200
-    assert response.json() == {"answer": "Salut"}
+    assert response.json() == {"answer": "Ola"}
     mock_create.assert_called_once_with(
         model="llama",
-        response_format={"type": "json_object"},
         messages=[
             {
                 "role": "system",
                 "content": (
-                    "Translate the markdown text to Spanish, preserving markdown formatting. "
-                    'Return JSON: {"answer": "your translated markdown text in Spanish"}. '
+                    "Keep the same html stucture and formatting. "
+                    "Translate the content in the html to the specified language Spanish. "
+                    "Check the translation for accuracy and make any necessary corrections. "
                     "Do not provide any other information."
                 ),
             },
-            {"role": "user", "content": '{"markdown_input": "Hello"}'},
+            {"role": "user", "content": "Hello"},
         ],
     )
 
@@ -190,9 +189,8 @@ def test_api_documents_ai_translate_authenticated_success(mock_create, reach, ro
 
     document = factories.DocumentFactory(link_reach=reach, link_role=role)
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Salut"))]
     )
 
     url = f"/api/v1.0/documents/{document.id!s}/ai-translate/"
@@ -202,18 +200,18 @@ def test_api_documents_ai_translate_authenticated_success(mock_create, reach, ro
     assert response.json() == {"answer": "Salut"}
     mock_create.assert_called_once_with(
         model="llama",
-        response_format={"type": "json_object"},
         messages=[
             {
                 "role": "system",
                 "content": (
-                    "Translate the markdown text to Colombian Spanish, "
-                    "preserving markdown formatting. Return JSON: "
-                    '{"answer": "your translated markdown text in Colombian Spanish"}. '
+                    "Keep the same html stucture and formatting. "
+                    "Translate the content in the html to the "
+                    "specified language Colombian Spanish. "
+                    "Check the translation for accuracy and make any necessary corrections. "
                     "Do not provide any other information."
                 ),
             },
-            {"role": "user", "content": '{"markdown_input": "Hello"}'},
+            {"role": "user", "content": "Hello"},
         ],
     )
 
@@ -268,9 +266,8 @@ def test_api_documents_ai_translate_success(mock_create, via, role, mock_user_te
             document=document, team="lasuite", role=role
         )
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Salut"))]
     )
 
     url = f"/api/v1.0/documents/{document.id!s}/ai-translate/"
@@ -280,18 +277,18 @@ def test_api_documents_ai_translate_success(mock_create, via, role, mock_user_te
     assert response.json() == {"answer": "Salut"}
     mock_create.assert_called_once_with(
         model="llama",
-        response_format={"type": "json_object"},
         messages=[
             {
                 "role": "system",
                 "content": (
-                    "Translate the markdown text to Colombian Spanish, "
-                    "preserving markdown formatting. Return JSON: "
-                    '{"answer": "your translated markdown text in Colombian Spanish"}. '
+                    "Keep the same html stucture and formatting. "
+                    "Translate the content in the html to the "
+                    "specified language Colombian Spanish. "
+                    "Check the translation for accuracy and make any necessary corrections. "
                     "Do not provide any other information."
                 ),
             },
-            {"role": "user", "content": '{"markdown_input": "Hello"}'},
+            {"role": "user", "content": "Hello"},
         ],
     )
 
@@ -339,9 +336,8 @@ def test_api_documents_ai_translate_throttling_document(mock_create):
     client = APIClient()
     document = factories.DocumentFactory(link_reach="public", link_role="editor")
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Salut"))]
     )
 
     url = f"/api/v1.0/documents/{document.id!s}/ai-translate/"
@@ -374,9 +370,8 @@ def test_api_documents_ai_translate_throttling_user(mock_create):
     client = APIClient()
     client.force_login(user)
 
-    answer = '{"answer": "Salut"}'
     mock_create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=answer))]
+        choices=[MagicMock(message=MagicMock(content="Salut"))]
     )
 
     for _ in range(3):

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/api/useDocAITransform.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/api/useDocAITransform.tsx
@@ -6,7 +6,8 @@ export type AITransformActions =
   | 'correct'
   | 'prompt'
   | 'rephrase'
-  | 'summarize';
+  | 'summarize'
+  | 'beautify';
 
 export type DocAITransform = {
   docId: string;

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/api/useDocAITransform.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/api/useDocAITransform.tsx
@@ -7,7 +7,8 @@ export type AITransformActions =
   | 'prompt'
   | 'rephrase'
   | 'summarize'
-  | 'beautify';
+  | 'beautify'
+  | 'emojify';
 
 export type DocAITransform = {
   docId: string;

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/AIButton.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/AIButton.tsx
@@ -176,6 +176,17 @@ export function AIGroupButton() {
             >
               {t('Beautify')}
             </AIMenuItemTransform>
+            <AIMenuItemTransform
+              action="emojify"
+              docId={currentDoc.id}
+              icon={
+                <Text $isMaterialIcon $size="s">
+                  emoji_emotions
+                </Text>
+              }
+            >
+              {t('Emojify')}
+            </AIMenuItemTransform>
           </>
         )}
         {canAITranslate && (

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/AIButton.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/AIButton.tsx
@@ -165,6 +165,17 @@ export function AIGroupButton() {
             >
               {t('Correct')}
             </AIMenuItemTransform>
+            <AIMenuItemTransform
+              action="beautify"
+              docId={currentDoc.id}
+              icon={
+                <Text $isMaterialIcon $size="s">
+                  draw
+                </Text>
+              }
+            >
+              {t('Beautify')}
+            </AIMenuItemTransform>
           </>
         )}
         {canAITranslate && (

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/QuoteBlock.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/QuoteBlock.tsx
@@ -3,7 +3,7 @@ import { BlockTypeSelectItem, createReactBlockSpec } from '@blocknote/react';
 import { TFunction } from 'i18next';
 import React from 'react';
 
-import { Text } from '@/components';
+import { Box, Text } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
 
 import { DocsBlockNoteEditor } from '../../types';
@@ -23,16 +23,17 @@ export const QuoteBlock = createReactBlockSpec(
       const { colorsTokens } = useCunninghamTheme();
 
       return (
-        <Text
+        <Box
+          as="blockquote"
           className="inline-content"
           $margin="0 0 1rem 0"
           $padding="0.5rem 1rem"
-          $variation="600"
           style={{
             borderLeft: `4px solid ${colorsTokens()['greyscale-300']}`,
             fontStyle: 'italic',
             flexGrow: 1,
           }}
+          $color="var(--c--theme--colors--greyscale-500)"
           ref={props.contentRef}
         />
       );


### PR DESCRIPTION
## Purpose

To translate with the AI we are using lossy functions `blocksToMarkdownLossy` / `tryParseMarkdownToBlocks`, it transforms the content editor to markdown. The problem is this transpilation is very lossy, we loose color, background, table size, line break etc...

## Proposal

We will use html instead of markdown to do the translation, html can carry much more information that markdown about the content style.

- [x] ⚡️(AI) improve formating of ai translation
- [x] ✨(AI) add beautify action to ai transform
- [x] ✨(AI) add emojify action to ai transform 

## Demo

### What we have now with markdown :

[scrnli_Ug6vr23om8ZN8E.webm](https://github.com/user-attachments/assets/949c760b-68fa-4f4e-acf3-a8e7f7f3a00b)

### With preserved formatting :

[scrnli_aTe1Ed2p695SF2.webm](https://github.com/user-attachments/assets/2b020e0f-4d5f-472b-a630-d292d03f535d)

### Feature Beautify

[scrnli_v7YQ56N18Q3O5n.webm](https://github.com/user-attachments/assets/81f00dbc-d60d-4d3e-9941-66b33ff45a5d)

