### PR TITLE
🚸(frontend) ctrl+k modal not when editor is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ and this project adheres to
 
 - 📝(doc) add publiccode.yml
 
+## Changed
+
+- 🚸(frontend) ctrl+k modal not when editor is focused #712
+
 ## Fixed
 
 - 🐛(back) allow only images to be used with the cors-proxy #781
+
 
 ## [2.5.0] - 2025-03-18
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-search.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-search.spec.ts
@@ -63,4 +63,35 @@ test.describe('Document search', () => {
       listSearch.getByRole('option').getByText(doc2Title),
     ).toBeHidden();
   });
+
+  test('it checks cmd+k modal search interaction', async ({
+    page,
+    browserName,
+  }) => {
+    const [doc1Title] = await createDoc(
+      page,
+      'Doc seack ctrl k',
+      browserName,
+      1,
+    );
+    await verifyDocName(page, doc1Title);
+
+    await page.keyboard.press('Control+k');
+    await expect(
+      page.getByLabel('Search modal').getByText('search'),
+    ).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    const editor = page.locator('.ProseMirror');
+    await editor.click();
+    await editor.fill('Hello world');
+    await editor.getByText('Hello world').dblclick();
+
+    await page.keyboard.press('Control+k');
+    await expect(page.getByRole('textbox', { name: 'Edit URL' })).toBeVisible();
+    await expect(
+      page.getByLabel('Search modal').getByText('search'),
+    ).toBeHidden();
+  });
 });

--- a/src/frontend/apps/impress/src/hook/useCmdK.tsx
+++ b/src/frontend/apps/impress/src/hook/useCmdK.tsx
@@ -5,6 +5,13 @@ export const useCmdK = (callback: () => void) => {
     const down = (e: KeyboardEvent) => {
       if ((e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
+
+        const isProseMirrorFocused =
+          document.activeElement?.classList.contains('ProseMirror');
+        if (isProseMirrorFocused) {
+          return;
+        }
+
         callback();
       }
     };


### PR DESCRIPTION
## Purpose

ctrl+k interaction is as well used in the editor. 

## Proposal

If the user has a focus on the editor, we don't open the searchmodal.

- [x] 🚸(frontend) ctrl+k modal not when editor is focused
