### PR TITLE
🐛(helm) charts generate invalid YAML for collaboration API / WS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- 🐛(helm) charts generate invalid YAML for collaboration API / WS #890
+
 ## [3.4.2] - 2025-07-18
 
 ### Changed
@@ -140,7 +144,6 @@ and this project adheres to
 - 🔒(frontend) enhance file download security #889
 - 🐛(backend) race condition create doc #633
 - 🐛(frontend) fix breaklines in custom blocks #908
-
 
 ## [3.1.0] - 2025-04-07
 

--- a/src/helm/impress/templates/ingress_collaboration_api.yaml
+++ b/src/helm/impress/templates/ingress_collaboration_api.yaml
@@ -51,10 +51,6 @@ spec:
             pathType: ImplementationSpecific
             {{- end }}
             backend:
-              service:
-                name: {{ include "impress.yProvider.fullname" . }}
-                port:
-                  number: {{ .Values.yProvider.service.port }}
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ include "impress.yProvider.fullname" . }}

--- a/src/helm/impress/templates/ingress_collaboration_ws.yaml
+++ b/src/helm/impress/templates/ingress_collaboration_ws.yaml
@@ -51,10 +51,6 @@ spec:
             pathType: ImplementationSpecific
             {{- end }}
             backend:
-              service:
-                name: {{ include "impress.yProvider.fullname" . }}
-                port:
-                  number: {{ .Values.yProvider.service.port }}
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ include "impress.yProvider.fullname" . }}


### PR DESCRIPTION
## Purpose

Closes #890

## Proposal

Remove the service blocks outside the conditionals in the collaboration API and WS templates. This makes these blocks follow the same pattern uses in other places in these templates and in other templates in the repo.
