### PR TITLE
🚸(backend) make document search on title accent-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- 🚸(backend) make document search on title accent-insensitive #874
 - 🚩 add homepage feature flag #861
 
 

--- a/src/backend/core/migrations/0021_activate_unaccent_extension.py
+++ b/src/backend/core/migrations/0021_activate_unaccent_extension.py
@@ -1,0 +1,10 @@
+from django.contrib.postgres.operations import UnaccentExtension
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0020_remove_is_public_add_field_attachments_and_duplicated_from"),
+    ]
+
+    operations = [UnaccentExtension()]


### PR DESCRIPTION

## Purpose

We want the document search on title to be accent-insensitive.

## Proposal

This should work in both cases:
- search for "vélo" when the document title contains "velo"
- search for "velo" when the document title contains "vélo"
