### PR TITLE
✨(backend) allow setting session cookie age via env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to
 
 ## Added
 
-- ✨(back) allow theme customnization using a configuration file #948
+- ✨(backend) allow setting session cookie age via env var #977
+- ✨(backend) allow theme customnization using a configuration file #948
 - ✨ Add a custom callout block to the editor #892
 - 🚩(frontend) version MIT only #911
 - ✨(backend) integrate maleware_detection from django-lasuite #936

--- a/docs/env.md
+++ b/docs/env.md
@@ -39,7 +39,7 @@ These are the environment variables you can set for the `impress-backend` contai
 | DJANGO_EMAIL_PORT                               | port used to connect to email host                                                            |                                                         |
 | DJANGO_EMAIL_USE_TLS                            | use tls for email host connection                                                             | false                                                   |
 | DJANGO_EMAIL_USE_SSL                            | use sstl for email host connection                                                            | false                                                   |
-| DJANGO_EMAIL_FROM                               | email address used as sender                                                                   | from@example.com                                        |
+| DJANGO_EMAIL_FROM                               | email address used as sender                                                                  | from@example.com                                        |
 | DJANGO_CORS_ALLOW_ALL_ORIGINS                   | allow all CORS origins                                                                        | true                                                    |
 | DJANGO_CORS_ALLOWED_ORIGINS                     | list of origins allowed for CORS                                                              | []                                                      |
 | DJANGO_CORS_ALLOWED_ORIGIN_REGEXES              | list of origins allowed for CORS using regulair expressions                                   | []                                                      |
@@ -54,12 +54,13 @@ These are the environment variables you can set for the `impress-backend` contai
 | CRISP_WEBSITE_ID                                | crisp website id for support                                                                  |                                                         |
 | DJANGO_CELERY_BROKER_URL                        | celery broker url                                                                             | redis://redis:6379/0                                    |
 | DJANGO_CELERY_BROKER_TRANSPORT_OPTIONS          | celery broker transport options                                                               | {}                                                      |
+| SESSION_COOKIE_AGE                              | duration of the cookie session                                                                | 60*60*12                                                |
 | OIDC_CREATE_USER                                | create used on OIDC                                                                           | false                                                   |
 | OIDC_RP_SIGN_ALGO                               | verification algorithm used OIDC tokens                                                       | RS256                                                   |
 | OIDC_RP_CLIENT_ID                               | client id used for OIDC                                                                       | impress                                                 |
 | OIDC_RP_CLIENT_SECRET                           | client secret used for OIDC                                                                   |                                                         |
 | OIDC_OP_JWKS_ENDPOINT                           | JWKS endpoint for OIDC                                                                        |                                                         |
-| OIDC_OP_AUTHORIZATION_ENDPOINT                  | Authorization endpoint for OIDC                                                                |                                                         |
+| OIDC_OP_AUTHORIZATION_ENDPOINT                  | Authorization endpoint for OIDC                                                               |                                                         |
 | OIDC_OP_TOKEN_ENDPOINT                          | Token endpoint for OIDC                                                                       |                                                         |
 | OIDC_OP_USER_ENDPOINT                           | User endpoint for OIDC                                                                        |                                                         |
 | OIDC_OP_LOGOUT_ENDPOINT                         | Logout endpoint for OIDC                                                                      |                                                         |
@@ -73,7 +74,7 @@ These are the environment variables you can set for the `impress-backend` contai
 | OIDC_REDIRECT_ALLOWED_HOSTS                     | Allowed hosts for OIDC redirect url                                                           | []                                                      |
 | OIDC_STORE_ID_TOKEN                             | Store OIDC token                                                                              | true                                                    |
 | OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION       | faillback to email for identification                                                         | true                                                    |
-| OIDC_ALLOW_DUPLICATE_EMAILS                     | Allow duplicate emails                                                                       | false                                                   |
+| OIDC_ALLOW_DUPLICATE_EMAILS                     | Allow duplicate emails                                                                        | false                                                   |
 | USER_OIDC_ESSENTIAL_CLAIMS                      | essential claims in OIDC token                                                                | []                                                      |
 | OIDC_USERINFO_FULLNAME_FIELDS                   | OIDC token claims to create full name                                                         | ["first_name", "last_name"]                             |
 | OIDC_USERINFO_SHORTNAME_FIELD                   | OIDC token claims to create shortname                                                         | first_name                                              |

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -462,7 +462,9 @@ class Base(Configuration):
     # Session
     SESSION_ENGINE = "django.contrib.sessions.backends.cache"
     SESSION_CACHE_ALIAS = "default"
-    SESSION_COOKIE_AGE = 60 * 60 * 12
+    SESSION_COOKIE_AGE = values.PositiveIntegerValue(
+        default=60 * 60 * 12, environ_name="SESSION_COOKIE_AGE", environ_prefix=None
+    )
 
     # OIDC - Authorization Code Flow
     OIDC_CREATE_USER = values.BooleanValue(


### PR DESCRIPTION

## Purpose

We want to be able to increase the duration of the cookie session.

## Proposal

Add django-configuration IntegerValue to expose the `SESSION_COOKIE_AGE` as an environment variable. 