### PR TITLE
🔒️(back) restrict accesss to document accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 ## Fixed
 
 - 🐛(backend) compute ancestor_links in get_abilities if needed #725
+- 🔒️(back) restrict access to document accesses #801
 
 ## [2.6.0] - 2025-03-21
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -27,6 +27,26 @@ class UserSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "email", "full_name", "short_name"]
 
 
+class UserLightSerializer(UserSerializer):
+    """Serialize users with limited fields."""
+
+    id = serializers.SerializerMethodField(read_only=True)
+    email = serializers.SerializerMethodField(read_only=True)
+
+    def get_id(self, _user):
+        """Return always None. Here to have the same fields than in UserSerializer."""
+        return None
+
+    def get_email(self, _user):
+        """Return always None. Here to have the same fields than in UserSerializer."""
+        return None
+
+    class Meta:
+        model = models.User
+        fields = ["id", "email", "full_name", "short_name"]
+        read_only_fields = ["id", "email", "full_name", "short_name"]
+
+
 class BaseAccessSerializer(serializers.ModelSerializer):
     """Serialize template accesses."""
 
@@ -116,6 +136,17 @@ class DocumentAccessSerializer(BaseAccessSerializer):
         resource_field_name = "document"
         fields = ["id", "user", "user_id", "team", "role", "abilities"]
         read_only_fields = ["id", "abilities"]
+
+
+class DocumentAccessLightSerializer(DocumentAccessSerializer):
+    """Serialize document accesses with limited fields."""
+
+    user = UserLightSerializer(read_only=True)
+
+    class Meta:
+        model = models.DocumentAccess
+        fields = ["id", "user", "team", "role", "abilities"]
+        read_only_fields = ["id", "team", "role", "abilities"]
 
 
 class TemplateAccessSerializer(BaseAccessSerializer):

--- a/src/backend/core/tests/test_models_document_accesses.py
+++ b/src/backend/core/tests/test_models_document_accesses.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 
 import pytest
 
-from core import factories
+from core import factories, models
 
 pytestmark = pytest.mark.django_db
 
@@ -294,7 +294,7 @@ def test_models_document_access_get_abilities_for_editor_of_owner():
     abilities = access.get_abilities(user)
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
+        "retrieve": False,
         "update": False,
         "partial_update": False,
         "set_role_to": [],
@@ -311,7 +311,7 @@ def test_models_document_access_get_abilities_for_editor_of_administrator():
     abilities = access.get_abilities(user)
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
+        "retrieve": False,
         "update": False,
         "partial_update": False,
         "set_role_to": [],
@@ -333,7 +333,7 @@ def test_models_document_access_get_abilities_for_editor_of_editor_user(
 
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
+        "retrieve": False,
         "update": False,
         "partial_update": False,
         "set_role_to": [],
@@ -353,7 +353,7 @@ def test_models_document_access_get_abilities_for_reader_of_owner():
     abilities = access.get_abilities(user)
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
+        "retrieve": False,
         "update": False,
         "partial_update": False,
         "set_role_to": [],
@@ -370,7 +370,7 @@ def test_models_document_access_get_abilities_for_reader_of_administrator():
     abilities = access.get_abilities(user)
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
+        "retrieve": False,
         "update": False,
         "partial_update": False,
         "set_role_to": [],
@@ -392,7 +392,7 @@ def test_models_document_access_get_abilities_for_reader_of_reader_user(
 
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
+        "retrieve": False,
         "update": False,
         "partial_update": False,
         "set_role_to": [],
@@ -412,8 +412,16 @@ def test_models_document_access_get_abilities_preset_role(django_assert_num_quer
 
     assert abilities == {
         "destroy": False,
-        "retrieve": True,
+        "retrieve": False,
         "update": False,
         "partial_update": False,
         "set_role_to": [],
     }
+
+
+@pytest.mark.parametrize("role", models.RoleChoices)
+def test_models_document_access_get_abilities_retrieve_own_access(role):
+    """Check abilities of self access for the owner of a document."""
+    access = factories.UserDocumentAccessFactory(role=role)
+    abilities = access.get_abilities(access.user)
+    assert abilities["retrieve"] is True


### PR DESCRIPTION
## Purpose

Every user having an access to a document, no matter its role have access to the entire accesses list with all the user details. Only owner or admin should be able to have the entire list, for the other roles, they have access to the list containing only owner and administrator with less information on the username. The email and its id is removed

## Proposal

- [x] 🔒️(back) restrict accesss to document accesses