### PR TITLE
🛂(frontend) block edition to not connected users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - 🚩(frontend) version MIT only #911
 - ✨(backend) integrate maleware_detection from django-lasuite #936
 - 🩺(CI) add lint spell mistakes #954
+- 🛂(frontend) block edition to not connected users #945
 
 ## Changed
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/common.ts
@@ -102,7 +102,7 @@ export const verifyDocName = async (page: Page, docName: string) => {
 export const addNewMember = async (
   page: Page,
   index: number,
-  role: 'Administrator' | 'Owner' | 'Member' | 'Editor' | 'Reader',
+  role: 'Administrator' | 'Owner' | 'Editor' | 'Reader',
   fillText: string = 'user ',
 ) => {
   const responsePromiseSearchUser = page.waitForResponse(

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next';
 import * as Y from 'yjs';
 
 import { Box, TextErrors } from '@/components';
-import { Doc } from '@/docs/doc-management';
+import { Doc, useIsCollaborativeEditable } from '@/docs/doc-management';
 import { useAuth } from '@/features/auth';
 
 import { useUploadFile } from '../hook';
@@ -49,7 +49,9 @@ export const BlockNoteEditor = ({ doc, provider }: BlockNoteEditorProps) => {
   const { setEditor } = useEditorStore();
   const { t } = useTranslation();
 
-  const readOnly = !doc.abilities.partial_update;
+  const { isEditable, isLoading } = useIsCollaborativeEditable(doc);
+  const readOnly = !doc.abilities.partial_update || !isEditable || isLoading;
+
   useSaveDoc(doc.id, provider.document, !readOnly);
   const { i18n } = useTranslation();
   const lang = i18n.resolvedLanguage;

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/DocEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/DocEditor.tsx
@@ -25,7 +25,6 @@ interface DocEditorProps {
 
 export const DocEditor = ({ doc, versionId }: DocEditorProps) => {
   const { isDesktop } = useResponsiveStore();
-
   const isVersion = !!versionId && typeof versionId === 'string';
 
   const { colorsTokens } = useCunninghamTheme();

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertNetwork.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertNetwork.tsx
@@ -1,0 +1,113 @@
+import { Button, Modal, ModalSize } from '@openfun/cunningham-react';
+import { t } from 'i18next';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { css } from 'styled-components';
+
+import { Box, BoxButton, Icon, Text } from '@/components';
+import { useCunninghamTheme } from '@/cunningham';
+
+export const AlertNetwork = () => {
+  const { t } = useTranslation();
+  const { colorsTokens, spacingsTokens } = useCunninghamTheme();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <>
+      <Box>
+        <Box
+          $direction="row"
+          $justify="space-between"
+          $width="100%"
+          $background={colorsTokens['warning-100']}
+          $radius={spacingsTokens['3xs']}
+          $padding="xs"
+          $flex={1}
+          $align="center"
+          $gap={spacingsTokens['3xs']}
+          $css={css`
+            border: 1px solid var(--c--theme--colors--warning-300);
+          `}
+        >
+          <Box $direction="row" $gap={spacingsTokens['2xs']}>
+            <Icon iconName="mobiledata_off" $theme="warning" $variation="600" />
+            <Text $theme="warning" $variation="600" $weight={500}>
+              {t('Your network do not allow you to edit')}
+            </Text>
+          </Box>
+          <BoxButton
+            $direction="row"
+            $gap={spacingsTokens['3xs']}
+            $align="center"
+            onClick={() => setIsModalOpen(true)}
+          >
+            <Icon
+              iconName="info"
+              $theme="warning"
+              $variation="600"
+              $size="16px"
+              $weight="500"
+              $margin={{ top: 'auto' }}
+            />
+            <Text $theme="warning" $variation="600" $weight="500" $size="xs">
+              {t('Know more')}
+            </Text>
+          </BoxButton>
+        </Box>
+      </Box>
+      {isModalOpen && (
+        <AlertNetworkModal onClose={() => setIsModalOpen(false)} />
+      )}
+    </>
+  );
+};
+
+interface AlertNetworkModalProps {
+  onClose: () => void;
+}
+
+export const AlertNetworkModal = ({ onClose }: AlertNetworkModalProps) => {
+  return (
+    <Modal
+      isOpen
+      closeOnClickOutside
+      onClose={() => onClose()}
+      rightActions={
+        <>
+          <Button aria-label={t('OK')} onClick={onClose}>
+            {t('OK')}
+          </Button>
+        </>
+      }
+      size={ModalSize.MEDIUM}
+      title={
+        <Text
+          $size="h6"
+          as="h6"
+          $margin={{ all: '0' }}
+          $align="flex-start"
+          $variation="1000"
+        >
+          {t("Why can't I edit?")}
+        </Text>
+      }
+    >
+      <Box
+        aria-label={t('Content modal to explain why the user cannot edit')}
+        className="--docs--modal-alert-network"
+        $margin={{ top: 'xs' }}
+      >
+        <Text $size="sm" $variation="600">
+          {t(
+            'The network configuration of your workstation or internet connection does not allow editing shared documents.',
+          )}
+        </Text>
+        <Text $size="sm" $variation="600" $margin={{ top: 'xs' }}>
+          {t(
+            'Docs use WebSockets to enable real-time editing. These communication channels allow instant and bidirectional exchanges between your browser and our servers. To access collaborative editing, please contact your IT department to enable WebSockets.',
+          )}
+        </Text>
+      </Box>
+    </Modal>
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertPublic.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertPublic.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from 'react-i18next';
+import { css } from 'styled-components';
+
+import { Box, Icon, Text } from '@/components';
+import { useCunninghamTheme } from '@/cunningham';
+
+export const AlertPublic = ({ isPublicDoc }: { isPublicDoc: boolean }) => {
+  const { t } = useTranslation();
+  const { colorsTokens, spacingsTokens } = useCunninghamTheme();
+
+  return (
+    <Box
+      aria-label={t('Public document')}
+      $color={colorsTokens['primary-800']}
+      $background={colorsTokens['primary-050']}
+      $radius={spacingsTokens['3xs']}
+      $direction="row"
+      $padding="xs"
+      $flex={1}
+      $align="center"
+      $gap={spacingsTokens['3xs']}
+      $css={css`
+        border: 1px solid var(--c--theme--colors--primary-300, #e3e3fd);
+      `}
+    >
+      <Icon
+        $theme="primary"
+        $variation="800"
+        data-testid="public-icon"
+        iconName={isPublicDoc ? 'public' : 'vpn_lock'}
+      />
+      <Text $theme="primary" $variation="800" $weight="500">
+        {isPublicDoc
+          ? t('Public document')
+          : t('Document accessible to any connected person')}
+      </Text>
+    </Box>
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeader.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeader.tsx
@@ -1,17 +1,20 @@
 import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
-import { css } from 'styled-components';
 
-import { Box, HorizontalSeparator, Icon, Text } from '@/components';
+import { Box, HorizontalSeparator, Text } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
 import {
   Doc,
   LinkReach,
+  Role,
   currentDocRole,
+  useIsCollaborativeEditable,
   useTrans,
 } from '@/docs/doc-management';
 import { useResponsiveStore } from '@/stores';
 
+import { AlertNetwork } from './AlertNetwork';
+import { AlertPublic } from './AlertPublic';
 import { DocTitle } from './DocTitle';
 import { DocToolBox } from './DocToolBox';
 
@@ -20,51 +23,26 @@ interface DocHeaderProps {
 }
 
 export const DocHeader = ({ doc }: DocHeaderProps) => {
-  const { colorsTokens, spacingsTokens } = useCunninghamTheme();
+  const { spacingsTokens } = useCunninghamTheme();
   const { isDesktop } = useResponsiveStore();
-
   const { t } = useTranslation();
+  const { transRole } = useTrans();
+  const { isEditable } = useIsCollaborativeEditable(doc);
   const docIsPublic = doc.link_reach === LinkReach.PUBLIC;
   const docIsAuth = doc.link_reach === LinkReach.AUTHENTICATED;
-
-  const { transRole } = useTrans();
 
   return (
     <>
       <Box
         $width="100%"
-        $padding={{ top: isDesktop ? '4xl' : 'md' }}
+        $padding={{ top: isDesktop ? '50px' : 'md' }}
         $gap={spacingsTokens['base']}
         aria-label={t('It is the card information about the document.')}
         className="--docs--doc-header"
       >
+        {!isEditable && <AlertNetwork />}
         {(docIsPublic || docIsAuth) && (
-          <Box
-            aria-label={t('Public document')}
-            $color={colorsTokens['primary-800']}
-            $background={colorsTokens['primary-050']}
-            $radius={spacingsTokens['3xs']}
-            $direction="row"
-            $padding="xs"
-            $flex={1}
-            $align="center"
-            $gap={spacingsTokens['3xs']}
-            $css={css`
-              border: 1px solid var(--c--theme--colors--primary-300, #e3e3fd);
-            `}
-          >
-            <Icon
-              $theme="primary"
-              $variation="800"
-              data-testid="public-icon"
-              iconName={docIsPublic ? 'public' : 'vpn_lock'}
-            />
-            <Text $theme="primary" $variation="800">
-              {docIsPublic
-                ? t('Public document')
-                : t('Document accessible to any connected person')}
-            </Text>
-          </Box>
+          <AlertPublic isPublicDoc={docIsPublic} />
         )}
         <Box
           $direction="row"
@@ -86,8 +64,18 @@ export const DocHeader = ({ doc }: DocHeaderProps) => {
               <Box $direction="row">
                 {isDesktop && (
                   <>
-                    <Text $variation="600" $size="s" $weight="bold">
-                      {transRole(currentDocRole(doc.abilities))}&nbsp;·&nbsp;
+                    <Text
+                      $variation="600"
+                      $size="s"
+                      $weight="bold"
+                      $theme={isEditable ? 'greyscale' : 'warning'}
+                    >
+                      {transRole(
+                        isEditable
+                          ? currentDocRole(doc.abilities)
+                          : Role.READER,
+                      )}
+                      &nbsp;·&nbsp;
                     </Text>
                     <Text $variation="600" $size="s">
                       {t('Last update: {{update}}', {

--- a/src/frontend/apps/impress/src/features/docs/doc-management/hooks/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useCollaboration';
-export * from './useTrans';
 export * from './useCopyDocLink';
+export * from './useIsCollaborativeEditable';
+export * from './useTrans';

--- a/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useIsCollaborativeEditable.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useIsCollaborativeEditable.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { useIsOffline } from '@/features/service-worker';
+
 import { useProviderStore } from '../stores';
 import { Doc, LinkReach } from '../types';
 
@@ -12,12 +14,13 @@ export const useIsCollaborativeEditable = (doc: Doc) => {
   const isShared = docIsPublic || docIsAuth || docHasMember;
   const [isEditable, setIsEditable] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
+  const { isOffline } = useIsOffline();
 
   /**
    * Connection can take a few seconds
    */
   useEffect(() => {
-    const _isEditable = isConnected || !isShared;
+    const _isEditable = isConnected || !isShared || isOffline;
     setIsLoading(true);
 
     if (_isEditable) {
@@ -32,7 +35,7 @@ export const useIsCollaborativeEditable = (doc: Doc) => {
     }, 5000);
 
     return () => clearTimeout(timer);
-  }, [isConnected, isShared]);
+  }, [isConnected, isOffline, isShared]);
 
   return {
     isEditable,

--- a/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useIsCollaborativeEditable.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useIsCollaborativeEditable.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+import { useProviderStore } from '../stores';
+import { Doc, LinkReach } from '../types';
+
+export const useIsCollaborativeEditable = (doc: Doc) => {
+  const { isConnected } = useProviderStore();
+
+  const docIsPublic = doc.link_reach === LinkReach.PUBLIC;
+  const docIsAuth = doc.link_reach === LinkReach.AUTHENTICATED;
+  const docHasMember = doc.nb_accesses_direct > 1;
+  const isShared = docIsPublic || docIsAuth || docHasMember;
+  const [isEditable, setIsEditable] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+
+  /**
+   * Connection can take a few seconds
+   */
+  useEffect(() => {
+    const _isEditable = isConnected || !isShared;
+    setIsLoading(true);
+
+    if (_isEditable) {
+      setIsEditable(true);
+      setIsLoading(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsEditable(false);
+      setIsLoading(false);
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, [isConnected, isShared]);
+
+  return {
+    isEditable,
+    isLoading,
+  };
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-management/stores/useProviderStore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/stores/useProviderStore.tsx
@@ -1,4 +1,4 @@
-import { HocuspocusProvider } from '@hocuspocus/provider';
+import { HocuspocusProvider, WebSocketStatus } from '@hocuspocus/provider';
 import * as Y from 'yjs';
 import { create } from 'zustand';
 
@@ -12,10 +12,12 @@ export interface UseCollaborationStore {
   ) => HocuspocusProvider;
   destroyProvider: () => void;
   provider: HocuspocusProvider | undefined;
+  isConnected: boolean;
 }
 
 const defaultValues = {
   provider: undefined,
+  isConnected: false,
 };
 
 export const useProviderStore = create<UseCollaborationStore>((set, get) => ({
@@ -33,6 +35,11 @@ export const useProviderStore = create<UseCollaborationStore>((set, get) => ({
       url: wsUrl,
       name: storeId,
       document: doc,
+      onStatus: ({ status }) => {
+        set({
+          isConnected: status === WebSocketStatus.Connected,
+        });
+      },
     });
 
     set({

--- a/src/frontend/apps/impress/src/features/service-worker/__tests__/ApiPlugin.test.tsx
+++ b/src/frontend/apps/impress/src/features/service-worker/__tests__/ApiPlugin.test.tsx
@@ -4,8 +4,8 @@
 
 import '@testing-library/jest-dom';
 
-import { ApiPlugin } from '../ApiPlugin';
 import { RequestSerializer } from '../RequestSerializer';
+import { ApiPlugin } from '../plugins/ApiPlugin';
 
 const mockedGet = jest.fn().mockResolvedValue({});
 const mockedGetAllKeys = jest.fn().mockResolvedValue([]);

--- a/src/frontend/apps/impress/src/features/service-worker/__tests__/OfflinePlugin.test.tsx
+++ b/src/frontend/apps/impress/src/features/service-worker/__tests__/OfflinePlugin.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+
+import '@testing-library/jest-dom';
+
+import { MESSAGE_TYPE } from '../conf';
+import { OfflinePlugin } from '../plugins/OfflinePlugin';
+
+const mockServiceWorkerScope = {
+  clients: {
+    matchAll: jest.fn().mockResolvedValue([]),
+  },
+} as unknown as ServiceWorkerGlobalScope;
+
+(global as any).self = {
+  ...global,
+  clients: mockServiceWorkerScope.clients,
+} as unknown as ServiceWorkerGlobalScope;
+
+describe('OfflinePlugin', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it(`calls fetchDidSucceed`, async () => {
+    const apiPlugin = new OfflinePlugin();
+    const postMessageSpy = jest.spyOn(apiPlugin, 'postMessage');
+
+    await apiPlugin.fetchDidSucceed?.({
+      response: new Response(),
+    } as any);
+
+    expect(postMessageSpy).toHaveBeenCalledWith(false, 'fetchDidSucceed');
+  });
+
+  it(`calls fetchDidFail`, async () => {
+    const apiPlugin = new OfflinePlugin();
+    const postMessageSpy = jest.spyOn(apiPlugin, 'postMessage');
+
+    await apiPlugin.fetchDidFail?.({} as any);
+
+    expect(postMessageSpy).toHaveBeenCalledWith(true, 'fetchDidFail');
+  });
+
+  it(`calls postMessage`, async () => {
+    const apiPlugin = new OfflinePlugin();
+    const mockClients = [
+      { postMessage: jest.fn() },
+      { postMessage: jest.fn() },
+    ];
+
+    mockServiceWorkerScope.clients.matchAll = jest
+      .fn()
+      .mockResolvedValue(mockClients);
+
+    await apiPlugin.postMessage(false, 'testMessage');
+
+    for (const client of mockClients) {
+      expect(client.postMessage).toHaveBeenCalledWith({
+        type: MESSAGE_TYPE.OFFLINE,
+        value: false,
+        message: 'testMessage',
+      });
+    }
+  });
+});

--- a/src/frontend/apps/impress/src/features/service-worker/__tests__/useOffline.test.tsx
+++ b/src/frontend/apps/impress/src/features/service-worker/__tests__/useOffline.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom';
+import { act, renderHook } from '@testing-library/react';
+
+import { MESSAGE_TYPE } from '../conf';
+import { useIsOffline, useOffline } from '../hooks/useOffline';
+
+const mockAddEventListener = jest.fn();
+const mockRemoveEventListener = jest.fn();
+Object.defineProperty(navigator, 'serviceWorker', {
+  value: {
+    addEventListener: mockAddEventListener,
+    removeEventListener: mockRemoveEventListener,
+  },
+  writable: true,
+});
+
+describe('useOffline', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set isOffline to true when receiving an offline message', () => {
+    useIsOffline.setState({ isOffline: false });
+
+    const { result } = renderHook(() => useIsOffline());
+    renderHook(() => useOffline());
+
+    act(() => {
+      const messageEvent = {
+        data: {
+          type: MESSAGE_TYPE.OFFLINE,
+          value: true,
+          message: 'Offline',
+        },
+      };
+
+      mockAddEventListener.mock.calls[0][1](messageEvent);
+    });
+
+    expect(result.current.isOffline).toBe(true);
+  });
+
+  it('should set isOffline to false when receiving an online message', () => {
+    useIsOffline.setState({ isOffline: false });
+
+    const { result } = renderHook(() => useIsOffline());
+    renderHook(() => useOffline());
+
+    act(() => {
+      const messageEvent = {
+        data: {
+          type: MESSAGE_TYPE.OFFLINE,
+          value: false,
+          message: 'Online',
+        },
+      };
+
+      mockAddEventListener.mock.calls[0][1](messageEvent);
+    });
+
+    expect(result.current.isOffline).toBe(false);
+  });
+});

--- a/src/frontend/apps/impress/src/features/service-worker/__tests__/useSWRegister.test.tsx
+++ b/src/frontend/apps/impress/src/features/service-worker/__tests__/useSWRegister.test.tsx
@@ -26,6 +26,7 @@ describe('useSWRegister', () => {
       value: {
         register: registerSpy,
         addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
       },
       writable: true,
     });

--- a/src/frontend/apps/impress/src/features/service-worker/conf.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/conf.ts
@@ -3,14 +3,15 @@ import pkg from '@/../package.json';
 export const SW_DEV_URL = [
   'http://localhost:3000',
   'https://impress.127.0.0.1.nip.io',
-  'https://impress-staging.beta.numerique.gouv.fr',
 ];
 
 export const SW_DEV_API = 'http://localhost:8071';
-
 export const SW_VERSION = `v-${process.env.NEXT_PUBLIC_BUILD_ID}`;
-
 export const DAYS_EXP = 5;
 
 export const getCacheNameVersion = (cacheName: string) =>
   `${pkg.name}-${cacheName}-${SW_VERSION}`;
+
+export const MESSAGE_TYPE = {
+  OFFLINE: 'OFFLINE',
+};

--- a/src/frontend/apps/impress/src/features/service-worker/hooks/useOffline.tsx
+++ b/src/frontend/apps/impress/src/features/service-worker/hooks/useOffline.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { create } from 'zustand';
+
+import { MESSAGE_TYPE } from '../conf';
+
+interface OfflineMessageData {
+  type: string;
+  value: boolean;
+  message: string;
+}
+
+interface IsOfflineState {
+  isOffline: boolean;
+  setIsOffline: (value: boolean) => void;
+}
+
+export const useIsOffline = create<IsOfflineState>((set) => ({
+  isOffline: typeof navigator !== 'undefined' && !navigator.onLine,
+  setIsOffline: (value: boolean) => set({ isOffline: value }),
+}));
+
+export const useOffline = () => {
+  const { setIsOffline } = useIsOffline();
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent<OfflineMessageData>) => {
+      if (event.data?.type === MESSAGE_TYPE.OFFLINE) {
+        setIsOffline(event.data.value);
+      }
+    };
+
+    navigator.serviceWorker?.addEventListener('message', handleMessage);
+
+    return () => {
+      navigator.serviceWorker?.removeEventListener('message', handleMessage);
+    };
+  }, [setIsOffline]);
+};

--- a/src/frontend/apps/impress/src/features/service-worker/hooks/useSWRegister.tsx
+++ b/src/frontend/apps/impress/src/features/service-worker/hooks/useSWRegister.tsx
@@ -30,11 +30,22 @@ export const useSWRegister = () => {
         });
 
       const currentController = navigator.serviceWorker.controller;
-      navigator.serviceWorker.addEventListener('controllerchange', () => {
+      const onControllerChange = () => {
         if (currentController) {
           window.location.reload();
         }
-      });
+      };
+      navigator.serviceWorker.addEventListener(
+        'controllerchange',
+        onControllerChange,
+      );
+
+      return () => {
+        navigator.serviceWorker.removeEventListener(
+          'controllerchange',
+          onControllerChange,
+        );
+      };
     }
   }, []);
 };

--- a/src/frontend/apps/impress/src/features/service-worker/index.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/index.ts
@@ -1,1 +1,2 @@
+export * from './hooks/useOffline';
 export * from './hooks/useSWRegister';

--- a/src/frontend/apps/impress/src/features/service-worker/plugins/ApiPlugin.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/plugins/ApiPlugin.ts
@@ -3,9 +3,9 @@ import { WorkboxPlugin } from 'workbox-core';
 import { Doc, DocsResponse } from '@/docs/doc-management';
 import { LinkReach, LinkRole } from '@/docs/doc-management/types';
 
-import { DBRequest, DocsDB } from './DocsDB';
-import { RequestSerializer } from './RequestSerializer';
-import { SyncManager } from './SyncManager';
+import { DBRequest, DocsDB } from '../DocsDB';
+import { RequestSerializer } from '../RequestSerializer';
+import { SyncManager } from '../SyncManager';
 
 interface OptionsReadonly {
   tableName: 'doc-list' | 'doc-item';

--- a/src/frontend/apps/impress/src/features/service-worker/plugins/OfflinePlugin.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/plugins/OfflinePlugin.ts
@@ -1,0 +1,36 @@
+import { WorkboxPlugin } from 'workbox-core';
+
+import { MESSAGE_TYPE } from '../conf';
+
+declare const self: ServiceWorkerGlobalScope;
+
+export class OfflinePlugin implements WorkboxPlugin {
+  constructor() {}
+
+  postMessage = async (value: boolean, message: string) => {
+    const allClients = await self.clients.matchAll({
+      includeUncontrolled: true,
+    });
+
+    for (const client of allClients) {
+      client.postMessage({
+        type: MESSAGE_TYPE.OFFLINE,
+        value,
+        message,
+      });
+    }
+  };
+
+  /**
+   * Means that the fetch failed (500 is not failed), so often it is a network error.
+   */
+  fetchDidFail: WorkboxPlugin['fetchDidFail'] = async () => {
+    void this.postMessage(true, 'fetchDidFail');
+    return Promise.resolve();
+  };
+
+  fetchDidSucceed: WorkboxPlugin['fetchDidSucceed'] = async ({ response }) => {
+    void this.postMessage(false, 'fetchDidSucceed');
+    return Promise.resolve(response);
+  };
+}

--- a/src/frontend/apps/impress/src/features/service-worker/service-worker-api.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/service-worker-api.ts
@@ -3,10 +3,11 @@ import { ExpirationPlugin } from 'workbox-expiration';
 import { registerRoute } from 'workbox-routing';
 import { NetworkFirst, NetworkOnly } from 'workbox-strategies';
 
-import { ApiPlugin } from './ApiPlugin';
 import { DocsDB } from './DocsDB';
 import { SyncManager } from './SyncManager';
 import { DAYS_EXP, SW_DEV_API, getCacheNameVersion } from './conf';
+import { ApiPlugin } from './plugins/ApiPlugin';
+import { OfflinePlugin } from './plugins/OfflinePlugin';
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -37,6 +38,7 @@ registerRoute(
         type: 'list',
         syncManager,
       }),
+      new OfflinePlugin(),
     ],
   }),
   'GET',
@@ -52,6 +54,7 @@ registerRoute(
         type: 'item',
         syncManager,
       }),
+      new OfflinePlugin(),
     ],
   }),
   'GET',
@@ -66,6 +69,7 @@ registerRoute(
         type: 'update',
         syncManager,
       }),
+      new OfflinePlugin(),
     ],
   }),
   'PATCH',
@@ -79,6 +83,7 @@ registerRoute(
         type: 'create',
         syncManager,
       }),
+      new OfflinePlugin(),
     ],
   }),
   'POST',
