### PR TITLE
🔖(minor) release 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.7.0] - 2025-03-28
+
 ## Added
 
 - 📄(legal) Require contributors to sign a DCO #779
@@ -15,12 +17,13 @@ and this project adheres to
 ## Changed
 
 - ♻️(frontend) Integrate UI kit #783
-- 🏗️(y-provider) manage auth in y-provider app
+- 🏗️(y-provider) manage auth in y-provider app #804
 
 ## Fixed
 
 - 🐛(backend) compute ancestor_links in get_abilities if needed #725
 - 🔒️(back) restrict access to document accesses #801
+
 
 ## [2.6.0] - 2025-03-21
 
@@ -503,8 +506,9 @@ and this project adheres to
 - ✨(frontend) Coming Soon page (#67)
 - 🚀 Impress, project to manage your documents easily and collaboratively.
 
-[unreleased]: https://github.com/numerique-gouv/impress/compare/v2.6.0...main
-[v2.5.0]: https://github.com/numerique-gouv/impress/releases/v2.6.0
+[unreleased]: https://github.com/numerique-gouv/impress/compare/v2.7.0...main
+[v2.7.0]: https://github.com/numerique-gouv/impress/releases/v2.7.0
+[v2.6.0]: https://github.com/numerique-gouv/impress/releases/v2.6.0
 [v2.5.0]: https://github.com/numerique-gouv/impress/releases/v2.5.0
 [v2.4.0]: https://github.com/numerique-gouv/impress/releases/v2.4.0
 [v2.3.0]: https://github.com/numerique-gouv/impress/releases/v2.3.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impress"
-version = "2.6.0"
+version = "2.7.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts",

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-impress",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
@@ -161,6 +161,7 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
         </Text>
         <Select
           clearable={false}
+          fullWidth
           label={t('Template')}
           options={templateOptions}
           value={templateSelected}

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "workspaces": {
     "packages": [

--- a/src/frontend/packages/eslint-config-impress/package.json
+++ b/src/frontend/packages/eslint-config-impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-impress",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint --ext .js ."

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "scripts": {
     "extract-translation": "yarn extract-translation:impress",

--- a/src/frontend/servers/y-provider/package.json
+++ b/src/frontend/servers/y-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-y-provider",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Y.js provider for docs",
   "repository": "https://github.com/numerique-gouv/impress",
   "license": "MIT",

--- a/src/helm/helmfile.yaml
+++ b/src/helm/helmfile.yaml
@@ -1,7 +1,7 @@
 environments:
   dev:
     values:
-      - version: 2.6.0
+      - version: 2.7.0
 ---
 repositories:
 - name: bitnami

--- a/src/helm/impress/Chart.yaml
+++ b/src/helm/impress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: docs
-version: 2.6.0
+version: 2.7.0
 appVersion: latest

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Added

- 📄(legal) Require contributors to sign a DCO #779

## Changed

- ♻️(frontend) Integrate UI kit #783
- 🏗️(y-provider) manage auth in y-provider app #804

## Fixed

- 🐛(backend) compute ancestor_links in get_abilities if needed #725
- 🔒️(back) restrict access to document accesses #801
