### PR TITLE
🔧(backend) Allow overwriting the data directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 - 🚩 add homepage feature flag #861
 - ✨(settings) Allow configuring PKCE for the SSO #886
 - 🌐(i18n) activate chinese and spanish languages #884
+- 🔧(backend) allow overwriting the data directory #893
 
 ## Changed
 

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -23,7 +23,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATA_DIR = os.path.join("/", "data")
+DATA_DIR = os.getenv("DATA_DIR", os.path.join("/", "data"))
 
 
 def get_release():


### PR DESCRIPTION
## Purpose

Deployments that don't rely on Docker should be given the option to use a different data directory.

## Proposal

Allow customization of the `DATA_DIR` through an environment variable of the same name.

If the environment variable is not set the behaviour remains the same as before.