### PR TITLE
🔧(backend) configurable footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- 🚩(backend) add feature flag for the footer #841
 - 🔧(backend) add view to manage footer json #841
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Added
+
+- 🔧(backend) add view to manage footer json #841
+
 ## Changed
 
 - 🚨(frontend) block button when creating doc #749

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -64,3 +64,4 @@ COLLABORATION_WS_URL=ws://localhost:4444/collaboration/ws/
 
 # Frontend
 FRONTEND_THEME=default
+FRONTEND_URL_JSON_FOOTER=http://frontend:3000/contents/footer-demo.json

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -64,4 +64,5 @@ COLLABORATION_WS_URL=ws://localhost:4444/collaboration/ws/
 
 # Frontend
 FRONTEND_THEME=default
+FRONTEND_FOOTER_FEATURE_ENABLED=True
 FRONTEND_URL_JSON_FOOTER=http://frontend:3000/contents/footer-demo.json

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1692,6 +1692,7 @@ class ConfigView(drf.views.APIView):
             "CRISP_WEBSITE_ID",
             "ENVIRONMENT",
             "FRONTEND_CSS_URL",
+            "FRONTEND_FOOTER_FEATURE_ENABLED",
             "FRONTEND_THEME",
             "MEDIA_BASE_URL",
             "POSTHOG_KEY",

--- a/src/backend/core/services/config_services.py
+++ b/src/backend/core/services/config_services.py
@@ -1,0 +1,25 @@
+"""Config services."""
+
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def get_footer_json(footer_json_url: str) -> dict:
+    """
+    Fetches the footer JSON from the given URL."
+    """
+    try:
+        response = requests.get(
+            footer_json_url, timeout=5, headers={"User-Agent": "Docs-Application"}
+        )
+        response.raise_for_status()
+
+        footer_json = response.json()
+
+        return footer_json
+    except (requests.RequestException, ValueError) as e:
+        logger.error("Failed to fetch footer JSON: %s", e)
+        return {}

--- a/src/backend/core/tests/conftest.py
+++ b/src/backend/core/tests/conftest.py
@@ -2,11 +2,19 @@
 
 from unittest import mock
 
