### PR TITLE
:memo:(self-hosted) update collaboration vars

### DIFF
--- a/docs/examples/impress.values.yaml
+++ b/docs/examples/impress.values.yaml
@@ -85,7 +85,7 @@ backend:
   # Extra volume to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumeMounts:
     - name: certs
-      mountPath: /usr/local/lib/python3.12/site-packages/certifi/cacert.pem
+      mountPath: /usr/local/lib/python3.13/site-packages/certifi/cacert.pem
       subPath: cacert.pem
 
   # Extra volume to manage our local custom CA and avoid to set ssl_verify: false
@@ -121,6 +121,22 @@ yProvider:
     COLLABORATION_SERVER_ORIGIN: https://impress.127.0.0.1.nip.io
     COLLABORATION_SERVER_SECRET: my-secret
     Y_PROVIDER_API_KEY: my-secret
+    COLLABORATION_BACKEND_BASE_URL: https://impress.127.0.0.1.nip.io
+    NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/cacert.pem
+
+  # Mount the certificate so yProvider can establish tls with the backend
+  extraVolumeMounts:
+    - name: certs
+      mountPath: /usr/local/share/ca-certificates/cacert.pem
+      subPath: cacert.pem
+
+  extraVolumes:
+    - name: certs
+      configMap:
+        name: certifi
+        items:
+        - key: cacert.pem
+          path: cacert.pem
 
 posthog:
   ingress:
@@ -135,9 +151,6 @@ ingress:
 ingressCollaborationWS:
   enabled: true
   host: impress.127.0.0.1.nip.io
-  
-  annotations:
-    nginx.ingress.kubernetes.io/auth-url: https://impress.127.0.0.1.nip.io/api/v1.0/documents/collaboration-auth/
 
 ingressCollaborationApi:
   enabled: true


### PR DESCRIPTION
Remove the `auth-url` annotation and add the
`COLLABORATION_BACKEND_BASE_URL` variable, introduced in 3.0.0.

Mount the development CA to the yProvider container to allow TLS connections with the backend.

## Purpose

The helm charts are outdated as of release 3.0.0. This adds the correct variables and certificates for yProvider when deploying to the example kind cluster.

![Screenshot from 2025-06-15 12-54-00](https://github.com/user-attachments/assets/3b834495-3f70-43a9-8b94-600ca02741ad)
