### PR TITLE
🐛(readme) fix preprod link to redirect to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Docs is a collaborative text editor designed to address common challenges in kno
 
 ### Test it
 
-Test Docs on your browser by logging in on this [environment](https://impress-preprod.beta.numerique.gouv.fr/docs/0aa856e9-da41-4d59-b73d-a61cb2c1245f/)
+Test Docs on your browser by logging in on this [environment](https://impress-preprod.beta.numerique.gouv.fr/)
 
 ```
 email: test.docs@yopmail.com


### PR DESCRIPTION
The current link redirects to a 404. New link redirect to homepage.