### PR TITLE
🐛(tilt) update certificate path for Python 3.13 upgrade

### DIFF
--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -96,7 +96,7 @@ backend:
   # Extra volume mounts to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumeMounts:
     - name: certs
-      mountPath: /usr/local/lib/python3.12/site-packages/certifi/cacert.pem
+      mountPath: /usr/local/lib/python3.13/site-packages/certifi/cacert.pem
       subPath: cacert.pem
 
   # Extra volumes to manage our local custom CA and avoid to set ssl_verify: false


### PR DESCRIPTION
Fix certificate directory reference that still pointed to Python 3.12 folder after upgrading to Python 3.13. Resolves certificate verification errors in tilt stack caused by incorrect certificate location.

