### PR TITLE
feat: allow disabling posthog from helm

### DIFF
--- a/src/helm/impress/README.md
+++ b/src/helm/impress/README.md
@@ -134,7 +134,7 @@
 | `backend.pdb.enabled`                                 | Enable pdb on backend                                                              | `true`                                                                                                                        |
 | `backend.themeCustomization.enabled`                  | Enable theme customization                                                         | `false`                                                                                                                       |
 | `backend.themeCustomization.file_content`             | Content of the theme customization file. Must be a json object.                    | `""`                                                                                                                          |
-| `backend.themeCustomization.mount_path`               | Path where the customization file will be mounted in the backend deployment.       | `/app/configuration/theme/`                                                                                                   |
+| `backend.themeCustomization.mount_path`               | Path where the customization file will be mounted in the backend deployment.       | `/app/impress/configuration/theme`                                                                                            |
 | `backend.celery.replicas`                             | Amount of celery replicas                                                          | `1`                                                                                                                           |
 | `backend.celery.command`                              | Override the celery container command                                              | `[]`                                                                                                                          |
 | `backend.celery.args`                                 | Override the celery container args                                                 | `["celery","-A","impress.celery_app","worker","-l","INFO","-n","impress@%h"]`                                                 |
@@ -200,6 +200,7 @@
 
 | Name                                   | Description                                                 | Value                     |
 | -------------------------------------- | ----------------------------------------------------------- | ------------------------- |
+| `posthog.enabled`                      | Enable or disable posthog integration                       | `true`                    |
 | `posthog.ingress.enabled`              | Enable or disable the ingress resource creation             | `false`                   |
 | `posthog.ingress.className`            | Kubernetes ingress class name to use (e.g., nginx, traefik) | `nil`                     |
 | `posthog.ingress.host`                 | Primary hostname for the ingress resource                   | `impress.example.com`     |

--- a/src/helm/impress/templates/ingress_posthog.yaml
+++ b/src/helm/impress/templates/ingress_posthog.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.posthog.ingress.enabled -}}
+{{- if and .Values.posthog.enabled .Values.posthog.ingress.enabled -}}
 {{- $fullName := include "impress.fullname" . -}}
 {{- if and .Values.posthog.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.posthog.ingress.annotations "kubernetes.io/ingress.class") }}

--- a/src/helm/impress/templates/ingress_posthog_assets.yaml
+++ b/src/helm/impress/templates/ingress_posthog_assets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.posthog.ingressAssets.enabled -}}
+{{- if and .Values.posthog.enabled .Values.posthog.ingressAssets.enabled -}}
 {{- $fullName := include "impress.fullname" . -}}
 {{- if and .Values.posthog.ingressAssets.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.posthog.ingressAssets.annotations "kubernetes.io/ingress.class") }}

--- a/src/helm/impress/templates/posthog_assets_svc.yaml
+++ b/src/helm/impress/templates/posthog_assets_svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.posthog.ingressAssets.enabled -}}
+{{- if and .Values.posthog.enabled .Values.posthog.ingressAssets.enabled -}}
 {{- $envVars := include "impress.common.env" (list . .Values.posthog) -}}
 {{- $fullName := include "impress.posthog.fullname" . -}}
 {{- $component := "posthog" -}}

--- a/src/helm/impress/templates/posthog_svc.yaml
+++ b/src/helm/impress/templates/posthog_svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.posthog.ingress.enabled -}}
+{{- if and .Values.posthog.enabled .Values.posthog.ingress.enabled -}}
 {{- $envVars := include "impress.common.env" (list . .Values.posthog) -}}
 {{- $fullName := include "impress.posthog.fullname" . -}}
 {{- $component := "posthog" -}}

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -451,6 +451,7 @@ frontend:
 
 posthog:
 
+  ## @param posthog.enabled Enable or disable posthog integration
   ## @param posthog.ingress.enabled Enable or disable the ingress resource creation
   ## @param posthog.ingress.className Kubernetes ingress class name to use (e.g., nginx, traefik)
   ## @param posthog.ingress.host Primary hostname for the ingress resource
@@ -460,6 +461,7 @@ posthog:
   ## @param posthog.ingress.tls.additional Additional TLS configurations for extra hosts/certificates
   ## @param posthog.ingress.customBackends Custom backend service configurations for the ingress
   ## @param posthog.ingress.annotations Additional Kubernetes annotations to apply to the ingress
+  enabled: true
   ingress:
     enabled: false
     className: null


### PR DESCRIPTION
## Purpose
Allow disabling Posthog forwarding completely from helm values, as some people might not need it. 


## Proposal

- By setting `.Values.posthog.enabled` to false, the 2 posthog services and ingresses are disabled.
- By default, posthog is enabled, so no breaking change is introduced.
