### PR TITLE
✨ (helm) Service Account support for K8s Resources in Helm Charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to
 ## [Unreleased]
 
 - 📝(doc) add publiccode.yml
+- ✨(helm) Service Account support for K8s Resources in Helm Charts #778
 
 ## [2.5.0] - 2025-03-18
 

--- a/src/helm/impress/README.md
+++ b/src/helm/impress/README.md
@@ -73,6 +73,8 @@
 | `ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-url`                        |                                                      | `https://impress.example.com/api/v1.0/documents/media-auth/`         |
 | `ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-response-headers`           |                                                      | `Authorization, X-Amz-Date, X-Amz-Content-SHA256`                    |
 | `ingressMedia.annotations.nginx.ingress.kubernetes.io/upstream-vhost`                  |                                                      | `minio.impress.svc.cluster.local:9000`                               |
+| `ingressMedia.annotations.nginx.ingress.kubernetes.io/configuration-snippet`           |                                                      | `add_header Content-Security-Policy "default-src 'none'" always;
+`   |
 | `serviceMedia.host`                                                                    |                                                      | `minio.impress.svc.cluster.local`                                    |
 | `serviceMedia.port`                                                                    |                                                      | `9000`                                                               |
 | `serviceMedia.annotations`                                                             |                                                      | `{}`                                                                 |
@@ -132,6 +134,7 @@
 | `backend.extraVolumeMounts`                           | Additional volumes to mount on the backend.                                        | `[]`                                                                                                                          |
 | `backend.extraVolumes`                                | Additional volumes to mount on the backend.                                        | `[]`                                                                                                                          |
 | `backend.pdb.enabled`                                 | Enable pdb on backend                                                              | `true`                                                                                                                        |
+| `backend.serviceAccountName`                          | Optional service account name to use for backend pods                              | `nil`                                                                                                                         |
 
 ### frontend
 
@@ -182,6 +185,7 @@
 | `frontend.extraVolumeMounts`                           | Additional volumes to mount on the frontend.                                        | `[]`                       |
 | `frontend.extraVolumes`                                | Additional volumes to mount on the frontend.                                        | `[]`                       |
 | `frontend.pdb.enabled`                                 | Enable pdb on frontend                                                              | `true`                     |
+| `frontend.serviceAccountName`                          | Optional service account name to use for frontend pods                              | `nil`                      |
 
 ### posthog
 
@@ -264,3 +268,4 @@
 | `yProvider.extraVolumeMounts`                           | Additional volumes to mount on the yProvider.                                        | `[]`                         |
 | `yProvider.extraVolumes`                                | Additional volumes to mount on the yProvider.                                        | `[]`                         |
 | `yProvider.pdb.enabled`                                 | Enable pdb on yProvider                                                              | `true`                       |
+| `yProvider.serviceAccountName`                          | Optional service account name to use for yProvider pods                              | `nil`                        |

--- a/src/helm/impress/templates/backend_deployment.yaml
+++ b/src/helm/impress/templates/backend_deployment.yaml
@@ -30,6 +30,9 @@ spec:
       imagePullSecrets:
         - name: {{ include "impress.secret.dockerconfigjson.name" (dict "fullname" (include "impress.fullname" .) "imageCredentials" $.Values.image.credentials) }}
       {{- end}}
+      {{- if .Values.backend.serviceAccountName }}
+      serviceAccountName: {{ .Values.backend.serviceAccountName }}
+      {{- end }}
       shareProcessNamespace: {{ .Values.backend.shareProcessNamespace }}
       containers:
         {{- with .Values.backend.sidecars }}

--- a/src/helm/impress/templates/backend_job_createsuperuser.yaml
+++ b/src/helm/impress/templates/backend_job_createsuperuser.yaml
@@ -27,6 +27,9 @@ spec:
       imagePullSecrets:
         - name: {{ include "impress.secret.dockerconfigjson.name" (dict "fullname" (include "impress.fullname" .) "imageCredentials" $.Values.image.credentials) }}
       {{- end}}
+      {{- if .Values.backend.serviceAccountName }}
+      serviceAccountName: {{ .Values.backend.serviceAccountName }}
+      {{- end }}
       shareProcessNamespace: {{ .Values.backend.shareProcessNamespace }}
       containers:
         {{- with .Values.backend.sidecars }}

--- a/src/helm/impress/templates/backend_job_migrate.yaml
+++ b/src/helm/impress/templates/backend_job_migrate.yaml
@@ -27,6 +27,9 @@ spec:
       imagePullSecrets:
         - name: {{ include "impress.secret.dockerconfigjson.name" (dict "fullname" (include "impress.fullname" .) "imageCredentials" $.Values.image.credentials) }}
       {{- end}}
+      {{- if .Values.backend.serviceAccountName }}
+      serviceAccountName: {{ .Values.backend.serviceAccountName }}
+      {{- end }}
       shareProcessNamespace: {{ .Values.backend.shareProcessNamespace }}
       containers:
         {{- with .Values.backend.sidecars }}

