### PR TITLE
Allow customized Gaufre

### DIFF
--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -31,6 +31,9 @@ AWS_S3_ACCESS_KEY_ID=impress
 AWS_S3_SECRET_ACCESS_KEY=password
 MEDIA_BASE_URL=http://localhost:8083
 
+# Gaufre
+GAUFREJS_URL=https://integration.lasuite.numerique.gouv.fr/api/v1/gaufre.js
+
 # OIDC
 OIDC_OP_JWKS_ENDPOINT=http://nginx:8083/realms/impress/protocol/openid-connect/certs
 OIDC_OP_AUTHORIZATION_ENDPOINT=http://localhost:8083/realms/impress/protocol/openid-connect/auth

--- a/src/frontend/apps/impress/src/features/header/components/LaGaufre.tsx
+++ b/src/frontend/apps/impress/src/features/header/components/LaGaufre.tsx
@@ -3,6 +3,7 @@ import '@gouvfr-lasuite/integration/dist/css/gaufre.css';
 import Script from 'next/script';
 import React from 'react';
 import { createGlobalStyle } from 'styled-components';
+import { GAUFREJS_URL } from '../conf'
 
 import { useCunninghamTheme } from '@/cunningham';
 
@@ -19,10 +20,12 @@ export const LaGaufre = () => {
     return null;
   }
 
+  const src = GAUFREJS_URL || "https://integration.lasuite.numerique.gouv.fr/api/v1/gaufre.js"
+
   return (
     <>
       <Script
-        src="https://integration.lasuite.numerique.gouv.fr/api/v1/gaufre.js"
+        src={src}
         strategy="lazyOnload"
         id="lasuite-gaufre-script"
       />

--- a/src/frontend/apps/impress/src/features/header/conf.ts
+++ b/src/frontend/apps/impress/src/features/header/conf.ts
@@ -1,1 +1,2 @@
 export const HEADER_HEIGHT = 52;
+export const GAUFREJS_URL = process.env["GAUFREJS_URL"]


### PR DESCRIPTION
In line with https://github.com/suitenumerique/integration/pull/26 and other PRs, it would be nice to not hardcode the Gaufre URL :) 