### PR TITLE
♻️(front) use sentry tags instead of extra scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Changed
+
+- Use sentry tags instead of extra scope
+
 ## [2.3.0] - 2025-03-03
 
 ## Added

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -19,6 +19,7 @@ from django.utils.translation import gettext_lazy as _
 import sentry_sdk
 from configurations import Configuration, values
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import ignore_logger
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -646,8 +647,10 @@ class Base(Configuration):
                 release=get_release(),
                 integrations=[DjangoIntegration()],
             )
-            with sentry_sdk.configure_scope() as scope:
-                scope.set_extra("application", "backend")
+            sentry_sdk.set_tag("application", "backend")
+
+            # Ignore the logs added by the DockerflowMiddleware
+            ignore_logger("request.summary")
 
         if (
             cls.OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION

--- a/src/frontend/apps/impress/src/stores/useSentryStore.tsx
+++ b/src/frontend/apps/impress/src/stores/useSentryStore.tsx
@@ -12,21 +12,21 @@ interface SentryState {
 export const useSentryStore = create<SentryState>((set, get) => ({
   sentry: undefined,
   setSentry: (dsn, environment) => {
-    const sentry = get().sentry;
-    if (sentry) {
+    if (get().sentry) {
       return;
     }
 
-    set({
-      sentry: Sentry.init({
-        dsn,
-        environment,
-        integrations: [Sentry.replayIntegration()],
-        release: packageJson.version,
-        replaysSessionSampleRate: 0.1,
-        replaysOnErrorSampleRate: 1.0,
-        tracesSampleRate: 0.1,
-      }),
+    const sentry = Sentry.init({
+      dsn,
+      environment,
+      integrations: [Sentry.replayIntegration()],
+      release: packageJson.version,
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1.0,
+      tracesSampleRate: 0.1,
     });
+    Sentry.setTag('application', 'frontend');
+
+    set({ sentry });
   },
 }));

--- a/src/frontend/servers/y-provider/src/services/sentry.ts
+++ b/src/frontend/servers/y-provider/src/services/sentry.ts
@@ -9,3 +9,4 @@ Sentry.init({
   tracesSampleRate: 0.1,
   profilesSampleRate: 1.0,
 });
+Sentry.setTag('application', 'y-provider');


### PR DESCRIPTION
## Purpose

To ease filtering issues on sentry, we want to use tags instead of extra scope. Tags are indexed and searchable, it's not the case with extra scope. Moreover using setExtra to add additional data is deprecated.

## Proposal

- [x] use sentry tags instead of extra scope