### PR TITLE
Fix typo in landing content

### DIFF
--- a/src/frontend/apps/impress/src/features/home/components/HomeContent.tsx
+++ b/src/frontend/apps/impress/src/features/home/components/HomeContent.tsx
@@ -104,7 +104,7 @@ export function HomeContent() {
                     </Text>
                     <Text as="p" $display="inline">
                       <Trans t={t} i18nKey="home-content-open-source-part2">
-                        You can easily self-hosted Docs (check our installation{' '}
+                        You can easily self-host Docs (check our installation{' '}
                         <a
                           href="https://github.com/suitenumerique/docs/tree/main/docs"
                           target="_blank"


### PR DESCRIPTION
## Purpose

Fixing a typo on the landing page

## Proposal

It shouldn't be past tense.