### PR TITLE
🚧(resource-server) Allow documents API via RS

### DIFF
--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -587,6 +587,60 @@ class Base(Configuration):
         default=True, environ_name="ALLOW_LOGOUT_GET_METHOD", environ_prefix=None
     )
 
+    # OIDC - Docs as a resource server
+    OIDC_OP_URL = values.Value(
+        default=None, environ_name="OIDC_OP_URL", environ_prefix=None
+    )
+    OIDC_OP_INTROSPECTION_ENDPOINT = values.Value(
+        environ_name="OIDC_OP_INTROSPECTION_ENDPOINT", environ_prefix=None
+    )
+    OIDC_VERIFY_SSL = values.BooleanValue(
+        default=True, environ_name="OIDC_VERIFY_SSL", environ_prefix=None
+    )
+    OIDC_TIMEOUT = values.IntegerValue(
+        default=3, environ_name="OIDC_TIMEOUT", environ_prefix=None
+    )
+    OIDC_PROXY = values.Value(None, environ_name="OIDC_PROXY", environ_prefix=None)
+
+    OIDC_RS_BACKEND_CLASS = "lasuite.oidc_resource_server.backend.ResourceServerBackend"
+    OIDC_RS_AUDIENCE_CLAIM = values.Value(  # The claim used to identify the audience
+        default="client_id", environ_name="OIDC_RS_AUDIENCE_CLAIM", environ_prefix=None
+    )
+    OIDC_RS_PRIVATE_KEY_STR = values.Value(
+        default=None,
+        environ_name="OIDC_RS_PRIVATE_KEY_STR",
+        environ_prefix=None,
+    )
+    OIDC_RS_ENCRYPTION_KEY_TYPE = values.Value(
+        default="RSA",
+        environ_name="OIDC_RS_ENCRYPTION_KEY_TYPE",
+        environ_prefix=None,
+    )
+    OIDC_RS_ENCRYPTION_ALGO = values.Value(
+        default="RSA-OAEP",
+        environ_name="OIDC_RS_ENCRYPTION_ALGO",
+        environ_prefix=None,
+    )
+    OIDC_RS_ENCRYPTION_ENCODING = values.Value(
+        default="A256GCM",
+        environ_name="OIDC_RS_ENCRYPTION_ENCODING",
+        environ_prefix=None,
+    )
+    OIDC_RS_CLIENT_ID = values.Value(
+        None, environ_name="OIDC_RS_CLIENT_ID", environ_prefix=None
+    )
+    OIDC_RS_CLIENT_SECRET = values.Value(
+        None,
+        environ_name="OIDC_RS_CLIENT_SECRET",
+        environ_prefix=None,
+    )
+    OIDC_RS_SIGNING_ALGO = values.Value(
+        default="ES256", environ_name="OIDC_RS_SIGNING_ALGO", environ_prefix=None
+    )
+    OIDC_RS_SCOPES = values.ListValue(
+        [], environ_name="OIDC_RS_SCOPES", environ_prefix=None
+    )
+
     # AI service
     AI_FEATURE_ENABLED = values.BooleanValue(
         default=False, environ_name="AI_FEATURE_ENABLED", environ_prefix=None

--- a/src/backend/impress/urls.py
+++ b/src/backend/impress/urls.py
@@ -12,10 +12,12 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
+from resource_server import urls as resource_server_urls
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("core.urls")),
-]
+] + resource_server_urls.urlpatterns
 
 if settings.DEBUG:
     urlpatterns = (

--- a/src/backend/resource_server/urls.py
+++ b/src/backend/resource_server/urls.py
@@ -1,0 +1,25 @@
+"""Resource server API URL Configuration"""
+
+from django.urls import include, path
+
+from lasuite.oidc_resource_server.urls import urlpatterns as resource_server_urls
+from rest_framework.routers import DefaultRouter
+
+from . import viewsets
+
+# - Main endpoints
+router = DefaultRouter()
+router.register("documents", viewsets.RSDocumentViewSet, basename="documents")
+
+
+urlpatterns = [
+    path(
+        "resource-server/v1.0/",
+        include(
+            [
+                *router.urls,
+                *resource_server_urls,
+            ]
+        ),
+    ),
+]

--- a/src/backend/resource_server/viewsets.py
+++ b/src/backend/resource_server/viewsets.py
@@ -1,0 +1,12 @@
+
+from lasuite.oidc_resource_server.mixins import ResourceServerMixin
+
+from core.api.viewsets import DocumentViewSet
+
+
+class RSDocumentViewSet(ResourceServerMixin, DocumentViewSet):
+    """
+    ViewSet for the resource server document API.
+
+    Exposes the same endpoints as the main document API, as resource server.
+    """

--- a/src/helm/impress/templates/ingress.yaml
+++ b/src/helm/impress/templates/ingress.yaml
@@ -74,6 +74,20 @@ spec:
               serviceName: {{ include "impress.backend.fullname" . }}
               servicePort: {{ .Values.backend.service.port }}
             {{- end }}
+          - path: /resource-server
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "impress.backend.fullname" . }}
+                port:
+                  number: {{ .Values.backend.service.port }}
+              {{- else }}
+              serviceName: {{ include "impress.backend.fullname" . }}
+              servicePort: {{ .Values.backend.service.port }}
+            {{- end }}
           {{- with .Values.ingress.customBackends }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -97,6 +111,20 @@ spec:
               servicePort: {{ $.Values.frontend.service.port }}
             {{- end }}
           - path: /api
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "impress.backend.fullname" $ }}
+                port:
+                  number: {{ $.Values.backend.service.port }}
+              {{- else }}
+              serviceName: {{ include "impress.backend.fullname" $ }}
+              servicePort: {{ $.Values.backend.service.port }}
+            {{- end }}
+          - path: /resource-server
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             {{- end }}


### PR DESCRIPTION
## Purpose

This provides a base configuration to allow to access all "/documents" API via OIDC resource server authentication.

## Proposal

- [x] add new "resource server" API endpoints (instead of allowing the whole API to be authenticated via resource server)
- [ ] requires https://github.com/suitenumerique/django-lasuite/pull/16 to be merged and release before being able to use with this version of keycloak
