### PR TITLE
📝(doc) Fix Markdown in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -42,34 +42,36 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Guidelines
 
-- Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this 
+- Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
-## Code of Conduct:
-
-1. Correction
+### 1. Correction
 
 Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
 Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
-2. Warning
+
+### 2. Warning
 
 Community Impact: A violation through a single incident or series of actions.
 
 Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
-3. Temporary Ban
+
+### 3. Temporary Ban
 
 Community Impact: A serious violation of community standards, including sustained inappropriate behavior.
 
 Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
-4. Permanent Ban
+
+### 4. Permanent Ban
 
 Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
 Consequence: A permanent ban from any sort of public interaction within the community.
-Attribution
 
-This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+## Attribution
 
-Community Impact Guidelines were inspired by Mozilla's code of conduct enforcement ladder.
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by Mozilla's [code of conduct enforcement ladder](https://github.com/mozilla/inclusion/blob/master/code-of-conduct-enforcement/consequence-ladder.md).
 
 For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.


### PR DESCRIPTION
## Purpose

The COC file was visually broken because of some Markdown formatting issues. This PR fixes that, as well as adding links that were missing at the end.

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/273746e2-e9b1-4768-ab5b-87e396d95045" />


## Actions

- Fix Markdown formatting
- Add link to contributor-covenant.org
- Add link to Mozilla code of conduct enforcement ladder
