### PR TITLE
🔒️(drf) disable browsable HTML API renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to
 ## Fixed
 
 - 🐛(nginx) fix 404 when accessing a doc #866
+- 🔒️(drf) disable browsable HTML API renderer #919
 
 ## [3.1.0] - 2025-04-07
 

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -334,6 +334,12 @@ class Base(Configuration):
             "rest_framework.parsers.JSONParser",
             "nested_multipart_parser.drf.DrfNestedParser",
         ],
+        "DEFAULT_RENDERER_CLASSES": [
+            # 🔒️ Disable BrowsableAPIRenderer which provides forms allowing a user to
+            # see all the data in the database (ie a serializer with a ForeignKey field
+            # will generate a form with a field with all possible values of the FK).
+            "rest_framework.renderers.JSONRenderer",
+        ],
         "EXCEPTION_HANDLER": "core.api.exception_handler",
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
         "PAGE_SIZE": 20,


### PR DESCRIPTION
## Purpose

The `BrowsableAPIRenderer` generates a form to test POST/PUT/... actions and fill the FK fields with unfiltered data. This issue has been spoted on visio and fixed suitenumerique/meet#508

## Proposal

- [x] 🔒️(drf) disable browsable HTML API renderer
