### PR TITLE
🐛(backend) compute ancestor_links in get_abilities if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 - 🔒️(back) restrict access to favorite_list endpoint #690
 - 🐛(backend) refactor to fix filtering on children 
     and descendants views #695
+- 🐛(backend) compute ancestor_links in get_abilities if needed #725
 
 
 ## [2.4.0] - 2025-03-06

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -833,14 +833,15 @@ class DocumentViewSet(
         )
 
         # Get the highest readable ancestor
-        highest_readable = ancestors.readable_per_se(request.user).only("depth").first()
+        highest_readable = (
+            ancestors.readable_per_se(request.user).only("depth", "path").first()
+        )
         if highest_readable is None:
             raise (
                 drf.exceptions.PermissionDenied()
                 if request.user.is_authenticated
                 else drf.exceptions.NotAuthenticated()
             )
-
         paths_links_mapping = {}
         ancestors_links = []
         children_clause = db.Q()
@@ -863,6 +864,17 @@ class DocumentViewSet(
 
         queryset = ancestors.filter(depth__gte=highest_readable.depth) | children
         queryset = queryset.order_by("path")
+        # Annotate if the current document is the highest ancestor for the user
+        queryset = queryset.annotate(
+            is_highest_ancestor_for_user=db.Case(
+                db.When(
+                    path=db.Value(highest_readable.path),
+                    then=db.Value(True),
+                ),
+                default=db.Value(False),
+                output_field=db.BooleanField(),
+            )
+        )
         queryset = self.annotate_user_roles(queryset)
         queryset = self.annotate_is_favorite(queryset)
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -730,6 +730,42 @@ class Document(MP_Node, BaseModel):
 
         return dict(links_definitions)  # Convert defaultdict back to a normal dict
 
+    def compute_ancestors_links(self, user):
+        """
+        Compute the ancestors links for the current document up to the highest readable ancestor.
+        """
+        cache_key = f"ancestors_links_{self.id!s}_{user.id!s}"
+        ancestors_links = cache.get(cache_key)
+        if ancestors_links:
+            return ancestors_links
+
+        ancestors = (
+            (self.get_ancestors() | self._meta.model.objects.filter(pk=self.pk))
+            .filter(ancestors_deleted_at__isnull=True)
+            .order_by("path")
+        )
+        highest_readable = ancestors.readable_per_se(user).only("depth", "path").first()
+
+        if highest_readable is None:
+            return []
+
+        ancestors_links = []
+        paths_links_mapping = {}
+        for ancestor in ancestors:
+            if ancestor.depth < highest_readable.depth:
+                continue
+
+            ancestors_links.append(
+                {"link_reach": ancestor.link_reach, "link_role": ancestor.link_role}
+            )
+            paths_links_mapping[ancestor.path] = ancestors_links.copy()
+
+        ancestors_links = paths_links_mapping.get(self.path[: -self.steplen], [])
+
+        cache.set(cache_key, ancestors_links)
+
+        return ancestors_links
+
     def get_abilities(self, user, ancestors_links=None):
         """
         Compute and return abilities for a given user on the document.
@@ -737,7 +773,7 @@ class Document(MP_Node, BaseModel):
         if self.depth <= 1 or getattr(self, "is_highest_ancestor_for_user", False):
             ancestors_links = []
         elif ancestors_links is None:
-            ancestors_links = self.get_ancestors().values("link_reach", "link_role")
+            ancestors_links = self.compute_ancestors_links(user=user)
 
         roles = set(
             self.get_roles(user)

--- a/src/backend/core/tests/documents/test_api_documents_tree.py
+++ b/src/backend/core/tests/documents/test_api_documents_tree.py
@@ -139,10 +139,13 @@ def test_api_documents_tree_list_anonymous_public_parent():
     has a public ancestor but only up to the highest public ancestor.
     """
     great_grand_parent = factories.DocumentFactory(
-        link_reach=random.choice(["authenticated", "restricted"])
+        link_reach="authenticated",
+        link_role="editor",
     )
     grand_parent = factories.DocumentFactory(
-        link_reach="public", parent=great_grand_parent
+        link_reach="public",
+        parent=great_grand_parent,
+        link_role="reader",
     )
     factories.DocumentFactory(link_reach="public", parent=great_grand_parent)
     factories.DocumentFactory(
@@ -151,14 +154,28 @@ def test_api_documents_tree_list_anonymous_public_parent():
     )
 
     parent = factories.DocumentFactory(
-        parent=grand_parent, link_reach=random.choice(["authenticated", "restricted"])
+        link_role="reader",
+        link_reach="authenticated",
+        parent=grand_parent,
     )
-    parent_sibling = factories.DocumentFactory(parent=grand_parent)
+    parent_sibling = factories.DocumentFactory(
+        parent=grand_parent,
+        link_role="reader",
+        link_reach="restricted",
+    )
     document = factories.DocumentFactory(
-        link_reach=random.choice(["authenticated", "restricted"]), parent=parent
+        parent=parent,
+        link_role="editor",
+        link_reach="restricted",
     )
-    document_sibling = factories.DocumentFactory(parent=parent)
-    child = factories.DocumentFactory(link_reach="public", parent=document)
+    document_sibling = factories.DocumentFactory(
+        parent=parent,
+        link_role="reader",
+        link_reach="restricted",
+    )
+    child = factories.DocumentFactory(
+        link_reach="public", link_role="editor", parent=document
+    )
 
     response = APIClient().get(f"/api/v1.0/documents/{document.id!s}/tree/")
 

--- a/src/backend/core/tests/test_models_documents.py
+++ b/src/backend/core/tests/test_models_documents.py
@@ -1297,3 +1297,40 @@ def test_models_documents_restore_complex_bis(django_assert_num_queries):
 def test_models_documents_get_select_options(ancestors_links, select_options):
     """Validate that the "get_select_options" method operates as expected."""
     assert models.LinkReachChoices.get_select_options(ancestors_links) == select_options
+
+def test_models_documents_compute_ancestors_links_no_highest_readable():
+    """Test the compute_ancestors_links method."""
+    document = factories.DocumentFactory(link_reach="public")
+    assert document.compute_ancestors_links(user=AnonymousUser()) == []
+
+def test_models_documents_compute_ancestors_links_highest_readable(django_assert_num_queries):
+    """Test the compute_ancestors_links method."""
+    user = factories.UserFactory()
+    other_user = factories.UserFactory()
+    root = factories.DocumentFactory(link_reach="restricted", link_role="reader", users=[user])
+
+    factories.DocumentFactory(parent=root, link_reach="public", link_role="reader", users=[user])
+    child2 = factories.DocumentFactory(parent=root, link_reach="authenticated", link_role="editor", users=[user, other_user])
+    child3 = factories.DocumentFactory(parent=child2, link_reach="authenticated", link_role="reader", users=[user, other_user])
+
+    with django_assert_num_queries(2):
+        assert child3.compute_ancestors_links(user=user) == [
+            {"link_reach": root.link_reach, "link_role": root.link_role},
+            {"link_reach": child2.link_reach, "link_role": child2.link_role},
+        ]
+
+    with django_assert_num_queries(0):
+        assert child3.compute_ancestors_links(user=user) == [
+            {"link_reach": root.link_reach, "link_role": root.link_role},
+            {"link_reach": child2.link_reach, "link_role": child2.link_role},
+        ]
+
+    with django_assert_num_queries(2):
+        assert child3.compute_ancestors_links(user=other_user) == [
+            {"link_reach": child2.link_reach, "link_role": child2.link_role},
+        ]
+
+    with django_assert_num_queries(0):
+        assert child3.compute_ancestors_links(user=other_user) == [
+            {"link_reach": child2.link_reach, "link_role": child2.link_role},
+        ]


### PR DESCRIPTION
## Purpose

The refactor made in the tree view caching the ancestors_links to not compute them again in the document.get_abilities method lead to a bug. If the get_abilities method is called without ancestors_links, then they are computes on all the ancestors but not from the highest readable ancestor for the current user. We have to compute them with this constraints and to avoid to compute it again and again we save the result in a cache.

## Proposal

- [x] compute ancestor_links in get_abilities if needed
