### PR TITLE
🚚(frontend) redirect to 401 page when 401 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to
     and descendants views #695
 - 🐛(action) fix notify-argocd workflow #713
 - 🚨(helm) fix helmfile lint #736
+- 🚚(frontend) redirect to 401 page when 401 error #759
 
 
 ## [2.4.0] - 2025-03-06

--- a/src/frontend/apps/impress/src/core/AppProvider.tsx
+++ b/src/frontend/apps/impress/src/core/AppProvider.tsx
@@ -1,9 +1,10 @@
 import { CunninghamProvider } from '@openfun/cunningham-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 import { useCunninghamTheme } from '@/cunningham';
-import { Auth } from '@/features/auth';
+import { Auth, KEY_AUTH, setAuthUrl } from '@/features/auth';
 import { useResponsiveStore } from '@/stores/';
 
 import { ConfigProvider } from './config/';
@@ -15,17 +16,19 @@ import { ConfigProvider } from './config/';
  *      - global cache duration - we decided 3 minutes
  *      - It can be overridden to each query
  */
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 1000 * 60 * 3,
-      retry: 1,
-    },
+const defaultOptions = {
+  queries: {
+    staleTime: 1000 * 60 * 3,
+    retry: 1,
   },
+};
+const queryClient = new QueryClient({
+  defaultOptions,
 });
 
 export function AppProvider({ children }: { children: React.ReactNode }) {
   const { theme } = useCunninghamTheme();
+  const { replace } = useRouter();
 
   const initializeResizeListener = useResponsiveStore(
     (state) => state.initializeResizeListener,
@@ -35,6 +38,27 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     const cleanupResizeListener = initializeResizeListener();
     return cleanupResizeListener;
   }, [initializeResizeListener]);
+
+  useEffect(() => {
+    queryClient.setDefaultOptions({
+      ...defaultOptions,
+      mutations: {
+        onError: (error) => {
+          if (
+            error instanceof Error &&
+            'status' in error &&
+            error.status === 401
+          ) {
+            void queryClient.resetQueries({
+              queryKey: [KEY_AUTH],
+            });
+            setAuthUrl();
+            void replace(`/401`);
+          }
+        },
+      },
+    });
+  }, [replace]);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/frontend/apps/impress/src/libs/Analytics.tsx
+++ b/src/frontend/apps/impress/src/libs/Analytics.tsx
@@ -16,7 +16,7 @@ export abstract class AbstractAnalytic {
     Analytics.registerAnalytic(this);
   }
 
-  public abstract Provider(children?: ReactNode): JSX.Element;
+  public abstract Provider(children: ReactNode): JSX.Element;
 
   public abstract trackEvent(evt: AnalyticEvent): void;
 
@@ -24,18 +24,7 @@ export abstract class AbstractAnalytic {
 }
 
 export class Analytics {
-  private static instance: Analytics;
   private static analytics: AbstractAnalytic[] = [];
-
-  private constructor() {}
-
-  public static getInstance(): Analytics {
-    if (!Analytics.instance) {
-      Analytics.instance = new Analytics();
-    }
-
-    return Analytics.instance;
-  }
 
   public static clearAnalytics(): void {
     Analytics.analytics = [];
@@ -74,12 +63,19 @@ export class Analytics {
   }
 }
 
+const AnalyticsProvider = ({ children }: PropsWithChildren) => {
+  return Analytics.providers(children);
+};
+
+const isFeatureFlagActivated = (flagName: string) =>
+  Analytics.isFeatureFlagActivated(flagName);
+
+const trackEvent = (evt: AnalyticEvent) => Analytics.trackEvent(evt);
+
 export const useAnalytics = () => {
   return {
-    AnalyticsProvider: ({ children }: PropsWithChildren) =>
-      Analytics.providers(children),
-    isFeatureFlagActivated: (flagName: string) =>
-      Analytics.isFeatureFlagActivated(flagName),
-    trackEvent: (evt: AnalyticEvent) => Analytics.trackEvent(evt),
+    AnalyticsProvider,
+    isFeatureFlagActivated,
+    trackEvent,
   };
 };


### PR DESCRIPTION
## Purpose

 - Users could still be able to edit a document if the session was expired. It could give the feeling that the document was not saved.
 - `useAnalytics` was unmounting children because of function not correctly dispatched.

## Proposal

If during a mutation request (POST, PUT, DELETE), the server returns a 401 error, the user is redirected to the 401 page.

- [x] 🚚(frontend) redirect to 401 page when 401 error
- [x] 🐛(frontend) unmount components Analytics
