### PR TITLE
🧑‍💻 (frontend): add placeholder translation to mitigate merge conflicts

### DIFF
--- a/src/frontend/apps/impress/src/i18n/translations.json
+++ b/src/frontend/apps/impress/src/i18n/translations.json
@@ -210,14 +210,16 @@
       "You do not have permission to view users sharing this document or modify link settings.": "Ihnen fehlt die Berechtigung, die das Dokument teilenden Benutzer einzusehen oder die Linkeinstellungen zu ändern.",
       "Your current document will revert to this version.": "Ihr aktuelles Dokument wird auf diese Version zurückgesetzt.",
       "Your {{format}} was downloaded succesfully": "Ihr {{format}} wurde erfolgreich heruntergeladen",
-      "you have reported to the website manager a lack of accessibility that prevents you from accessing content or one of the services of the portal and you have not received a satisfactory response.": "sie haben dem Website-Manager einen Mangel an Barrierefreiheit gemeldet, der Ihnen den Zugriff auf Inhalte oder einen der Dienste des Portals verwehrt, und Sie haben keine zufriedenstellende Antwort erhalten."
+      "you have reported to the website manager a lack of accessibility that prevents you from accessing content or one of the services of the portal and you have not received a satisfactory response.": "sie haben dem Website-Manager einen Mangel an Barrierefreiheit gemeldet, der Ihnen den Zugriff auf Inhalte oder einen der Dienste des Portals verwehrt, und Sie haben keine zufriedenstellende Antwort erhalten.",
+      "PLACEHOLDER_STRING_TO_AVOID_MERGE_CONFLICT_ADD_STRING_ABOVE_THIS_TO_AVOID_MERGE_CONFLICT": "☝️☝️ Ein Platzhalter-String zur Vermeidung von Merge-Konflikten. Fügen Sie neue Strings oberhalb dieser Zeile ein, um Merge-Konflikte zu vermeiden. ☝️☝️"
     }
   },
   "en": {
     "translation": {
       "Shared with {{count}} users_many": "Shared with {{count}} users",
       "Shared with {{count}} users_one": "Shared with {{count}} user",
-      "Shared with {{count}} users_other": "Shared with {{count}} users"
+      "Shared with {{count}} users_other": "Shared with {{count}} users",
+      "PLACEHOLDER_STRING_TO_AVOID_MERGE_CONFLICT_ADD_STRING_ABOVE_THIS_TO_AVOID_MERGE_CONFLICT": "☝️☝️ A placeholder string to prevent merge conflicts. Insert new strings above this line to prevent merge conflicts. ☝️☝️"
     }
   },
   "fr": {
@@ -438,7 +440,8 @@
       "home-content-open-source-part1": "Docs est construit sur <2>Django Rest Framework</2> et <6>Next.js</6>. Nous utilisons également <9>Yjs</9> et <13>BlockNote.js</13>, deux projets que nous sommes fiers de sponsoriser.",
       "home-content-open-source-part2": "Vous pouvez facilement auto-héberger Docs (consultez notre <2>documentation</2> d'installation).<br/>Docs utilise une <7>licence</7> (MIT) adaptée à l'innovation et aux entreprises.<br/>Les contributions sont les bienvenues (consultez notre feuille de route <13>ici</13>).",
       "home-content-open-source-part3": "Docs est le résultat d'un effort conjoint mené par les gouvernements français 🇫🇷🥖 <1>(DINUM)</1> et allemand 🇩🇪🥨 <5>(ZenDiS)</5>.",
-      "you have reported to the website manager a lack of accessibility that prevents you from accessing content or one of the services of the portal and you have not received a satisfactory response.": "vous avez signalé au responsable du site internet un défaut d'accessibilité qui vous empêche d'accéder à un contenu ou à un des services du portail et vous n'avez pas obtenu de réponse satisfaisante."
+      "you have reported to the website manager a lack of accessibility that prevents you from accessing content or one of the services of the portal and you have not received a satisfactory response.": "vous avez signalé au responsable du site internet un défaut d'accessibilité qui vous empêche d'accéder à un contenu ou à un des services du portail et vous n'avez pas obtenu de réponse satisfaisante.",
+      "PLACEHOLDER_STRING_TO_AVOID_MERGE_CONFLICT_ADD_STRING_ABOVE_THIS_TO_AVOID_MERGE_CONFLICT": "☝️☝️ Une chaîne de remplacement pour éviter les conflits de fusion. Insérez de nouvelles chaînes au-dessus de cette ligne pour éviter les conflits de fusion. ☝️☝️"
     }
   },
   "nl": {
@@ -664,7 +667,8 @@
       "home-content-open-source-part1": "home-content-open-source-part1",
       "home-content-open-source-part2": "home-content-open-source-part2",
       "home-content-open-source-part3": "home-content-open-source-part3",
-      "you have reported to the website manager a lack of accessibility that prevents you from accessing content or one of the services of the portal and you have not received a satisfactory response.": "u heeft aan de websitebeheerder gerapporteerd dat u geen toegang heeft tot de inhoud of een van de diensten van het portaal, en u hebt geen bevredigend antwoord ontvangen."
+      "you have reported to the website manager a lack of accessibility that prevents you from accessing content or one of the services of the portal and you have not received a satisfactory response.": "u heeft aan de websitebeheerder gerapporteerd dat u geen toegang heeft tot de inhoud of een van de diensten van het portaal, en u hebt geen bevredigend antwoord ontvangen.",
+      "PLACEHOLDER_STRING_TO_AVOID_MERGE_CONFLICT_ADD_STRING_ABOVE_THIS_TO_AVOID_MERGE_CONFLICT": "☝️☝️ Een tijdelijke string om merge-conflicten te voorkomen. Voeg nieuwe strings boven deze regel in om merge-conflicten te voorkomen. ☝️☝️"
     }
   },
   "tr": { "translation": {} }


### PR DESCRIPTION
Added a placeholder translation entry at the end of each language file to reduce merge conflicts when multiple contributors are working on translations. This change also helps minimize unnecessary diff sizes.
Address: #831

## Purpose

Introduce a placeholder translation entry to prevent merge conflicts in translation files and reduce unnecessary diff size during collaborative work.

