### PR TITLE
🔒️(back) don't allow an owner to change or delete other owner accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - 🚩 add homepage feature flag #861
 
+## Fixed
+
+- 🔒️(back) don't allow an owner to change or delete other owner accesses
+
 
 ## [3.1.0] - 2025-04-07
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1113,11 +1113,17 @@ class DocumentAccess(BaseAccess):
         """
         roles = self._get_roles(self.document, user)
         is_owner_or_admin = bool(set(roles).intersection(set(PRIVILEGED_ROLES)))
+
         if self.role == RoleChoices.OWNER:
+            # An owner can only delete its own access if other owners exist
             can_delete = (
-                RoleChoices.OWNER in roles
+                self.user
+                and self.user.id == user.id
                 and self.document.accesses.filter(role=RoleChoices.OWNER).count() > 1
             )
+
+            # An owner can only update its own access to a non-owner role
+            # and only if other owners exist
             set_role_to = (
                 [RoleChoices.ADMIN, RoleChoices.EDITOR, RoleChoices.READER]
                 if can_delete

--- a/src/backend/core/tests/test_models_document_accesses.py
+++ b/src/backend/core/tests/test_models_document_accesses.py
@@ -151,6 +151,23 @@ def test_models_document_access_get_abilities_for_owner_of_owner():
     ).user
     abilities = access.get_abilities(user)
     assert abilities == {
+        "destroy": False,
+        "retrieve": True,
+        "update": False,
+        "partial_update": False,
+        "set_role_to": [],
+    }
+
+
+def test_models_document_access_get_abilities_for_owner_of_self_with_other_owner():
+    """
+    Check abilities of self access for the owner of a document when there is at least one other
+    owner left.
+    """
+    access = factories.UserDocumentAccessFactory(role="owner")
+    factories.UserDocumentAccessFactory(document=access.document, role="owner")
+    abilities = access.get_abilities(access.user)
+    assert abilities == {
         "destroy": True,
         "retrieve": True,
         "update": True,


### PR DESCRIPTION
## Purpose

Owner accesses can not be modified or deleted from other owners. Only current owner can modify and delete its own access.


## Proposal

- [x] 🔒️(back) don't allow an owner to change or delete other owner accesses
