### PR TITLE
📝(doc) add publiccode.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - 🚩(frontend) feature flag analytic on copy as html #649
 - ✨(frontend) Custom block divider with export #698
 - 🌐(i18n) activate dutch language #742
+- 📝(doc) add publiccode.yml
 
 ## Changed
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,27 @@
+publiccodeYmlVersion: "2.4.0"
+name: Docs
+url: https://github.com/suitenumerique/docs
+landingURL: https://github.com/suitenumerique/docs
+creationDate: 2023-12-10
+logo: https://raw.githubusercontent.com/suitenumerique/docs/main/docs/assets/docs-logo.png
+usedBy:
+  - Direction interministériel du numérique (DINUM)
+fundedBy:
+  - name: Direction interministériel du numérique (DINUM)
+    url: https://www.numerique.gouv.fr
+roadmap: "https://github.com/orgs/suitenumerique/projects/2/views/1"
+softwareType: "standalone/other"
+description:
+  en:
+    shortDescription: "The open source document editor where your notes can become knowledge through live collaboration"
+  fr:
+    shortDescription: "L'éditeur de documents open source où vos notes peuvent devenir des connaissances grâce à la collaboration en direct."
+legal:
+  license: MIT
+maintenance:
+  type: internal
+  contacts:
+    - name: "Virgile Deville"
+      email: "virgile.deville@numerique.gouv.fr"
+    - name: "samuel.paccoud"
+      email: "samuel.paccoud@numerique.gouv.fr"


### PR DESCRIPTION
publiccode.yml is a standard for describing Free Software projects, similar to other initiatives such as https://codemeta.github.io.

It is particularly suitable for describing projects funded by public administrations. See https://github.com/publiccodeyml/publiccode.yml