### PR TITLE
add: arm64 arch image for Docker Hub

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -23,6 +23,12 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@v4
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -45,6 +51,7 @@ jobs:
         with:
           context: .
           target: backend-production
+          platforms: linux/amd64,linux/arm64
           build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -56,6 +63,12 @@ jobs:
       -
         name: Checkout repository
         uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       -
         name: Docker meta
         id: meta
@@ -79,6 +92,7 @@ jobs:
         with:
           context: .
           file: ./src/frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           target: frontend-production
           build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
           push: ${{ github.event_name != 'pull_request' }}
@@ -91,6 +105,12 @@ jobs:
       -
         name: Checkout repository
         uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       -
         name: Docker meta
         id: meta
@@ -114,6 +134,7 @@ jobs:
         with:
           context: .
           file: ./src/frontend/servers/y-provider/Dockerfile
+          platforms: linux/amd64,linux/arm64
           target: y-provider
           build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Purpose

To let official docker image be available for ARM based CPUs without building it.

## Proposal

I edited a build script to push images for both amd64 (default) and arm64 (raspberry pis etc.) architecture CPUs. 
I built all of container on my arm64 machine without getting any build errors.