### PR TITLE
🐛(nginx) fix 404 when accessing a doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to
 
 ⚡️(frontend) reduce unblocking time for config #867
 
+## Fixed
+
+- 🐛(nginx) fix 404 when accessing a doc #866
+
 ## [3.1.0] - 2025-04-07
 
 ## Added

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-routing.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-routing.spec.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 import { expect, test } from '@playwright/test';
 
 import {
@@ -101,8 +103,9 @@ test.describe('Doc Routing: Not loggued', () => {
     page,
     browserName,
   }) => {
-    await mockedDocument(page, { link_reach: 'public' });
-    await page.goto('/docs/mocked-document-id/');
+    const uuid = crypto.randomUUID();
+    await mockedDocument(page, { link_reach: 'public', id: uuid });
+    await page.goto(`/docs/${uuid}/`);
     await expect(page.locator('h2').getByText('Mocked document')).toBeVisible();
     await page.getByRole('button', { name: 'Login' }).click();
     await keyCloakSignIn(page, browserName, false);

--- a/src/frontend/apps/e2e/__tests__/app-impress/language.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/language.spec.ts
@@ -54,18 +54,11 @@ test.describe.serial('Language', () => {
   }) => {
     // Helper function to intercept and assert 404 response
     const check404Response = async (expectedDetail: string) => {
-      const expectedBackendResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api') &&
-          response.url().includes('non-existent-doc-uuid') &&
-          response.status() === 404,
+      const interceptedBackendResponse = await page.request.get(
+        'http://localhost:8071/api/v1.0/documents/non-existent-doc-uuid/',
       );
 
-      // Trigger the specific 404 XHR response by navigating to a non-existent document
-      await page.goto('/docs/non-existent-doc-uuid');
-
       // Assert that the intercepted error message is in the expected language
-      const interceptedBackendResponse = await expectedBackendResponse;
       expect(await interceptedBackendResponse.json()).toStrictEqual({
         detail: expectedDetail,
       });

--- a/src/frontend/apps/impress/conf/default.conf
+++ b/src/frontend/apps/impress/conf/default.conf
@@ -9,8 +9,8 @@ server {
       try_files $uri index.html $uri/ =404;
   }
 
-  location /docs/ {
-    error_page 404 /docs/[id]/;
+  location ~ "^/docs/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/?$" {
+      try_files $uri /docs/[id]/index.html;
   }
 
   error_page 404 /404.html;

--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -33,11 +33,11 @@ backend:
     LOGGING_LEVEL_LOGGERS_APP: INFO
     USER_OIDC_FIELD_TO_SHORTNAME: "given_name"
     USER_OIDC_FIELDS_TO_FULLNAME: "given_name,usual_name"
-    OIDC_OP_JWKS_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/certs
-    OIDC_OP_AUTHORIZATION_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/auth
-    OIDC_OP_TOKEN_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/token
-    OIDC_OP_USER_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/userinfo
-    OIDC_OP_LOGOUT_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/logout
+    OIDC_OP_JWKS_ENDPOINT: https://docs-keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/certs
+    OIDC_OP_AUTHORIZATION_ENDPOINT: https://docs-keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/auth
+    OIDC_OP_TOKEN_ENDPOINT: https://docs-keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/token
+    OIDC_OP_USER_ENDPOINT: https://docs-keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/userinfo
+    OIDC_OP_LOGOUT_ENDPOINT: https://docs-keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/logout
     OIDC_RP_CLIENT_ID: impress
     OIDC_RP_CLIENT_SECRET: ThisIsAnExampleKeyForDevPurposeOnly
     OIDC_RP_SIGN_ALGO: RS256

--- a/src/helm/helmfile.yaml
+++ b/src/helm/helmfile.yaml
@@ -26,7 +26,7 @@ releases:
           - name: KEYCLOAK_EXTRA_ARGS
             value: "--import-realm"
           - name: KC_HOSTNAME_URL
-            value: https://keycloak.127.0.0.1.nip.io
+            value: https://docs-keycloak.127.0.0.1.nip.io
       - extraVolumes:
           - name: import
             configMap:
@@ -40,12 +40,13 @@ releases:
       - proxy: edge
       - ingress:
           enabled: true
-          hostname: keycloak.127.0.0.1.nip.io
+          hostname: docs-keycloak.127.0.0.1.nip.io
       - extraDeploy:
         - apiVersion: v1
           kind: ConfigMap
           metadata:
             name: docs-keycloak
+            namespace: {{ .Namespace }}
           data:
             impress.json: |
 {{ readFile "../../docker/auth/realm.json" | replace "http://localhost:3200" "https://impress.127.0.0.1.nip.io" | indent 14 }}


### PR DESCRIPTION
## Purpose

We improve the nginx way to access to a specific doc, to not have a 404 before accessing the resource.

## Proposal

We stop to wait for a initial attempt that give a 404. 
If we see a UUID in the url we will redirect to the doc/[id] page. 
`Next` will then manage the 404.

## Easy way to test

- go to `src/frontend/apps/impress`
- `yarn build`
- Access the app from nginx, in `docker-compose.yml`, add this service:
```yaml
  nginx-ci:
    image: nginx:1.25
    ports:
      - "3000:3000"
    volumes:
      - ./src/frontend/apps/impress/conf/default.conf:/etc/nginx/conf.d/default.conf
      - ./src/frontend/apps/impress/out:/usr/share/nginx/html
    depends_on:
      - app-dev
      - keycloak
```
- go to `http://localhost:3000`
