### PR TITLE
🔧(front) configure x-frame-options to DENY in nginx conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - ✨(frontend) add customization for translations #857
 - 📝(project) add troubleshoot doc #1066
 - 📝(project) add system-requirement doc #1066
+- 🔧(front) configure x-frame-options to DENY in nginx conf #1084
 
 ### Changed
 

--- a/src/frontend/apps/impress/conf/default.conf
+++ b/src/frontend/apps/impress/conf/default.conf
@@ -7,10 +7,14 @@ server {
 
   location / {
       try_files $uri index.html $uri/ =404;
+
+      add_header X-Frame-Options DENY always;
   }
 
   location ~ "^/docs/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/?$" {
       try_files $uri /docs/[id]/index.html;
+
+      add_header X-Frame-Options DENY always;
   }
 
   error_page 404 /404.html;


### PR DESCRIPTION
## Purpose

The API has the reponse header x-frame-options configure to DENY and nothing is configure in the nginx configuring managing the frontend application. We want to have the same value. The header is added on all locations.


## Proposal

- [x] 🔧(front) configure x-frame-options to DENY in nginx conf

Fixes #998 