+from django.core.cache import cache
+
 import pytest
 
 USER = "user"
 TEAM = "team"
 VIA = [USER, TEAM]
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Fixture to clear the cache before each test."""
+    cache.clear()
 
 
 @pytest.fixture

--- a/src/backend/core/tests/documents/test_api_documents_ai_transform.py
+++ b/src/backend/core/tests/documents/test_api_documents_ai_transform.py
@@ -5,7 +5,6 @@ Test AI transform API endpoint for users in impress's core app.
 import random
 from unittest.mock import MagicMock, patch
 
-from django.core.cache import cache
 from django.test import override_settings
 
 import pytest
@@ -15,12 +14,6 @@ from core import factories
 from core.tests.conftest import TEAM, USER, VIA
 
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture(autouse=True)
-def clear_cache():
-    """Fixture to clear the cache before each test."""
-    cache.clear()
 
 
 @pytest.fixture

--- a/src/backend/core/tests/documents/test_api_documents_ai_translate.py
+++ b/src/backend/core/tests/documents/test_api_documents_ai_translate.py
@@ -5,7 +5,6 @@ Test AI translate API endpoint for users in impress's core app.
 import random
 from unittest.mock import MagicMock, patch
 
-from django.core.cache import cache
 from django.test import override_settings
 
 import pytest
@@ -15,12 +14,6 @@ from core import factories
 from core.tests.conftest import TEAM, USER, VIA
 
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture(autouse=True)
-def clear_cache():
-    """Fixture to clear the cache before each test."""
-    cache.clear()
 
 
 @pytest.fixture

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -18,8 +18,9 @@ pytestmark = pytest.mark.django_db
 @override_settings(
     COLLABORATION_WS_URL="http://testcollab/",
     CRISP_WEBSITE_ID="123",
-    FRONTEND_THEME="test-theme",
     FRONTEND_CSS_URL="http://testcss/",
+    FRONTEND_FOOTER_FEATURE_ENABLED=True,
+    FRONTEND_THEME="test-theme",
     MEDIA_BASE_URL="http://testserver/",
     POSTHOG_KEY={"id": "132456", "host": "https://eu.i.posthog-test.com"},
     SENTRY_DSN="https://sentry.test/123",
@@ -39,8 +40,9 @@ def test_api_config(is_authenticated):
         "COLLABORATION_WS_URL": "http://testcollab/",
         "CRISP_WEBSITE_ID": "123",
         "ENVIRONMENT": "test",
-        "FRONTEND_THEME": "test-theme",
         "FRONTEND_CSS_URL": "http://testcss/",
+        "FRONTEND_FOOTER_FEATURE_ENABLED": True,
+        "FRONTEND_THEME": "test-theme",
         "LANGUAGES": [
             ["en-us", "English"],
             ["fr-fr", "Français"],

--- a/src/backend/core/tests/test_api_footer.py
+++ b/src/backend/core/tests/test_api_footer.py
@@ -1,0 +1,81 @@
+"""Test the footer API."""
+
+import responses
+from rest_framework.test import APIClient
+
+
+def test_api_footer_without_settings_configured(settings):
+    """Test the footer API without settings configured."""
+    settings.FRONTEND_URL_JSON_FOOTER = None
+    client = APIClient()
+    response = client.get("/api/v1.0/footer/")
+    assert response.status_code == 200
+    assert response.json() == {}
+
+
+@responses.activate
+def test_api_footer_with_invalid_request(settings):
+    """Test the footer API with an invalid request."""
+    settings.FRONTEND_URL_JSON_FOOTER = "https://invalid-request.com"
+
+    footer_response = responses.get(settings.FRONTEND_URL_JSON_FOOTER, status=404)
+
+    client = APIClient()
+    response = client.get("/api/v1.0/footer/")
+    assert response.status_code == 200
+    assert response.json() == {}
+    assert footer_response.call_count == 1
+
+
+@responses.activate
+def test_api_footer_with_invalid_json(settings):
+    """Test the footer API with an invalid JSON response."""
+    settings.FRONTEND_URL_JSON_FOOTER = "https://valid-request.com"
+
+    footer_response = responses.get(
+        settings.FRONTEND_URL_JSON_FOOTER, status=200, body="invalid json"
+    )
+
+    client = APIClient()
+    response = client.get("/api/v1.0/footer/")
+    assert response.status_code == 200
+    assert response.json() == {}
+    assert footer_response.call_count == 1
+
+
+@responses.activate
+def test_api_footer_with_valid_json(settings):
+    """Test the footer API with an invalid JSON response."""
+    settings.FRONTEND_URL_JSON_FOOTER = "https://valid-request.com"
+
+    footer_response = responses.get(
+        settings.FRONTEND_URL_JSON_FOOTER, status=200, json={"foo": "bar"}
+    )
+
+    client = APIClient()
+    response = client.get("/api/v1.0/footer/")
+    assert response.status_code == 200
+    assert response.json() == {"foo": "bar"}
+    assert footer_response.call_count == 1
+
+
+@responses.activate
+def test_api_footer_with_valid_json_and_cache(settings):
+    """Test the footer API with an invalid JSON response."""
+    settings.FRONTEND_URL_JSON_FOOTER = "https://valid-request.com"
+
+    footer_response = responses.get(
+        settings.FRONTEND_URL_JSON_FOOTER, status=200, json={"foo": "bar"}
+    )
+
+    client = APIClient()
+    response = client.get("/api/v1.0/footer/")
+    assert response.status_code == 200
+    assert response.json() == {"foo": "bar"}
+    assert footer_response.call_count == 1
+
+    response = client.get("/api/v1.0/footer/")
+    assert response.status_code == 200
+    assert response.json() == {"foo": "bar"}
+    # The cache should have been used
+    assert footer_response.call_count == 1

--- a/src/backend/core/tests/test_api_utils_ai_document_rate_throttles.py
+++ b/src/backend/core/tests/test_api_utils_ai_document_rate_throttles.py
@@ -4,10 +4,8 @@ Test throttling on documents for the AI endpoint.
 
 from unittest.mock import patch
 
-from django.core.cache import cache
 from django.test import override_settings
 
-import pytest
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
 from rest_framework.views import APIView
@@ -23,12 +21,6 @@ class DocumentAPIView(APIView):
     def get(self, request, *args, **kwargs):
         """Minimal get method for testing purposes."""
         return Response({"message": "Success"})
-
-
-@pytest.fixture(autouse=True)
-def clear_cache():
-    """Fixture to clear the cache before each test."""
-    cache.clear()
 
 
 @override_settings(AI_DOCUMENT_RATE_THROTTLE_RATES={"minute": 3, "hour": 6, "day": 10})

--- a/src/backend/core/tests/test_api_utils_ai_user_rate_throttles.py
+++ b/src/backend/core/tests/test_api_utils_ai_user_rate_throttles.py
@@ -5,7 +5,6 @@ Test throttling on users for the AI endpoint.
 from unittest.mock import patch
 from uuid import uuid4
 
-from django.core.cache import cache
 from django.test import override_settings
 
 import pytest
@@ -27,12 +26,6 @@ class DocumentAPIView(APIView):
     def get(self, request, *args, **kwargs):
         """Minimal get method for testing purposes."""
         return Response({"message": "Success"})
-
-
-@pytest.fixture(autouse=True)
-def clear_cache():
-    """Fixture to clear the cache before each test."""
-    cache.clear()
 
 
 @override_settings(AI_USER_RATE_THROTTLE_RATES={"minute": 3, "hour": 6, "day": 10})

--- a/src/backend/core/urls.py
+++ b/src/backend/core/urls.py
@@ -56,4 +56,5 @@ urlpatterns = [
         ),
     ),
     path(f"api/{settings.API_VERSION}/config/", viewsets.ConfigView.as_view()),
+    path(f"api/{settings.API_VERSION}/footer/", viewsets.FooterView.as_view()),
 ]

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -413,6 +413,11 @@ class Base(Configuration):
     FRONTEND_URL_JSON_FOOTER = values.Value(
         None, environ_name="FRONTEND_URL_JSON_FOOTER", environ_prefix=None
     )
+    FRONTEND_FOOTER_FEATURE_ENABLED = values.BooleanValue(
+        default=False,
+        environ_name="FRONTEND_FOOTER_FEATURE_ENABLED",
+        environ_prefix=None,
+    )
     FRONTEND_FOOTER_VIEW_CACHE_TIMEOUT = values.Value(
         60 * 60 * 24,
         environ_name="FRONTEND_FOOTER_VIEW_CACHE_TIMEOUT",

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -410,7 +410,14 @@ class Base(Configuration):
     FRONTEND_THEME = values.Value(
         None, environ_name="FRONTEND_THEME", environ_prefix=None
     )
-
+    FRONTEND_URL_JSON_FOOTER = values.Value(
+        None, environ_name="FRONTEND_URL_JSON_FOOTER", environ_prefix=None
+    )
+    FRONTEND_FOOTER_VIEW_CACHE_TIMEOUT = values.Value(
+        60 * 60 * 24,
+        environ_name="FRONTEND_FOOTER_VIEW_CACHE_TIMEOUT",
+        environ_prefix=None,
+    )
     FRONTEND_CSS_URL = values.Value(
         None, environ_name="FRONTEND_CSS_URL", environ_prefix=None
     )

--- a/src/frontend/apps/e2e/__tests__/app-impress/config.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/config.spec.ts
@@ -10,6 +10,7 @@ const config = {
   COLLABORATION_WS_URL: 'ws://localhost:4444/collaboration/ws/',
   ENVIRONMENT: 'development',
   FRONTEND_CSS_URL: null,
+  FRONTEND_FOOTER_FEATURE_ENABLED: true,
   FRONTEND_THEME: 'default',
   MEDIA_BASE_URL: 'http://localhost:8083',
   LANGUAGES: [

--- a/src/frontend/apps/impress/public/contents/footer-demo.json
+++ b/src/frontend/apps/impress/public/contents/footer-demo.json
@@ -1,0 +1,121 @@
+{
+  "default": {
+    "externalLinks": [
+      {
+        "label": "Github",
+        "href": "https://github.com/suitenumerique/docs/"
+      },
+      {
+        "label": "DINUM",
+        "href": "https://www.numerique.gouv.fr/dinum/"
+      },
+      {
+        "label": "ZenDiS",
+        "href": "https://zendis.de/"
+      },
+      {
+        "label": "BlockNote.js",
+        "href": "https://www.blocknotejs.org/"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Unless otherwise stated, all content on this site is under",
+      "link": {
+        "label": "licence etalab-2.0",
+        "href": "https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+      }
+    }
+  },
+  "en": {
+    "legalLinks": [
+      {
+        "label": "Legal Notice",
+        "href": "#"
+      },
+      {
+        "label": "Personal data and cookies",
+        "href": "#"
+      },
+      {
+        "label": "Accessibility",
+        "href": "#"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Unless otherwise stated, all content on this site is under",
+      "link": {
+        "label": "licence MIT",
+        "href": "https://github.com/suitenumerique/docs/blob/main/LICENSE"
+      }
+    }
+  },
+  "fr": {
+    "legalLinks": [
+      {
+        "label": "Mentions légales",
+        "href": "#"
+      },
+      {
+        "label": "Données personnelles et cookies",
+        "href": "#"
+      },
+      {
+        "label": "Accessibilité",
+        "href": "#"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Sauf mention contraire, tout le contenu de ce site est sous",
+      "link": {
+        "label": "licence MIT",
+        "href": "https://github.com/suitenumerique/docs/blob/main/LICENSE"
+      }
+    }
+  },
+  "de": {
+    "legalLinks": [
+      {
+        "label": "Impressum",
+        "href": "#"
+      },
+      {
+        "label": "Personenbezogene Daten und Cookies",
+        "href": "#"
+      },
+      {
+        "label": "Barrierefreiheit",
+        "href": "#"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Sofern nicht anders angegeben, steht der gesamte Inhalt dieser Website unter",
+      "link": {
+        "label": "licence MIT",
+        "href": "https://github.com/suitenumerique/docs/blob/main/LICENSE"
+      }
+    }
+  },
+  "nl": {
+    "legalLinks": [
+      {
+        "label": "Wettelijke bepalingen",
+        "href": "#"
+      },
+      {
+        "label": "Persoonlijke gegevens en cookies",
+        "href": "#"
+      },
+      {
+        "label": "Toegankelijkheid",
+        "href": "#"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Tenzij anders vermeld, is alle inhoud van deze site ondergebracht onder",
+      "link": {
+        "label": "licence MIT",
+        "href": "https://github.com/suitenumerique/docs/blob/main/LICENSE"
+      }
+    }
+  }
+}

--- a/src/frontend/apps/impress/public/contents/footer-dsfr.json
+++ b/src/frontend/apps/impress/public/contents/footer-dsfr.json
@@ -1,0 +1,135 @@
+{
+  "default": {
+    "externalLinks": [
+      {
+        "label": "legifrance.gouv.fr",
+        "href": "https://legifrance.gouv.fr/"
+      },
+      {
+        "label": "info.gouv.fr",
+        "href": "https://info.gouv.fr/"
+      },
+      {
+        "label": "service-public.fr",
+        "href": "https://service-public.fr/"
+      },
+      {
+        "label": "data.gouv.fr",
+        "href": "https://data.gouv.fr/"
+      }
+    ],
+    "legalLinks": [
+      {
+        "label": "Legal Notice",
+        "href": "https://docs.numerique.gouv.fr/docs/4db744e3-5b47-4ed9-b9e7-d4312318bbce/"
+      },
+      {
+        "label": "Personal data and cookies",
+        "href": "https://docs.numerique.gouv.fr/docs/eb863389-a5e5-4d18-879d-149a1122380e/"
+      },
+      {
+        "label": "Accessibility",
+        "href": "https://docs.numerique.gouv.fr/docs/9694e570-1427-4ef7-b0a0-c3e894360e1b/"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Unless otherwise stated, all content on this site is under",
+      "link": {
+        "label": "licence etalab-2.0",
+        "href": "https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+      }
+    }
+  },
+  "en": {
+    "legalLinks": [
+      {
+        "label": "Legal Notice",
+        "href": "https://docs.numerique.gouv.fr/docs/4db744e3-5b47-4ed9-b9e7-d4312318bbce/"
+      },
+      {
+        "label": "Personal data and cookies",
+        "href": "https://docs.numerique.gouv.fr/docs/eb863389-a5e5-4d18-879d-149a1122380e/"
+      },
+      {
+        "label": "Accessibility",
+        "href": "https://docs.numerique.gouv.fr/docs/9694e570-1427-4ef7-b0a0-c3e894360e1b/"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Unless otherwise stated, all content on this site is under",
+      "link": {
+        "label": "licence etalab-2.0",
+        "href": "https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+      }
+    }
+  },
+  "fr": {
+    "legalLinks": [
+      {
+        "label": "Mentions légales",
+        "href": "https://docs.numerique.gouv.fr/docs/4db744e3-5b47-4ed9-b9e7-d4312318bbce/"
+      },
+      {
+        "label": "Données personnelles et cookies",
+        "href": "https://docs.numerique.gouv.fr/docs/eb863389-a5e5-4d18-879d-149a1122380e/"
+      },
+      {
+        "label": "Accessibilité",
+        "href": "https://docs.numerique.gouv.fr/docs/9694e570-1427-4ef7-b0a0-c3e894360e1b/"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Sauf mention contraire, tout le contenu de ce site est sous",
+      "link": {
+        "label": "licence etalab-2.0",
+        "href": "https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+      }
+    }
+  },
+  "de": {
+    "legalLinks": [
+      {
+        "label": "Impressum",
+        "href": "https://docs.numerique.gouv.fr/docs/4db744e3-5b47-4ed9-b9e7-d4312318bbce/"
+      },
+      {
+        "label": "Personenbezogene Daten und Cookies",
+        "href": "https://docs.numerique.gouv.fr/docs/eb863389-a5e5-4d18-879d-149a1122380e/"
+      },
+      {
+        "label": "Barrierefreiheit",
+        "href": "https://docs.numerique.gouv.fr/docs/9694e570-1427-4ef7-b0a0-c3e894360e1b/"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Sofern nicht anders angegeben, steht der gesamte Inhalt dieser Website unter",
+      "link": {
+        "label": "licence etalab-2.0",
+        "href": "https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+      }
+    }
+  },
+  "nl": {
+    "legalLinks": [
+      {
+        "label": "Wettelijke bepalingen",
+        "href": "https://docs.numerique.gouv.fr/docs/4db744e3-5b47-4ed9-b9e7-d4312318bbce/"
+      },
+      {
+        "label": "Persoonlijke gegevens en cookies",
+        "href": "https://docs.numerique.gouv.fr/docs/eb863389-a5e5-4d18-879d-149a1122380e/"
+      },
+      {
+        "label": "Toegankelijkheid",
+        "href": "https://docs.numerique.gouv.fr/docs/9694e570-1427-4ef7-b0a0-c3e894360e1b/"
+      }
+    ],
+    "bottomInformation": {
+      "label": "Tenzij anders vermeld, is alle inhoud van deze site ondergebracht onder",
+      "link": {
+        "label": "licence etalab-2.0",
+        "href": "https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+      }
+    }
+  }
+}

--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -50,6 +50,7 @@ backend:
     DB_USER: dinum
     DB_PASSWORD: pass
     DB_PORT: 5432
+    FRONTEND_URL_JSON_FOOTER: https://impress.127.0.0.1.nip.io/contents/footer-demo.json
     POSTGRES_DB: impress
     POSTGRES_USER: dinum
     POSTGRES_PASSWORD: pass

--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -50,6 +50,7 @@ backend:
     DB_USER: dinum
     DB_PASSWORD: pass
     DB_PORT: 5432
+    FRONTEND_FOOTER_FEATURE_ENABLED: true
     FRONTEND_URL_JSON_FOOTER: https://impress.127.0.0.1.nip.io/contents/footer-demo.json
     POSTGRES_DB: impress
     POSTGRES_USER: dinum


### PR DESCRIPTION
## Purpose

- We want to have different footer content per environment.
- We want to be able to not have footer as well

## Proposal

- We added `FRONTEND_FOOTER_FEATURE_ENABLED` environment variable, a feature flag to enable or not the footer.
- We added the `FRONTEND_URL_JSON_FOOTER` environment variable. It will give the possibility to generate your own footer content in the frontend.

## Structure content footer:

https://github.com/suitenumerique/docs/blob/1972ef4d07eb2be2b7b0ac901b00ac8ffc8b9d7f/src/frontend/apps/impress/public/contents/footer-demo.json
