### PR TITLE
♻️(back) use same base route path for swagger

### DIFF
--- a/src/backend/core/tests/swagger/test_openapi_schema.py
+++ b/src/backend/core/tests/swagger/test_openapi_schema.py
@@ -33,7 +33,7 @@ def test_openapi_client_schema():
     )
     assert output.getvalue() == ""
 
-    response = Client().get("/v1.0/swagger.json")
+    response = Client().get("/api/v1.0/swagger.json")
 
     assert response.status_code == 200
     with open(

--- a/src/backend/impress/urls.py
+++ b/src/backend/impress/urls.py
@@ -28,7 +28,7 @@ if settings.DEBUG:
 if settings.USE_SWAGGER or settings.DEBUG:
     urlpatterns += [
         path(
-            f"{settings.API_VERSION}/swagger.json",
+            f"api/{settings.API_VERSION}/swagger.json",
             SpectacularJSONAPIView.as_view(
                 api_version=settings.API_VERSION,
                 urlconf="core.urls",
@@ -36,12 +36,12 @@ if settings.USE_SWAGGER or settings.DEBUG:
             name="client-api-schema",
         ),
         path(
-            f"{settings.API_VERSION}//swagger/",
+            f"api/{settings.API_VERSION}/swagger/",
             SpectacularSwaggerView.as_view(url_name="client-api-schema"),
             name="swagger-ui-schema",
         ),
         re_path(
-            f"{settings.API_VERSION}//redoc/",
+            f"api/{settings.API_VERSION}/redoc/",
             SpectacularRedocView.as_view(url_name="client-api-schema"),
             name="redoc-schema",
         ),


### PR DESCRIPTION
## Purpose

Swaggers urls where not using the same base route path /api/v1.0, we prepend it to have the same path everywhere. Moreover, a double slash was used for swagger and redoc dashboard.


## Proposal

- [x] use same base route path for swagger
