### PR TITLE
🐛(tests) override AI feature flag in config test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- 🐛(tests) override AI feature flag in config test #950
+
 ## [3.2.1] - 2025-05-06
 
 ## Fixed

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.django_db
     MEDIA_BASE_URL="http://testserver/",
     POSTHOG_KEY={"id": "132456", "host": "https://eu.i.posthog-test.com"},
     SENTRY_DSN="https://sentry.test/123",
+    AI_FEATURE_ENABLED=False,
 )
 @pytest.mark.parametrize("is_authenticated", [False, True])
 def test_api_config(is_authenticated):
@@ -53,7 +54,10 @@ def test_api_config(is_authenticated):
         ],
         "LANGUAGE_CODE": "en-us",
         "MEDIA_BASE_URL": "http://testserver/",
-        "POSTHOG_KEY": {"id": "132456", "host": "https://eu.i.posthog-test.com"},
+        "POSTHOG_KEY": {
+            "id": "132456",
+            "host": "https://eu.i.posthog-test.com",
+        },
         "SENTRY_DSN": "https://sentry.test/123",
         "AI_FEATURE_ENABLED": False,
     }


### PR DESCRIPTION
The env.d/development/common file sets
AI_FEATURE_ENABLED=true.
When pytest starts it imports these variables, so
the /api/v1.0/config endpoint returns
AI_FEATURE_ENABLED=True and the test_api_config
assertion fails.

Explicitly overriding AI_FEATURE_ENABLED=False in
test_api_config restores the expected behaviour
and makes the whole test-suite green.