### PR TITLE
django-lasuite malware detection integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - ✨ Add a custom callout block to the editor #892
 - 🚩(frontend) version MIT only #911
+- ✨(backend) integrate maleware_detection from django-lasuite #936
 
 ## Changed
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -98,3 +98,5 @@ These are the environmental variables you can set for the impress-backend contai
 | DJANGO_CSRF_TRUSTED_ORIGINS                     | CSRF trusted origins                                                                          | []                                                      |
 | REDIS_URL                                       | cache url                                                                                     | redis://redis:6379/1                                    |
 | CACHES_DEFAULT_TIMEOUT                          | cache default timeout                                                                         | 30                                                      |
+| MALWARE_DETECTION_BACKEND                       | The malware detection backend use from the django-lasuite package                             | lasuite.malware_detection.backends.dummy.DummyBackend           |
+| MALWARE_DETECTION_PARAMETERS                    | A dict containing all the parameters to initiate the malware detection backend                | {"callback_path": "core.malware_detection.malware_detection_callback",} |

--- a/src/backend/core/enums.py
+++ b/src/backend/core/enums.py
@@ -3,6 +3,7 @@ Core application enums declaration
 """
 
 import re
+from enum import StrEnum
 
 from django.conf import global_settings, settings
 from django.db import models
@@ -38,3 +39,10 @@ class MoveNodePositionChoices(models.TextChoices):
     LAST_SIBLING = "last-sibling", _("Last sibling")
     LEFT = "left", _("Left")
     RIGHT = "right", _("Right")
+
+
+class DocumentAttachmentStatus(StrEnum):
+    """Defines the possible statuses for an attachment."""
+
+    PROCESSING = "processing"
+    READY = "ready"

--- a/src/backend/core/malware_detection.py
+++ b/src/backend/core/malware_detection.py
@@ -1,0 +1,51 @@
+"""Malware detection callbacks"""
+
+import logging
+
+from django.core.files.storage import default_storage
+
+from lasuite.malware_detection.enums import ReportStatus
+
+from core.enums import DocumentAttachmentStatus
+from core.models import Document
+
+logger = logging.getLogger(__name__)
+
+
+def malware_detection_callback(file_path, status, error_info, **kwargs):
+    """Malware detection callback"""
+
+    if status == ReportStatus.SAFE:
+        logger.info("File %s is safe", file_path)
+        # Get existing metadata
+        s3_client = default_storage.connection.meta.client
+        bucket_name = default_storage.bucket_name
+        head_resp = s3_client.head_object(Bucket=bucket_name, Key=file_path)
+        metadata = head_resp.get("Metadata", {})
+        metadata.update({"status": DocumentAttachmentStatus.READY})
+        # Update status in metadata
+        s3_client.copy_object(
+            Bucket=bucket_name,
+            CopySource={"Bucket": bucket_name, "Key": file_path},
+            Key=file_path,
+            ContentType=head_resp.get("ContentType"),
+            Metadata=metadata,
+            MetadataDirective="REPLACE",
+        )
+        return
+
+    document_id = kwargs.get("document_id")
+    logger.error(
+        "File %s for document %s is infected with malware. Error info: %s",
+        file_path,
+        document_id,
+        error_info,
+    )
+
+    # Remove the file from the document and change the status to unsafe
+    document = Document.objects.get(pk=document_id)
+    document.attachments.remove(file_path)
+    document.save(update_fields=["attachments"])
+
+    # Delete the file from the storage
+    default_storage.delete(file_path)

--- a/src/backend/core/malware_detection.py
+++ b/src/backend/core/malware_detection.py
@@ -10,6 +10,7 @@ from core.enums import DocumentAttachmentStatus
 from core.models import Document
 
 logger = logging.getLogger(__name__)
+security_logger = logging.getLogger("docs.security")
 
 
 def malware_detection_callback(file_path, status, error_info, **kwargs):
@@ -35,7 +36,7 @@ def malware_detection_callback(file_path, status, error_info, **kwargs):
         return
 
     document_id = kwargs.get("document_id")
-    logger.error(
+    security_logger.warning(
         "File %s for document %s is infected with malware. Error info: %s",
         file_path,
         document_id,

--- a/src/backend/core/tests/documents/test_api_documents_attachment_upload.py
+++ b/src/backend/core/tests/documents/test_api_documents_attachment_upload.py
@@ -4,6 +4,7 @@ Test file uploads API endpoint for users in impress's core app.
 
 import re
 import uuid
+from unittest import mock
 
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -12,6 +13,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from core import factories
+from core.api.viewsets import malware_detection
 from core.tests.conftest import TEAM, USER, VIA
 
 pytestmark = pytest.mark.django_db
@@ -59,7 +61,8 @@ def test_api_documents_attachment_upload_anonymous_success():
     file = SimpleUploadedFile(name="test.png", content=PIXEL, content_type="image/png")
 
     url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
-    response = APIClient().post(url, {"file": file}, format="multipart")
+    with mock.patch.object(malware_detection, "analyse_file") as mock_analyse_file:
+        response = APIClient().post(url, {"file": file}, format="multipart")
 
     assert response.status_code == 201
 
@@ -74,12 +77,13 @@ def test_api_documents_attachment_upload_anonymous_success():
     assert document.attachments == [f"{document.id!s}/attachments/{file_id!s}.png"]
 
     # Now, check the metadata of the uploaded file
-    key = file_path.replace("/media", "")
+    key = file_path.replace("/media/", "")
+    mock_analyse_file.assert_called_once_with(key, document_id=document.id)
     file_head = default_storage.connection.meta.client.head_object(
         Bucket=default_storage.bucket_name, Key=key
     )
 
-    assert file_head["Metadata"] == {"owner": "None"}
+    assert file_head["Metadata"] == {"owner": "None", "status": "processing"}
     assert file_head["ContentType"] == "image/png"
     assert file_head["ContentDisposition"] == 'inline; filename="test.png"'
 
@@ -139,13 +143,18 @@ def test_api_documents_attachment_upload_authenticated_success(reach, role):
     file = SimpleUploadedFile(name="test.png", content=PIXEL, content_type="image/png")
 
     url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
-    response = client.post(url, {"file": file}, format="multipart")
+    with mock.patch.object(malware_detection, "analyse_file") as mock_analyse_file:
+        response = client.post(url, {"file": file}, format="multipart")
 
     assert response.status_code == 201
 
     pattern = re.compile(rf"^/media/{document.id!s}/attachments/(.*)\.png")
     match = pattern.search(response.json()["file"])
     file_id = match.group(1)
+
+    mock_analyse_file.assert_called_once_with(
+        f"{document.id!s}/attachments/{file_id!s}.png", document_id=document.id
+    )
 
     # Validate that file_id is a valid UUID
     uuid.UUID(file_id)
@@ -210,7 +219,8 @@ def test_api_documents_attachment_upload_success(via, role, mock_user_teams):
     file = SimpleUploadedFile(name="test.png", content=PIXEL, content_type="image/png")
 
     url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
-    response = client.post(url, {"file": file}, format="multipart")
+    with mock.patch.object(malware_detection, "analyse_file") as mock_analyse_file:
+        response = client.post(url, {"file": file}, format="multipart")
 
     assert response.status_code == 201
 
@@ -226,11 +236,12 @@ def test_api_documents_attachment_upload_success(via, role, mock_user_teams):
     assert document.attachments == [f"{document.id!s}/attachments/{file_id!s}.png"]
 
     # Now, check the metadata of the uploaded file
-    key = file_path.replace("/media", "")
+    key = file_path.replace("/media/", "")
+    mock_analyse_file.assert_called_once_with(key, document_id=document.id)
     file_head = default_storage.connection.meta.client.head_object(
         Bucket=default_storage.bucket_name, Key=key
     )
-    assert file_head["Metadata"] == {"owner": str(user.id)}
+    assert file_head["Metadata"] == {"owner": str(user.id), "status": "processing"}
     assert file_head["ContentType"] == "image/png"
     assert file_head["ContentDisposition"] == 'inline; filename="test.png"'
 
@@ -304,7 +315,8 @@ def test_api_documents_attachment_upload_fix_extension(
     url = f"/api/v1.0/documents/{document.id!s}/attachment-upload/"
 
     file = SimpleUploadedFile(name=name, content=content)
-    response = client.post(url, {"file": file}, format="multipart")
+    with mock.patch.object(malware_detection, "analyse_file") as mock_analyse_file:
+        response = client.post(url, {"file": file}, format="multipart")
 
     assert response.status_code == 201
 
@@ -324,11 +336,16 @@ def test_api_documents_attachment_upload_fix_extension(
     uuid.UUID(file_id)
 
     # Now, check the metadata of the uploaded file
-    key = file_path.replace("/media", "")
+    key = file_path.replace("/media/", "")
+    mock_analyse_file.assert_called_once_with(key, document_id=document.id)
     file_head = default_storage.connection.meta.client.head_object(
         Bucket=default_storage.bucket_name, Key=key
     )
-    assert file_head["Metadata"] == {"owner": str(user.id), "is_unsafe": "true"}
+    assert file_head["Metadata"] == {
+        "owner": str(user.id),
+        "is_unsafe": "true",
+        "status": "processing",
+    }
     assert file_head["ContentType"] == content_type
     assert file_head["ContentDisposition"] == f'attachment; filename="{name:s}"'
 
@@ -364,7 +381,8 @@ def test_api_documents_attachment_upload_unsafe():
     file = SimpleUploadedFile(
         name="script.exe", content=b"\x4d\x5a\x90\x00\x03\x00\x00\x00"
     )
-    response = client.post(url, {"file": file}, format="multipart")
+    with mock.patch.object(malware_detection, "analyse_file") as mock_analyse_file:
+        response = client.post(url, {"file": file}, format="multipart")
 
     assert response.status_code == 201
 
@@ -381,11 +399,16 @@ def test_api_documents_attachment_upload_unsafe():
     file_id = file_id.replace("-unsafe", "")
     uuid.UUID(file_id)
 
+    key = file_path.replace("/media/", "")
+    mock_analyse_file.assert_called_once_with(key, document_id=document.id)
     # Now, check the metadata of the uploaded file
-    key = file_path.replace("/media", "")
     file_head = default_storage.connection.meta.client.head_object(
         Bucket=default_storage.bucket_name, Key=key
     )
-    assert file_head["Metadata"] == {"owner": str(user.id), "is_unsafe": "true"}
+    assert file_head["Metadata"] == {
+        "owner": str(user.id),
+        "is_unsafe": "true",
+        "status": "processing",
+    }
     assert file_head["ContentType"] == "application/octet-stream"
     assert file_head["ContentDisposition"] == 'attachment; filename="script.exe"'

--- a/src/backend/core/tests/test_malware_detection.py
+++ b/src/backend/core/tests/test_malware_detection.py
@@ -15,8 +15,8 @@ from core.malware_detection import malware_detection_callback
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture
-def safe_file():
+@pytest.fixture(name="safe_file")
+def fixture_safe_file():
     """Create a safe file."""
     file_path = "test.txt"
     default_storage.save(file_path, ContentFile("test"))
@@ -24,8 +24,8 @@ def safe_file():
     default_storage.delete(file_path)
 
 
-@pytest.fixture
-def unsafe_file():
+@pytest.fixture(name="unsafe_file")
+def fixture_unsafe_file():
     """Create an unsafe file."""
     file_path = "unsafe.txt"
     default_storage.save(file_path, ContentFile("test"))

--- a/src/backend/core/tests/test_malware_detection.py
+++ b/src/backend/core/tests/test_malware_detection.py
@@ -1,0 +1,76 @@
+"""Test malware detection callback."""
+
+import random
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
+import pytest
+from lasuite.malware_detection.enums import ReportStatus
+
+from core.enums import DocumentAttachmentStatus
+from core.factories import DocumentFactory
+from core.malware_detection import malware_detection_callback
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def safe_file():
+    """Create a safe file."""
+    file_path = "test.txt"
+    default_storage.save(file_path, ContentFile("test"))
+    yield file_path
+    default_storage.delete(file_path)
+
+
+@pytest.fixture
+def unsafe_file():
+    """Create an unsafe file."""
+    file_path = "unsafe.txt"
+    default_storage.save(file_path, ContentFile("test"))
+    yield file_path
+
+
+def test_malware_detection_callback_safe_status(safe_file):
+    """Test malware detection callback with safe status."""
+
+    document = DocumentFactory(attachments=[safe_file])
+
+    malware_detection_callback(
+        safe_file,
+        ReportStatus.SAFE,
+        error_info={},
+        document_id=document.id,
+    )
+
+    document.refresh_from_db()
+
+    assert safe_file in document.attachments
+    assert default_storage.exists(safe_file)
+
+    s3_client = default_storage.connection.meta.client
+    bucket_name = default_storage.bucket_name
+    head_resp = s3_client.head_object(Bucket=bucket_name, Key=safe_file)
+    metadata = head_resp.get("Metadata", {})
+    assert metadata["status"] == DocumentAttachmentStatus.READY
+
+
+def test_malware_detection_callback_unsafe_status(unsafe_file):
+    """Test malware detection callback with unsafe status."""
+
+    document = DocumentFactory(attachments=[unsafe_file])
+
+    malware_detection_callback(
+        unsafe_file,
+        random.choice(
+            [status.value for status in ReportStatus if status != ReportStatus.SAFE]
+        ),
+        error_info={"error": "test", "error_code": 4001},
+        document_id=document.id,
+    )
+
+    document.refresh_from_db()
+
+    assert unsafe_file not in document.attachments
+    assert not default_storage.exists(unsafe_file)

--- a/src/backend/impress/__init__.py
+++ b/src/backend/impress/__init__.py
@@ -1,0 +1,5 @@
+"""Impress package. Import the celery app early to load shared task form dependencies."""
+
+from .celery_app import app as celery_app
+
+__all__ = ["celery_app"]

--- a/src/backend/impress/celery_app.py
+++ b/src/backend/impress/celery_app.py
@@ -11,6 +11,9 @@ os.environ.setdefault("DJANGO_CONFIGURATION", "Development")
 
 install(check_options=True)
 
+# Can not be loaded only after install call.
+from django.conf import settings  # pylint: disable=wrong-import-position
+
 app = Celery("impress")
 
 # Using a string here means the worker doesn't have to serialize
@@ -20,4 +23,4 @@ app = Celery("impress")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django apps.
-app.autodiscover_tasks()
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -317,6 +317,7 @@ class Base(Configuration):
         "django.contrib.staticfiles",
         # OIDC third party
         "mozilla_django_oidc",
+        "lasuite.malware_detection",
     ]
 
     # Cache
@@ -678,6 +679,21 @@ class Base(Configuration):
                 "propagate": False,
             },
         },
+    }
+
+    MALWARE_DETECTION = {
+        "BACKEND": values.Value(
+            "lasuite.malware_detection.backends.dummy.DummyBackend",
+            environ_name="MALWARE_DETECTION_BACKEND",
+            environ_prefix=None,
+        ),
+        "PARAMETERS": values.DictValue(
+            default={
+                "callback_path": "core.malware_detection.malware_detection_callback",
+            },
+            environ_name="MALWARE_DETECTION_PARAMETERS",
+            environ_prefix=None,
+        ),
     }
 
     API_USERS_LIST_LIMIT = values.PositiveIntegerValue(

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "django-cors-headers==4.7.0",
     "django-countries==7.6.1",
     "django-filter==25.1",
-    "django-lasuite==0.0.7",
+    "django-lasuite[all]==0.0.8",
     "django-parler==2.3",
     "django-redis==5.4.0",
     "django-storages[s3]==1.14.6",


### PR DESCRIPTION
## Purpose

The django lasuite library has a dedicated module managing malware detection.
We have to configure it using django settings and then put the logic we want to apply in a callback.
While the analyse is not made, we set a temporary status to the file metadata and this status is check in the media-auth endpoint to determine is the s3 signature should be return or not.
If a file is glas as unsafe, it is deleted.

## Proposal

- [x] ✨(backend) force loading celery shared task in libraries
- [x] ✨(backend) configure lasuite.malware_detection module
- [x] ✨(backend) manage uploaded file status and call to malware detection
