### PR TITLE
:bug:(backend) fix postgres healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgresql:
     image: postgres:16
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 1s
       timeout: 2s
       retries: 300
@@ -194,7 +194,7 @@ services:
   kc_postgresql:
     image: postgres:14.3
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 1s
       timeout: 2s
       retries: 300


### PR DESCRIPTION
## Purpose

Today, the docker healthcheck does not include the postgreql user or database name.  This causes errors such as the following:

```
kc_postgresql-1  | 2025-03-17 03:16:17.323 UTC [13424] FATAL:  role "root" does not exist
```

## Proposal

Update the `pg_isready` command to specify the username and password such as `pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}`.

See also:
- https://github.com/suitenumerique/docs/issues/731 for an example of this log message being reported.  (however, it may not be the root cause of the issue described.)
- https://github.com/peter-evans/docker-compose-healthcheck/issues/16 for a similar report in another repo, fixed the same way


# Test

After applying this fix, the error message mentioned above no longer appears in `docker compose logs -f`.

```
$ make test
...
1124 passed, 9579 warnings in 18.60s
```