### PR TITLE
⬆️(compose) upgrade node image to version 22

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@ services:
     working_dir: /app
 
   node:
-    image: node:18
+    image: node:22
     user: "${DOCKER_USER:-1000}"
     environment:
       HOME: /tmp 


### PR DESCRIPTION
## Purpose

We node service in docker compose can be a helper to use node locally without installing it. Docs requires at least node 22 so we upgrade it to node 22.


## Proposal

- [x] upgrade node image to version 22
