### PR TITLE
🔧(docker) add a service in compose to frontend development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ run-backend: ## Start only the backend application and all needed services
 run: ## start the wsgi (production) and development server
 run: 
 	@$(MAKE) run-backend
-	@$(COMPOSE) up --force-recreate -d frontend
+	@$(COMPOSE) up --force-recreate -d frontend-development
 .PHONY: run
 
 status: ## an alias for "docker compose ps"
@@ -315,7 +315,7 @@ frontend-lint: ## run the frontend linter
 .PHONY: frontend-lint
 
 run-frontend-development: ## Run the frontend in development mode
-	@$(COMPOSE) stop frontend
+	@$(COMPOSE) stop frontend frontend-development
 	cd $(PATH_FRONT_IMPRESS) && yarn dev
 .PHONY: run-frontend-development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,7 +157,23 @@ services:
         API_ORIGIN: "http://localhost:8071"
         PUBLISH_AS_MIT: "false"
         SW_DEACTIVATED: "true"
+    image: impress:frontend-production
+    ports:
+      - "3000:3000"
+
+  frontend-development:
+    user: "${DOCKER_USER:-1000}"
+    build: 
+      context: .
+      dockerfile: ./src/frontend/Dockerfile
+      target: impress-dev
+      args:
+        API_ORIGIN: "http://localhost:8071"
+        PUBLISH_AS_MIT: "false"
+        SW_DEACTIVATED: "true"
     image: impress:frontend-development
+    volumes:
+      - ./src/frontend:/home/frontend
     ports:
       - "3000:3000"
 


### PR DESCRIPTION
## Purpose

We want a serice in compose starting the frontend application in development mode. We want to take the advantage of the hot reload module, so the sources are mounted inside the container.

## Proposal

- [x] 🔧(docker) add a service in compose to frontend development
