### PR TITLE
core:backend: enable overriding BASE_DIR setting

### DIFF
--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -23,7 +23,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATA_DIR = os.path.join("/", "data")
+DATA_DIR = os.path.join(BASE_DIR, "data")
 
 
 def get_release():


### PR DESCRIPTION
## Purpose

Django backend currently collects static files and creates a `/data` directory to store them. `DATA_DIR` path is hardcoded as `/` and that can cause some systems to throw errors (Mac, PaaS, VMs and containers, and other systems with strict read-only permissions ). The error will look like this: 

```shell
    os.makedirs(directory, exist_ok=True)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 217, in makedirs
  File "<frozen os>", line 217, in makedirs
  File "<frozen os>", line 227, in makedirs
OSError: [Errno 30] Read-only file system: '/data'
```

Changes in this PR allow developers to [override the path](url) in order to test the backend in any environment.

## Proposal

I propose to avoid hardcoding the backend root as an absolute system path and replace it by the variable `BASE_DIR`, which is a standard Django convention. `DATA_DIR` will always point to Django project's root directory by default to create `/data`, unless specified otherwise.

**Note:** similar to #893 but with a different method.

