### PR TITLE
📌(yjs) stop pinning node to minor version on yjs docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 
 ### Changed
 
+- 📌(yjs) stop pinning node to minor version on yjs docker image #1005
 - 🧑‍💻(docker) add .next to .dockerignore #1055
 - 🧑‍💻(docker) handle frontend development images with docker compose #1033
 - 🧑‍💻(docker) add y-provider config to development environment #1057

--- a/src/frontend/servers/y-provider/Dockerfile
+++ b/src/frontend/servers/y-provider/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.9-alpine AS base
+FROM node:22-alpine AS base
 
 # Upgrade system packages to install security updates
 RUN apk update && \


### PR DESCRIPTION
## Purpose

We want to build the yjs Docker image with the latest minor version in order to avoid outdated images.

## Proposal

Stop pinning node to minor version on yjs docker image
