### PR TITLE
🐛(back) validate document content in serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- 🐛(back) validate document content in serializer #822
+
 ## [3.0.0] - 2025-03-28
 
 ## Added

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -1,6 +1,8 @@
 """Client serializers for the impress core app."""
 
+import binascii
 import mimetypes
+from base64 import b64decode
 
 from django.conf import settings
 from django.db.models import Q
@@ -296,6 +298,18 @@ class DocumentSerializer(ListDocumentSerializer):
                 raise serializers.ValidationError(
                     "A document with this ID already exists. You cannot override it."
                 )
+
+        return value
+
+    def validate_content(self, value):
+        """Validate the content field."""
+        if not value:
+            return None
+
+        try:
+            b64decode(value, validate=True)
+        except binascii.Error as err:
+            raise serializers.ValidationError("Invalid base64 content.") from err
 
         return value
 


### PR DESCRIPTION
## Purpose

We recently extract images url in the content. For this, we assume that the document content is always in base64. We enforce this assumptim by checking if it's a valide base64 in the serializer.


## Proposal

- [x] 🐛(back) validate document content in serializer
