### PR TITLE
🐛(ci) fix Tilt resources dependencies

### DIFF
--- a/bin/Tiltfile
+++ b/bin/Tiltfile
@@ -39,6 +39,9 @@ docker_build(
     ]
 )
 
+k8s_resource('impress-docs-backend-migrate', resource_deps=['postgres-postgresql'])
+k8s_resource('impress-docs-backend-createsuperuser', resource_deps=['impress-docs-backend-migrate'])
+k8s_resource('impress-docs-backend', resource_deps=['impress-docs-backend-migrate'])
 k8s_yaml(local('cd ../src/helm && helmfile -n impress -e dev template .'))
 
 migration = '''


### PR DESCRIPTION
The Tilt stack was not starting properly due to dependency issues. We need to wait for PostgreSQL to be running before starting the migration.
