### PR TITLE
🧑‍💻(docker): set image name for y-provider in docker-compose.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - ✨(frontend) add customization for translations #857
 
+### Change
+
+- 🧑‍💻(docker): set image name for y-provider in docker-compose.yml #1056
+
 ## [3.3.0] - 2025-05-06
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,6 +180,7 @@ services:
 
   y-provider:
     user: ${DOCKER_USER:-1000}
+    image: impress:y-provider
     build: 
       context: .
       dockerfile: ./src/frontend/servers/y-provider/Dockerfile


### PR DESCRIPTION
Without this, Podman will not use the built image when starting the project.