@@ -93,6 +98,7 @@ registerRoute(
         type: 'delete',
         syncManager,
       }),
+      new OfflinePlugin(),
     ],
   }),
   'DELETE',
@@ -111,6 +117,7 @@ registerRoute(
         type: 'synch',
         syncManager,
       }),
+      new OfflinePlugin(),
     ],
   }),
   'GET',

--- a/src/frontend/apps/impress/src/features/service-worker/service-worker.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/service-worker.ts
@@ -19,8 +19,9 @@ import {
 } from 'workbox-strategies';
 
 // eslint-disable-next-line import/order
-import { ApiPlugin } from './ApiPlugin';
 import { DAYS_EXP, SW_DEV_URL, SW_VERSION, getCacheNameVersion } from './conf';
+import { ApiPlugin } from './plugins/ApiPlugin';
+import { OfflinePlugin } from './plugins/OfflinePlugin';
 import { isApiUrl } from './service-worker-api';
 
 // eslint-disable-next-line import/order
@@ -154,6 +155,7 @@ registerRoute(
     plugins: [
       new CacheableResponsePlugin({ statuses: [0, 200] }),
       new ExpirationPlugin({ maxAgeSeconds: 24 * 60 * 60 * DAYS_EXP }),
+      new OfflinePlugin(),
     ],
   }),
 );
