### PR TITLE
🔖(major) release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.0.0] - 2025-03-28
+
 ## Added
 
 - 📄(legal) Require contributors to sign a DCO #779
@@ -15,12 +17,13 @@ and this project adheres to
 ## Changed
 
 - ♻️(frontend) Integrate UI kit #783
-- 🏗️(y-provider) manage auth in y-provider app
+- 🏗️(y-provider) manage auth in y-provider app #804
 
 ## Fixed
 
 - 🐛(backend) compute ancestor_links in get_abilities if needed #725
 - 🔒️(back) restrict access to document accesses #801
+
 
 ## [2.6.0] - 2025-03-21
 
@@ -503,8 +506,9 @@ and this project adheres to
 - ✨(frontend) Coming Soon page (#67)
 - 🚀 Impress, project to manage your documents easily and collaboratively.
 
-[unreleased]: https://github.com/numerique-gouv/impress/compare/v2.6.0...main
-[v2.5.0]: https://github.com/numerique-gouv/impress/releases/v2.6.0
+[unreleased]: https://github.com/numerique-gouv/impress/compare/v3.0.0...main
+[v3.0.0]: https://github.com/numerique-gouv/impress/releases/v3.0.0
+[v2.6.0]: https://github.com/numerique-gouv/impress/releases/v2.6.0
 [v2.5.0]: https://github.com/numerique-gouv/impress/releases/v2.5.0
 [v2.4.0]: https://github.com/numerique-gouv/impress/releases/v2.4.0
 [v2.3.0]: https://github.com/numerique-gouv/impress/releases/v2.3.0

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,18 @@ the following command inside your docker container:
 
 ## [Unreleased]
 
+## [3.0.0] - 2025-03-28
+
+We are not using the nginx auth request anymore to access the collaboration server (`yProvider`)
+The authentication is now managed directly from the yProvider server. 
+You must remove the annotation `nginx.ingress.kubernetes.io/auth-url` from the `ingressCollaborationWS`.
+
+This means as well that the yProvider server must be able to access the Django server.
+To do so, you must set the `COLLABORATION_BACKEND_BASE_URL` environment variable to the `yProvider`
+service.
+
+## [2.2.0] - 2025-02-10
+
 - AI features are now limited to users who are authenticated. Before this release, even anonymous
   users who gained editor access on a document with link reach used to get AI feature.
   IF you want anonymous users to keep access on AI features, you must now define the

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impress"
-version = "2.6.0"
+version = "3.0.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts",

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-impress",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
@@ -161,6 +161,7 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
         </Text>
         <Select
           clearable={false}
+          fullWidth
           label={t('Template')}
           options={templateOptions}
           value={templateSelected}

--- a/src/frontend/apps/impress/src/features/service-worker/__tests__/useSWRegister.test.tsx
+++ b/src/frontend/apps/impress/src/features/service-worker/__tests__/useSWRegister.test.tsx
@@ -21,9 +21,11 @@ describe('useSWRegister', () => {
           reject('error');
         }),
     );
+
     Object.defineProperty(navigator, 'serviceWorker', {
       value: {
         register: registerSpy,
+        addEventListener: jest.fn(),
       },
       writable: true,
     });
@@ -31,6 +33,10 @@ describe('useSWRegister', () => {
     render(<TestComponent />);
 
     expect(registerSpy).toHaveBeenCalledWith('/service-worker.js?v=123456');
+    expect(navigator.serviceWorker.addEventListener).toHaveBeenCalledWith(
+      'controllerchange',
+      expect.any(Function),
+    );
   });
 
   it('checks service-worker is not register', () => {

--- a/src/frontend/apps/impress/src/features/service-worker/hooks/useSWRegister.tsx
+++ b/src/frontend/apps/impress/src/features/service-worker/hooks/useSWRegister.tsx
@@ -8,9 +8,33 @@ export const useSWRegister = () => {
     ) {
       navigator.serviceWorker
         .register(`/service-worker.js?v=${process.env.NEXT_PUBLIC_BUILD_ID}`)
+        .then((registration) => {
+          registration.onupdatefound = () => {
+            const newWorker = registration.installing;
+            if (!newWorker) {
+              return;
+            }
+
+            newWorker.onstatechange = () => {
+              if (
+                newWorker.state === 'installed' &&
+                navigator.serviceWorker.controller
+              ) {
+                newWorker.postMessage({ type: 'SKIP_WAITING' });
+              }
+            };
+          };
+        })
         .catch((err) => {
           console.error('Service worker registration failed:', err);
         });
+
+      const currentController = navigator.serviceWorker.controller;
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (currentController) {
+          window.location.reload();
+        }
+      });
     }
   }, []);
 };

--- a/src/frontend/apps/impress/src/features/service-worker/service-worker.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/service-worker.ts
@@ -65,6 +65,13 @@ self.addEventListener('install', function (event) {
   event.waitUntil(self.skipWaiting());
 });
 
+self.addEventListener('message', (event) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  if (event.data?.type === 'SKIP_WAITING') {
+    void self.skipWaiting();
+  }
+});
+
 self.addEventListener('activate', function (event) {
   const cacheAllow = SW_VERSION;
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "private": true,
   "workspaces": {
     "packages": [

--- a/src/frontend/packages/eslint-config-impress/package.json
+++ b/src/frontend/packages/eslint-config-impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-impress",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint --ext .js ."

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "extract-translation": "yarn extract-translation:impress",

--- a/src/frontend/servers/y-provider/package.json
+++ b/src/frontend/servers/y-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-y-provider",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "Y.js provider for docs",
   "repository": "https://github.com/numerique-gouv/impress",
   "license": "MIT",

--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -124,6 +124,7 @@ yProvider:
     tag: "latest"
 
   envVars:
+    COLLABORATION_BACKEND_BASE_URL: https://impress.127.0.0.1.nip.io
     COLLABORATION_LOGGING: true
     COLLABORATION_SERVER_ORIGIN: https://impress.127.0.0.1.nip.io
     COLLABORATION_SERVER_SECRET: my-secret
@@ -136,9 +137,6 @@ ingress:
 ingressCollaborationWS:
   enabled: true
   host: impress.127.0.0.1.nip.io
-  
-  annotations:
-    nginx.ingress.kubernetes.io/auth-url: https://impress.127.0.0.1.nip.io/api/v1.0/documents/collaboration-auth/
 
 ingressCollaborationApi:
   enabled: true

--- a/src/helm/helmfile.yaml
+++ b/src/helm/helmfile.yaml
@@ -1,7 +1,7 @@
 environments:
   dev:
     values:
-      - version: 2.6.0
+      - version: 3.0.0
 ---
 repositories:
 - name: bitnami

--- a/src/helm/impress/Chart.yaml
+++ b/src/helm/impress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: docs
-version: 2.6.0
+version: 3.0.0
 appVersion: latest

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Added

- 📄(legal) Require contributors to sign a DCO #779

## Changed

- ♻️(frontend) Integrate UI kit #783
- 🏗️(y-provider) manage auth in y-provider app #804

## Fixed

- 🐛(backend) compute ancestor_links in get_abilities if needed #725
- 🔒️(back) restrict access to document accesses #801
