### PR TITLE
➕(back) install and configure django csp

### DIFF
--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -285,6 +285,7 @@ class Base(Configuration):
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
         "dockerflow.django.middleware.DockerflowMiddleware",
+        "csp.middleware.CSPMiddleware",
     ]
 
     AUTHENTICATION_BACKENDS = [
@@ -318,6 +319,7 @@ class Base(Configuration):
         # OIDC third party
         "mozilla_django_oidc",
         "lasuite.malware_detection",
+        "csp",
     ]
 
     # Cache
@@ -716,6 +718,20 @@ class Base(Configuration):
         environ_name="API_USERS_LIST_LIMIT",
         environ_prefix=None,
     )
+    CONTENT_SECURITY_POLICY = {
+        "EXCLUDE_URL_PREFIXES": values.ListValue(
+            [],
+            environ_name="CONTENT_SECURITY_POLICY_EXCLUDE_URL_PREFIXES",
+            environ_prefix=None,
+        ),
+        "DIRECTIVES": values.DictValue(
+            default={
+                "default-src": ["'none'"],
+            },
+            environ_name="CONTENT_SECURITY_POLICY_DIRECTIVES",
+            environ_prefix=None,
+        ),
+    }
 
     # pylint: disable=invalid-name
     @property

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "django-configurations==2.5.1",
     "django-cors-headers==4.7.0",
     "django-countries==7.6.1",
+    "django-csp==4.0",
     "django-filter==25.1",
     "django-lasuite[all]==0.0.9",
     "django-parler==2.3",


### PR DESCRIPTION
## Purpose

We want to protect all requests from django with c content security policy header. We use the djang-csp library and configure it with default values.



## Proposal

- [x] ➕(back) install and configure django csp

Fixes #1000 