### PR TITLE
🚨(gitlint) Allow uppercase in commit messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 - 🧑‍💻(frontend) change literal section open source #702
 - ♻️(frontend) replace cors proxy for export #695
+- 🚨(gitlint) Allow uppercase in commit messages #756
 
 ## Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ All commit messages must adhere to the following format:
 
 *   <**gitmoji**>: Use a gitmoji to represent the purpose of the commit. For example, ✨ for adding a new feature or 🔥 for removing something, see the list here: <https://gitmoji.dev/>.
 *   **(type)**: Describe the type of change. Common types include `backend`, `frontend`, `CI`, `docker` etc...
-*   **title**: A short, descriptive title for the change, starting with a lowercase character.
+*   **title**: A short, descriptive title for the change.
 *   **description**: Include additional details about what was changed and why.
 
 ### Example Commit Message

--- a/gitlint/gitlint_emoji.py
+++ b/gitlint/gitlint_emoji.py
@@ -31,7 +31,7 @@ class GitmojiTitle(LineRule):
             "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/packages/gitmojis/src/gitmojis.json"
         ).json()["gitmojis"]
         emojis = [item["emoji"] for item in gitmojis]
-        pattern = r"^({:s})\(.*\)\s[a-z].*$".format("|".join(emojis))
+        pattern = r"^({:s})\(.*\)\s[a-zA-Z].*$".format("|".join(emojis))
         if not re.search(pattern, title):
             violation_msg = 'Title does not match regex "<gitmoji>(<scope>) <subject>"'
             return [RuleViolation(self.id, violation_msg, title)]


### PR DESCRIPTION
## Purpose

Many developers use uppercase as the first letter in their commit messages, it creates an error.

## Proposal

We will allow uppercase in commit messages to lower frustration when committing.
