### PR TITLE
👷(changelog) shift changelog maintenance burden to release manager

### DIFF
--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -35,32 +35,6 @@ jobs:
       - name: Lint commit messages added to main
         run: ~/.local/bin/gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
 
-  check-changelog:
-    runs-on: ubuntu-latest
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'noChangeLog') == false &&
-      github.event_name == 'pull_request'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 50
-      - name: Check that the CHANGELOG has been modified in the current branch
-        run: git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.after }} | grep 'CHANGELOG.md'
-
-  lint-changelog:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Check CHANGELOG max line length
-        run: |
-          max_line_length=$(cat CHANGELOG.md | grep -Ev "^\[.*\]: https://github.com" | wc -L)
-          if [ $max_line_length -ge 80 ]; then
-            echo "ERROR: CHANGELOG has lines longer than 80 characters."
-            exit 1
-          fi
-
   lint-back:
     runs-on: ubuntu-latest
     defaults:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,19 +46,6 @@ All commit messages must adhere to the following format:
 Implemented login and signup features, and integrated OAuth2 for social login.
 ```
 
-## Changelog Update
-
-Please add a line to the changelog describing your development. The changelog entry should include a brief summary of the changes, this helps in tracking changes effectively and keeping everyone informed. We usually include the title of the pull request, followed by the pull request ID to finish the log entry. The changelog line should be less than 80 characters in total.
-
-### Example Changelog Message
-```
-## [Unreleased]
-
-## Added
-
-- ✨(frontend) add AI to the project #321
-```
-
 ## Pull Requests
 
 It is nice to add information about the purpose of the pull request to help reviewers understand the context and intent of the changes. If you can, add some pictures or a small video to show the changes.
@@ -67,7 +54,6 @@ It is nice to add information about the purpose of the pull request to help revi
 - check your commits
 - check the linting: `make lint && make frontend-lint`
 - check the tests: `make test`
-- add a changelog entry
 
 Once all the required tests have passed, you can request a review from the project maintainers.
 


### PR DESCRIPTION
Most recent external contributions (including my own!) stumble on the changelog. IMHO, this represents an unnecessary friction for new contributors and a loss of focus for the reviewing team. 

I propose that we put the release manager in charge of maintaining the CHANGELOG.md file at each release, based on the commits being included in that specific release. To view unreleased changes, everyone can just browse the latest commit history.