### PR TITLE
🧑‍💻(docker): add .next to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,3 +34,4 @@ db.sqlite3
 
 # Frontend
 node_modules
+.next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - ✨(frontend) add customization for translations #857
 
+### Changed
+
+- 🧑‍💻(docker): add .next to .dockerignore #1055
+
 ## [3.3.0] - 2025-05-06
 
 ### Added


### PR DESCRIPTION
We don't want to copy this over to the Docker daemon, since this directory can be quite large.