--- a/src/helm/impress/templates/frontend_deployment.yaml
+++ b/src/helm/impress/templates/frontend_deployment.yaml
@@ -30,6 +30,9 @@ spec:
       imagePullSecrets:
         - name: {{ include "impress.secret.dockerconfigjson.name" (dict "fullname" (include "impress.fullname" .) "imageCredentials" $.Values.image.credentials) }}
       {{- end}}
+      {{- if .Values.frontend.serviceAccountName }}
+      serviceAccountName: {{ .Values.frontend.serviceAccountName }}
+      {{- end }}
       shareProcessNamespace: {{ .Values.frontend.shareProcessNamespace }}
       containers:
         {{- with .Values.frontend.sidecars }}

--- a/src/helm/impress/templates/yprovider_deployment.yaml
+++ b/src/helm/impress/templates/yprovider_deployment.yaml
@@ -30,6 +30,9 @@ spec:
       imagePullSecrets:
         - name: {{ include "impress.secret.dockerconfigjson.name" (dict "fullname" (include "impress.fullname" .) "imageCredentials" $.Values.image.credentials) }}
       {{- end}}
+      {{- if .Values.yProvider.serviceAccountName }}
+      serviceAccountName: {{ .Values.yProvider.serviceAccountName }}
+      {{- end }}
       shareProcessNamespace: {{ .Values.yProvider.shareProcessNamespace }}
       containers:
         {{- with .Values.yProvider.sidecars }}

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -166,6 +166,7 @@ ingressMedia:
   ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-url
   ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/auth-response-headers
   ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/upstream-vhost
+  ## @param ingressMedia.annotations.nginx.ingress.kubernetes.io/configuration-snippet
   annotations:
     nginx.ingress.kubernetes.io/auth-url: https://impress.example.com/api/v1.0/documents/media-auth/
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
@@ -233,8 +234,8 @@ backend:
     targetPort: 8000
     annotations: {}
 
- ## @param backend.migrate.command backend migrate command
- ## @param backend.migrate.restartPolicy backend migrate job restart policy
+  ## @param backend.migrate.command backend migrate command
+  ## @param backend.migrate.restartPolicy backend migrate job restart policy
   migrate:
     command:
       - "python"
@@ -243,8 +244,8 @@ backend:
       - "--no-input"
     restartPolicy: Never
 
- ## @param backend.createsuperuser.command backend migrate command
- ## @param backend.createsuperuser.restartPolicy backend migrate job restart policy
+  ## @param backend.createsuperuser.command backend migrate command
+  ## @param backend.createsuperuser.restartPolicy backend migrate job restart policy
   createsuperuser:
     command:
       - "/bin/sh"
@@ -263,7 +264,7 @@ backend:
     name: ""
     command: []
     restartPolicy: Never
-    annotations: 
+    annotations:
       argocd.argoproj.io/hook: PostSync
 
   ## @param backend.probes.liveness.path [nullable] Configure path for backend HTTP liveness probe
@@ -313,6 +314,9 @@ backend:
   ## @param backend.pdb.enabled Enable pdb on backend
   pdb:
     enabled: true
+
+  ## @param backend.serviceAccountName Optional service account name to use for backend pods
+  serviceAccountName: null
 
 ## @section frontend
 
@@ -411,6 +415,9 @@ frontend:
   ## @param frontend.pdb.enabled Enable pdb on frontend
   pdb:
     enabled: true
+
+  ## @param frontend.serviceAccountName Optional service account name to use for frontend pods
+  serviceAccountName: null
 
 ## @section posthog
 
@@ -584,3 +591,6 @@ yProvider:
   ## @param yProvider.pdb.enabled Enable pdb on yProvider
   pdb:
     enabled: true
+
+  ## @param yProvider.serviceAccountName Optional service account name to use for yProvider pods
+  serviceAccountName: null


### PR DESCRIPTION
## Purpose

Implement #778 

Add support for specifying custom service accounts in all Kubernetes resources in our Helm charts to enable workload identity federation with managed cloud services (PostgreSQL, Redis, etc.). This allows deployments to authenticate to cloud resources without embedding credentials in secrets.

## Proposal
This PR adds an optional serviceAccountName parameter to each component section in the Helm chart values that can be specified during deployment. When provided, the specified service account will be used for the corresponding Kubernetes resources.

✅ Add `serviceAccountName` field to Backend deployment and job templates
✅ Add `serviceAccountName` field to Frontend deployment template
✅ Add `serviceAccountName` field to Y-Provider deployment template
✅ Update `values.yaml` with new parameters and documentation
✅ Ensure backward compatibility with null default values
✅ Regenerate `README.md`
✅ Update `CHANGELOG.md`

Example usage in values.yaml:
```yaml
backend:
  serviceAccountName: backend-sa  # For database access

frontend:
  serviceAccountName: frontend-sa  # For storage access

yProvider:
  serviceAccountName: yprovider-sa  # For collaboration services
```