### PR TITLE
🐛(env) update yprovider env for local development

### DIFF
--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -56,11 +56,11 @@ AI_API_KEY=password
 AI_MODEL=llama
 
 # Collaboration
-COLLABORATION_API_URL=http://y-provider:4444/collaboration/api/
+COLLABORATION_API_URL=http://y-provider-development:4444/collaboration/api/
 COLLABORATION_BACKEND_BASE_URL=http://app-dev:8000
 COLLABORATION_SERVER_ORIGIN=http://localhost:3000
 COLLABORATION_SERVER_SECRET=my-secret
 COLLABORATION_WS_URL=ws://localhost:4444/collaboration/ws/
 
-Y_PROVIDER_API_BASE_URL=http://y-provider:4444/api/
+Y_PROVIDER_API_BASE_URL=http://y-provider-development:4444/api/
 Y_PROVIDER_API_KEY=yprovider-api-key

--- a/env.d/development/common.e2e.dist
+++ b/env.d/development/common.e2e.dist
@@ -1,4 +1,6 @@
 # For the CI job test-e2e
 BURST_THROTTLE_RATES="200/minute"
+COLLABORATION_API_URL=http://y-provider:4444/collaboration/api/
 DJANGO_SERVER_TO_SERVER_API_TOKENS=test-e2e
 SUSTAINED_THROTTLE_RATES="200/hour"
+Y_PROVIDER_API_BASE_URL=http://y-provider:4444/api/


### PR DESCRIPTION
## Purpose

In local development the notification to the yprovider server was not working anymore because of a recent change in the container name.
We adapt the env variables to match the new container name.