### PR TITLE
🐛(back) allow only images to be used with the cors-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Added
+
 - 📝(doc) add publiccode.yml
+
+## Fixed
+
+- 🐛(back) allow only images to be used with the cors-proxy #781
 
 ## [2.5.0] - 2025-03-18
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1271,13 +1271,21 @@ class DocumentViewSet(
                 },
                 timeout=10,
             )
+            content_type = response.headers.get("Content-Type", "")
+
+            if not content_type.startswith("image/"):
+                return drf.response.Response(
+                    status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+                )
 
             # Use StreamingHttpResponse with the response's iter_content to properly stream the data
             proxy_response = StreamingHttpResponse(
                 streaming_content=response.iter_content(chunk_size=8192),
-                content_type=response.headers.get(
-                    "Content-Type", "application/octet-stream"
-                ),
+                content_type=content_type,
+                headers={
+                    "Content-Disposition": "attachment;",
+                    "Content-Security-Policy": "default-src 'none'; img-src 'none' data:;",
+                },
                 status=response.status_code,
             )
 


### PR DESCRIPTION
## Purpose

The cors-proxy endpoint allowed to use every type of files and to execute it in the browser. We limit the scope only to images and Content-Security-Policy and Content-Disposition headers are also added to not allow script execution that can be present in a SVG file.


## Proposal

- [x] 🐛(back) allow only images to be used with the cors-proxy
