### PR TITLE
(backend) update migration script to allow setting Django site domain

### DIFF
--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -61,6 +61,8 @@ backend:
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
     Y_PROVIDER_API_BASE_URL: http://impress-y-provider:443/api/
     Y_PROVIDER_API_KEY: my-secret
+    DJANGO_SITE_DOMAIN: example.com
+    DJANGO_SITE_NAME: example
   migrate:
     command:
       - "/bin/sh"

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -233,10 +233,23 @@ backend:
  ## @param backend.migrate.restartPolicy backend migrate job restart policy
   migrate:
     command:
-      - "python"
-      - "manage.py"
-      - "migrate"
-      - "--no-input"
+      - "/bin/sh"
+      - "-c"
+      - |
+        pip install django-extensions
+        python manage.py migrate --no-input
+        python manage.py shell -c "
+        from django.contrib.sites.models import Site
+        import os
+        site_domain = os.environ.get('DJANGO_SITE_DOMAIN', 'example.com')
+        site_name = os.environ.get('DJANGO_SITE_NAME', site_domain)
+        site, created = Site.objects.get_or_create(id=1, defaults={'domain': site_domain, 'name': site_name})
+        if not created:
+            site.domain = site_domain
+            site.name = site_name
+            site.save()
+        print(f'Site updated: {site.domain}')
+        "
     restartPolicy: Never
 
  ## @param backend.createsuperuser.command backend migrate command


### PR DESCRIPTION
## Purpose

Allows setting the Django site domain and name using environment variables. This is to prevent having to manually update the default domain, which is used as the base URL for links shared by email.

## Proposal
Update the migration script that is executed in the Kubernetes Job to update the site_domain after all migrations are applied. It will read the `DJANGO_SITE_DOMAIN` and `DJANGO_SITE_NAME` environment variables if they exist, otherwise it will default back to example.com.
