### PR TITLE
Optimize Dockerfile to use `apk` with `--no-cache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ⚡️(docker) Optimize Dockerfile to use apk with --no-cache #743
+
 ## [3.4.1] - 2025-07-15
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ FROM python:3.13.3-alpine AS base
 RUN python -m pip install --upgrade pip setuptools
 
 # Upgrade system packages to install security updates
-RUN apk update && \
-  apk upgrade
+RUN apk update && apk upgrade --no-cache
 
 # ---- Back-end builder image ----
 FROM base AS back-builder
@@ -45,7 +44,7 @@ FROM base AS link-collector
 ARG IMPRESS_STATIC_ROOT=/data/static
 
 # Install pango & rdfind
-RUN apk add \
+RUN apk add --no-cache \
   pango \
   rdfind
 
@@ -71,7 +70,7 @@ FROM base AS core
 ENV PYTHONUNBUFFERED=1
 
 # Install required system libs
-RUN apk add \
+RUN apk add --no-cache \
   cairo \
   file \
   font-noto \
@@ -117,7 +116,7 @@ FROM core AS backend-development
 USER root:root
 
 # Install psql
-RUN apk add postgresql-client
+RUN apk add --no-cache postgresql-client
 
 # Uninstall impress and re-install it in editable mode along with development
 # dependencies


### PR DESCRIPTION
## Purpose

Using the `apk` commands with the `--no-cache` parameter for package installation and upgrade will prevent the package index from being cached and reduce the built image size.

## Proposal
- Add `--no-cache` with all the `apk upgrade` and `apk add` commands
- Remove additional `apk update` command
