### PR TITLE
📝(README) Added GNU Make link to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- 📝(doc) Added GNU Make link to README #750
 - ✨(frontend) add pinning on doc detail #711
 - 🚩(frontend) feature flag analytic on copy as html #649
 - ✨(frontend) Custom block divider with export #698

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Docker Compose version v2.32.4
 
 **Project bootstrap**
 
-The easiest way to start working on the project is to use GNU Make:
+The easiest way to start working on the project is to use [GNU Make](https://www.gnu.org/software/make/):
 
 ```shellscript
 $ make bootstrap FLUSH_ARGS='--no-input'


### PR DESCRIPTION
Just like docker-compose, create a link to GNU Make's site on its first mention.

## Purpose

More standard documentation.

## Proposal

Add a link for GNU Make's webpage when it's first mentioned

## Changes

- [X] Added link for GNU Make on README
- [X] Added CHANGELOG entry
- [X] Added pull request id to CHANGELOG
