### PR TITLE
:memo:(docs) README: fix grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ username: impress
 password: impress
 ```
 
-📝 Note that if you need to run them afterwards, you can use the eponym Make rule:
+📝 Note that if you need to run them afterwards, you can use the eponymous Make rule:
 
 ```shellscript
 $ make run


### PR DESCRIPTION
"eponym" is a noun; "eponymous" is an adjective.
