### PR TITLE
:recycle:(backend) refactored permissions check from BaseAccess serializer to permission class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - ✨(backend) integrate maleware_detection from django-lasuite #936
 - 🩺(CI) add lint spell mistakes #954
 - 🛂(frontend) block edition to not connected users #945
+- ♻️ Refactored permissions check from serializers to permission class #343
 
 ## Changed
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -68,56 +68,10 @@ class BaseAccessSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         """
-        Check access rights specific to writing (create/update)
+        Add the resource ID to the validated data on creation.
         """
-        request = self.context.get("request")
-        user = getattr(request, "user", None)
-        role = attrs.get("role")
-
-        # Update
-        if self.instance:
-            can_set_role_to = self.instance.get_abilities(user)["set_role_to"]
-
-            if role and role not in can_set_role_to:
-                message = (
-                    f"You are only allowed to set role to {', '.join(can_set_role_to)}"
-                    if can_set_role_to
-                    else "You are not allowed to set this role for this template."
-                )
-                raise exceptions.PermissionDenied(message)
-
-        # Create
-        else:
-            try:
-                resource_id = self.context["resource_id"]
-            except KeyError as exc:
-                raise exceptions.ValidationError(
-                    "You must set a resource ID in kwargs to create a new access."
-                ) from exc
-
-            if not self.Meta.model.objects.filter(  # pylint: disable=no-member
-                Q(user=user) | Q(team__in=user.teams),
-                role__in=[models.RoleChoices.OWNER, models.RoleChoices.ADMIN],
-                **{self.Meta.resource_field_name: resource_id},  # pylint: disable=no-member
-            ).exists():
-                raise exceptions.PermissionDenied(
-                    "You are not allowed to manage accesses for this resource."
-                )
-
-            if (
-                role == models.RoleChoices.OWNER
-                and not self.Meta.model.objects.filter(  # pylint: disable=no-member
-                    Q(user=user) | Q(team__in=user.teams),
-                    role=models.RoleChoices.OWNER,
-                    **{self.Meta.resource_field_name: resource_id},  # pylint: disable=no-member
-                ).exists()
-            ):
-                raise exceptions.PermissionDenied(
-                    "Only owners of a resource can assign other users as owners."
-                )
-
-        # pylint: disable=no-member
-        attrs[f"{self.Meta.resource_field_name}_id"] = self.context["resource_id"]
+        if not self.instance:
+            attrs[f"{self.Meta.resource_field_name}_id"] = self.context["resource_id"]
         return attrs
 
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1441,7 +1441,11 @@ class DocumentAccessViewSet(
 
     lookup_field = "pk"
     pagination_class = Pagination
-    permission_classes = [permissions.IsAuthenticated, permissions.AccessPermission]
+    permission_classes = [
+        permissions.IsAuthenticated,
+        permissions.CanManageAccessPermission,
+        permissions.AccessPermission,
+    ]
     queryset = models.DocumentAccess.objects.select_related("user").all()
     resource_field_name = "document"
     serializer_class = serializers.DocumentAccessSerializer
@@ -1613,7 +1617,11 @@ class TemplateAccessViewSet(
 
     lookup_field = "pk"
     pagination_class = Pagination
-    permission_classes = [permissions.IsAuthenticated, permissions.AccessPermission]
+    permission_classes = [
+        permissions.IsAuthenticated,
+        permissions.CanManageAccessPermission,
+        permissions.AccessPermission,
+    ]
     queryset = models.TemplateAccess.objects.select_related("user").all()
     resource_field_name = "template"
     serializer_class = serializers.TemplateAccessSerializer


### PR DESCRIPTION
Extracted access role validation from BaseAccessSerializer into permissions, invoking them in the according viewset.

This PR adresses the following issue: #[343](https://github.com/suitenumerique/docs/issues/343) 