### PR TITLE
⚡️(back) use redis as session backend in developement

### DIFF
--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -700,6 +700,28 @@ class Development(Base):
     SESSION_COOKIE_NAME = "impress_sessionid"
 
     USE_SWAGGER = True
+    SESSION_CACHE_ALIAS = "session"
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        },
+        "session": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": values.Value(
+                "redis://redis:6379/2",
+                environ_name="REDIS_URL",
+                environ_prefix=None,
+            ),
+            "TIMEOUT": values.IntegerValue(
+                30,  # timeout in seconds
+                environ_name="CACHES_DEFAULT_TIMEOUT",
+                environ_prefix=None,
+            ),
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            },
+        },
+    }
 
     def __init__(self):
         # pylint: disable=invalid-name


### PR DESCRIPTION
## Purpose

We want to persist the session during development. Otherwise the session is reset everytime the server is restart. This behavior make developing both a front and back feature a nigthmare, we spend our time login again and again


## Proposal

- [x] ⚡️(back) use redis as session backend in developement
