### PR TITLE
🐛(backend) allow more extensions for media download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 
 ## Fixed
 
+- 🐛(backend) allow any type of extensions for media download #671
 - ♻️(frontend) improve table pdf rendering
 
 ## [2.2.0] - 2025-02-10

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -38,7 +38,7 @@ ATTACHMENTS_FOLDER = "attachments"
 UUID_REGEX = (
     r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
 )
-FILE_EXT_REGEX = r"\.[a-zA-Z]{3,4}"
+FILE_EXT_REGEX = r"\.[a-zA-Z0-9]{1,10}"
 MEDIA_STORAGE_URL_PATTERN = re.compile(
     f"{settings.MEDIA_URL:s}(?P<pk>{UUID_REGEX:s})/"
     f"(?P<key>{ATTACHMENTS_FOLDER:s}/{UUID_REGEX:s}{FILE_EXT_REGEX:s})$"

--- a/src/backend/core/tests/documents/test_api_documents_media_auth.py
+++ b/src/backend/core/tests/documents/test_api_documents_media_auth.py
@@ -64,6 +64,30 @@ def test_api_documents_media_auth_anonymous_public():
     assert response.content.decode("utf-8") == "my prose"
 
 
+def test_api_documents_media_auth_extensions():
+    """Files with extensions of any format should work."""
+    document = factories.DocumentFactory(link_reach="public")
+
+    extensions = [
+        "c",
+        "go",
+        "gif",
+        "mp4",
+        "woff2",
+        "appimage",
+    ]
+    for ext in extensions:
+        filename = f"{uuid.uuid4()!s}.{ext:s}"
+        key = f"{document.pk!s}/attachments/{filename:s}"
+
+        original_url = f"http://localhost/media/{key:s}"
+        response = APIClient().get(
+            "/api/v1.0/documents/media-auth/", HTTP_X_ORIGINAL_URL=original_url
+        )
+
+        assert response.status_code == 200
+
+
 @pytest.mark.parametrize("reach", ["authenticated", "restricted"])
 def test_api_documents_media_auth_anonymous_authenticated_or_restricted(reach):
     """


### PR DESCRIPTION
## Purpose

A user reported that mp4 video were not working. 
The request to download the video is getting a 403 whereas images work on the same document :thinking: 

## Proposal

The regex to validate media file extensions was too restrictive. Make it more permissive to allow any type of file extensions.