### PR TITLE
🐛(storage) fix compatibility with Scaleway Object Storage

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -943,7 +943,7 @@ class DocumentViewSet(
     @drf.decorators.action(
         detail=True,
         methods=["get", "delete"],
-        url_path="versions/(?P<version_id>[0-9a-f-]{36})",
+        url_path="versions/(?P<version_id>[0-9a-z-]+)",
     )
     # pylint: disable=unused-argument
     def versions_detail(self, request, pk, version_id, *args, **kwargs):

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -582,9 +582,13 @@ class Document(MP_Node, BaseModel):
 
     def get_content_response(self, version_id=""):
         """Get the content in a specific version of the document"""
-        return default_storage.connection.meta.client.get_object(
-            Bucket=default_storage.bucket_name, Key=self.file_key, VersionId=version_id
-        )
+        params = {
+            "Bucket": default_storage.bucket_name,
+            "Key": self.file_key,
+        }
+        if version_id:
+            params["VersionId"] = version_id
+        return default_storage.connection.meta.client.get_object(**params)
 
     def get_versions_slice(self, from_version_id="", min_datetime=None, page_size=None):
         """Get document versions from object storage with pagination and starting conditions"""


### PR DESCRIPTION
I'm starting to test Docs deployment on various cloud providers. I will send follow-up PRs soon for a few more of them.

Some providers with S3-compatible APIs have slightly different implementations. In this case, Scaleway didn't accept version_id="" and has a different version ID scheme. This was tested successfully and should remain compatible with any other provider.