### PR TITLE
🐛(frontend) remove scroll listener table content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+- 🐛(frontend) remove scroll listener table content  #688
+- 🔒️(back) restrict access to favorite_list endpoint #690
+
+
 ## [2.4.0] - 2025-03-06
 
 ## Added
@@ -21,7 +26,7 @@ and this project adheres to
 ## Fixed
 
 - 🐛(frontend) fix collaboration error #684
-- 🔒️(back) restrict access to favorite_list endpoint #690
+
 
 ## [2.3.0] - 2025-03-03
 

--- a/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
@@ -48,16 +48,27 @@ export const TableContent = () => {
       }
     };
 
-    document.getElementById(MAIN_LAYOUT_ID)?.addEventListener('scroll', () => {
-      setTimeout(() => {
+    let timeout: NodeJS.Timeout;
+    const scrollFn = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+
+      timeout = setTimeout(() => {
         handleScroll();
       }, 300);
-    });
+    };
+
+    document
+      .getElementById(MAIN_LAYOUT_ID)
+      ?.addEventListener('scroll', scrollFn);
 
     handleScroll();
 
     return () => {
-      window.removeEventListener('scroll', handleScroll);
+      document
+        .getElementById(MAIN_LAYOUT_ID)
+        ?.removeEventListener('scroll', scrollFn);
     };
   }, [headings, setHeadingIdHighlight]);
 


### PR DESCRIPTION
## Purpose

During a useEffect cleaning, the selector was not the correct one. The debounce was not being removed correctly neither.

## Proposal

- [x] 🐛(frontend) remove scroll listener table content 

