### PR TITLE
⚡️(frontend) reduce unblocking time for config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to
 - 🚸(backend) make document search on title accent-insensitive #874
 - 🚩 add homepage feature flag #861
 
+## Changed
+
+⚡️(frontend) reduce unblocking time for config #867
 
 ## [3.1.0] - 2025-04-07
 

--- a/src/frontend/apps/impress/src/features/language/hooks/useLanguageSynchronizer.ts
+++ b/src/frontend/apps/impress/src/features/language/hooks/useLanguageSynchronizer.ts
@@ -16,7 +16,7 @@ export const useLanguageSynchronizer = () => {
 
   const availableBackendLanguages = useMemo(() => {
     return conf?.LANGUAGES.map(([locale]) => locale);
-  }, [conf]);
+  }, [conf?.LANGUAGES]);
 
   const synchronizeLanguage = useCallback(
     async (direction?: 'toBackend' | 'toFrontend') => {


### PR DESCRIPTION
## Purpose

We will serve the config from the cache if available in waiting for the config to be loaded.
It will remove the loading time for the config except when the config is not available in the cache.


