### PR TITLE
🔒️(back) restrict access to favorite_list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 ## Fixed
 
 - 🐛(frontend) fix collaboration error #684
+- 🔒️(back) restrict access to favorite_list endpoint #690
 
 ## [2.3.0] - 2025-03-03
 

--- a/src/backend/core/api/__init__.py
+++ b/src/backend/core/api/__init__.py
@@ -17,9 +17,10 @@ def exception_handler(exc, context):
     https://gist.github.com/twidi/9d55486c36b6a51bdcb05ce3a763e79f
     """
     if isinstance(exc, ValidationError):
-        detail = exc.message_dict
-
-        if hasattr(exc, "message"):
+        detail = None
+        if hasattr(exc, "message_dict"):
+            detail = exc.message_dict
+        elif hasattr(exc, "message"):
             detail = exc.message
         elif hasattr(exc, "messages"):
             detail = exc.messages

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -591,6 +591,7 @@ class DocumentViewSet(
     @drf.decorators.action(
         detail=False,
         methods=["get"],
+        permission_classes=[permissions.IsAuthenticated],
     )
     def favorite_list(self, request, *args, **kwargs):
         """Get list of favorite documents for the current user."""

--- a/src/backend/core/tests/documents/test_api_document_invitations.py
+++ b/src/backend/core/tests/documents/test_api_document_invitations.py
@@ -424,7 +424,8 @@ def test_api_document_invitations_create_privileged_members(
 
 def test_api_document_invitations_create_email_from_senders_language():
     """
-    When inviting on a document a user who does not exist yet in our database, the invitation email should be sent in the language of the sending user.
+    When inviting on a document a user who does not exist yet in our database,
+    the invitation email should be sent in the language of the sending user.
     """
     user = factories.UserFactory(language="fr-fr")
     document = factories.DocumentFactory()
@@ -559,9 +560,11 @@ def test_api_document_invitations_create_cannot_duplicate_invitation():
     )
 
     assert response.status_code == 400
-    assert response.json() == [
-        "Document invitation with this Email address and Document already exists."
-    ]
+    assert response.json() == {
+        "__all__": [
+            "Document invitation with this Email address and Document already exists."
+        ],
+    }
 
 
 def test_api_document_invitations_create_cannot_invite_existing_users():

--- a/src/backend/core/tests/documents/test_api_documents_favorite_list.py
+++ b/src/backend/core/tests/documents/test_api_documents_favorite_list.py
@@ -1,0 +1,78 @@
+"""Test for the document favorite_list endpoint."""
+
+import pytest
+from rest_framework.test import APIClient
+
+from core import factories, models
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_document_favorite_list_anonymous():
+    """Anonymous users should receive a 401 error."""
+    client = APIClient()
+
+    response = client.get(f"/api/v1.0/documents/favorite_list/")
+
+    assert response.status_code == 401
+
+
+def test_api_document_favorite_list_authenticated_no_favorite():
+    """Authenticated users should receive an empty list."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get(f"/api/v1.0/documents/favorite_list/")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "count": 0,
+        "next": None,
+        "previous": None,
+        "results": [],
+    }
+
+
+def test_api_document_favorite_list_authenticated_with_favorite():
+    """Authenticated users with a favorite should receive the favorite."""
+
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    # User don't have access to this document, let say it had access and this access has been
+    # removed. It should not be in the favorite list anymore.
+    factories.DocumentFactory(favorited_by=[user])
+
+    document = factories.UserDocumentAccessFactory(
+        user=user, role=models.RoleChoices.READER, document__favorited_by=[user]
+    ).document
+
+    response = client.get("/api/v1.0/documents/favorite_list/")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "abilities": document.get_abilities(user),
+                "created_at": document.created_at.isoformat().replace("+00:00", "Z"),
+                "creator": str(document.creator.id),
+                "content": document.content,
+                "depth": document.depth,
+                "excerpt": document.excerpt,
+                "id": str(document.id),
+                "link_reach": document.link_reach,
+                "link_role": document.link_role,
+                "nb_accesses": document.nb_accesses,
+                "numchild": document.numchild,
+                "path": document.path,
+                "title": document.title,
+                "updated_at": document.updated_at.isoformat().replace("+00:00", "Z"),
+                "user_roles": ["reader"],
+            }
+        ],
+    }


### PR DESCRIPTION
## Purpose

favorite_list endpoint is accessible to anonymous user. This lead to an
error 500. This endpoint should be accessible only to authenticated
users.

## Proposal

- [x] 🔒️(back) restrict access to favorite_list endpoint
- [x]  🐛(back) fix ValidationError exception handler