@@ -170,6 +172,7 @@ registerRoute(
       new ExpirationPlugin({
         maxAgeSeconds: 24 * 60 * 60 * DAYS_EXP,
       }),
+      new OfflinePlugin(),
     ],
   }),
   'GET',
@@ -234,6 +237,20 @@ registerRoute(
       }),
     ],
   }),
+);
+
+/**
+ * External urls post cache strategy
+ * It is interesting to intercept the request
+ * to have a fine grain control about if the user is
+ * online or offline
+ */
+registerRoute(
+  ({ url }) => !url.href.includes(self.location.origin) && !isApiUrl(url.href),
+  new NetworkOnly({
+    plugins: [new OfflinePlugin()],
+  }),
+  'POST',
 );
 
 /**

--- a/src/frontend/apps/impress/src/pages/_app.tsx
+++ b/src/frontend/apps/impress/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 
 import { AppProvider } from '@/core/';
-import { useSWRegister } from '@/features/service-worker/';
+import { useOffline, useSWRegister } from '@/features/service-worker/';
 import '@/i18n/initI18n';
 import { NextPageWithLayout } from '@/types/next';
 
@@ -15,6 +15,7 @@ type AppPropsWithLayout = AppProps & {
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
   useSWRegister();
+  useOffline();
   const getLayout = Component.getLayout ?? ((page) => page);
   const { t } = useTranslation();
 

--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -126,7 +126,7 @@ const DocPage = ({ id }: DocProps) => {
           causes={error.cause}
           icon={
             error.status === 502 ? (
-              <Icon iconName="wifi_off" $theme="danger" />
+              <Icon iconName="wifi_off" $theme="danger" $variation="600" />
             ) : undefined
           }
         />


### PR DESCRIPTION
## Purpose

We can have none connected users who overwrite documents with connected users.
See: https://github.com/suitenumerique/docs/issues/486

## Proposal

If an editor is working on a **shared** document but is not connected to the collaborative server
we are now blocking the edition. 

We are blocking when:
- The user is online (has internet)
- The user is not connected to the collaboration server
- The doc has members or is "public editable" or "auth editable"

---


- [x] 🛂(frontend) block edition to not connected users
- [x] ✈️(frontend) allow editing when offline
- [x] tests


## Demo

In the demo we are not connected to the collaboration server.

[scrnli_pkFb1Rn1YN1lhY.webm](https://github.com/user-attachments/assets/67f6e280-a6c0-46a7-ac3f-77099da7a255)
