### PR TITLE
fix document converter with large transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 - ✅(frontend) Improve tests coverage
 - ⬆️(docker) upgrade backend image to python 3.13 #973
 - ⬆️(docker) upgrade node images to alpine 3.21
+- 🐛(y-provider) increase JSON size limits for transcription conversion
 
 
 ### Removed

--- a/src/frontend/servers/y-provider/src/servers/appServer.ts
+++ b/src/frontend/servers/y-provider/src/servers/appServer.ts
@@ -21,7 +21,13 @@ import { logger } from '../utils';
  */
 export const initServer = () => {
   const { app } = expressWebsockets(express());
-  app.use(express.json());
+  app.use((req, res, next) => {
+    if (req.path === routes.CONVERT_MARKDOWN) {
+      // Large transcript files are bigger than the default '100kb' limit
+      return express.json({ limit: '500kb' })(req, res, next);
+    }
+    express.json()(req, res, next);
+  });
   app.use(corsMiddleware);
 
   /**


### PR DESCRIPTION
Problem:
- Default Express JSON parser limit (100kb) is insufficient for larger transcription files
- 2-hour audio transcriptions slightly exceed the 100kb limit, causing request failures

Solution:
- Implemented custom middleware to apply different JSON parser configurations based on route
- Applied 500kb limit specifically for transcription conversion endpoints
- Maintained default limits for all other routes to preserve security

Technical notes:
- Could not find a built-in Express solution to specify parser config per route
- Custom middleware conditionally applies the appropriate parser configuration