### PR TITLE
🔥(frontend) remove Beta from logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,16 @@ and this project adheres to
 
 ### Fixed
 
--🐛(frontend) table of content disappearing #982
--🐛(frontend) fix multiple EmojiPicker #1012
--🐛(frontend) fix meta title #1017
--🔧(git) set LF line endings for all text files #1032
--📝(docs) minor fixes to docs/env.md
+- 🐛(frontend) table of content disappearing #982
+- 🐛(frontend) fix multiple EmojiPicker #1012
+- 🐛(frontend) fix meta title #1017
+- 🔧(git) set LF line endings for all text files #1032
+- 📝(docs) minor fixes to docs/env.md
+
+## Removed
+
+- 🔥(frontend) remove Beta from logo #1095
+
 
 ## [3.3.0] - 2025-05-06
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/footer.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/footer.spec.ts
@@ -108,7 +108,6 @@ test.describe('Footer', () => {
     await expect(footer.getByAltText('Gouvernement Logo')).toBeVisible();
 
     await expect(footer.getByRole('heading', { name: 'Docs' })).toBeHidden();
-    await expect(footer.getByText('BETA')).toBeHidden();
 
     await expect(
       footer.getByRole('link', { name: 'legifrance.gouv.fr' }),

--- a/src/frontend/apps/e2e/__tests__/app-impress/home.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/home.spec.ts
@@ -80,7 +80,6 @@ test.describe('Home page', () => {
     ).toBeVisible();
     await expect(header.getByRole('img', { name: 'Docs logo' })).toBeVisible();
     await expect(header.getByRole('heading', { name: 'Docs' })).toBeVisible();
-    await expect(header.getByText('BETA')).toBeVisible();
 
     // Check the titles
     const h2 = page.locator('h2');

--- a/src/frontend/apps/impress/cunningham.ts
+++ b/src/frontend/apps/impress/cunningham.ts
@@ -58,7 +58,6 @@ tokens.themes.default.components = {
   ...{
     'la-gaufre': false,
     'home-proconnect': false,
-    beta: false,
     'image-system-filter': '',
     favicon: {
       ico: '/assets/favicon-light.ico',
@@ -84,7 +83,6 @@ const dsfrTheme = {
     components: {
       'la-gaufre': true,
       'home-proconnect': true,
-      beta: true,
       favicon: {
         ico: '/assets/favicon-dsfr.ico',
         'png-light': '/assets/favicon-dsfr.png',

--- a/src/frontend/apps/impress/src/cunningham/cunningham-tokens.css
+++ b/src/frontend/apps/impress/src/cunningham/cunningham-tokens.css
@@ -489,7 +489,6 @@
   --c--components--badge--info--color: var(--c--theme--colors--info-600);
   --c--components--la-gaufre: false;
   --c--components--home-proconnect: false;
-  --c--components--beta: false;
   --c--components--image-system-filter: ;
   --c--components--favicon--ico: /assets/favicon-light.ico;
   --c--components--favicon--png-light: /assets/favicon-light.png;
@@ -553,7 +552,6 @@
   --c--theme--logo--alt: gouvernement logo;
   --c--components--la-gaufre: true;
   --c--components--home-proconnect: true;
-  --c--components--beta: true;
   --c--components--favicon--ico: /assets/favicon-dsfr.ico;
   --c--components--favicon--png-light: /assets/favicon-dsfr.png;
   --c--components--favicon--png-dark: /assets/favicon-dark-dsfr.png;

--- a/src/frontend/apps/impress/src/cunningham/cunningham-tokens.ts
+++ b/src/frontend/apps/impress/src/cunningham/cunningham-tokens.ts
@@ -365,7 +365,6 @@ export const tokens = {
         },
         'la-gaufre': false,
         'home-proconnect': false,
-        beta: false,
         'image-system-filter': '',
         favicon: {
           ico: '/assets/favicon-light.ico',
@@ -439,7 +438,6 @@ export const tokens = {
       components: {
         'la-gaufre': true,
         'home-proconnect': true,
-        beta: true,
         favicon: {
           ico: '/assets/favicon-dsfr.ico',
           'png-light': '/assets/favicon-dsfr.png',

--- a/src/frontend/apps/impress/src/features/header/components/Title.tsx
+++ b/src/frontend/apps/impress/src/features/header/components/Title.tsx
@@ -1,14 +1,11 @@
 import { useTranslation } from 'react-i18next';
-import { css } from 'styled-components';
 
 import { Box, Text } from '@/components/';
 import { useCunninghamTheme } from '@/cunningham';
 
 export const Title = () => {
   const { t } = useTranslation();
-  const { spacingsTokens, colorsTokens, componentTokens } =
-    useCunninghamTheme();
-  const isBeta = componentTokens['beta'];
+  const { spacingsTokens, colorsTokens } = useCunninghamTheme();
 
   return (
     <Box
@@ -26,28 +23,6 @@ export const Title = () => {
       >
         {t('Docs')}
       </Text>
-      {isBeta && (
-        <Text
-          $padding={{
-            horizontal: '6px',
-            vertical: '4px',
-          }}
-          $size="11px"
-          $theme="primary"
-          $variation="500"
-          $weight="bold"
-          $radius="12px"
-          $css={css`
-            line-height: 9px;
-          `}
-          $width="40px"
-          $height="16px"
-          $background="#ECECFF"
-          $color="#5958D3"
-        >
-          BETA
-        </Text>
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Purpose

Docs got homologated, so we can remove the beta logo from the DSFR theme.

## Proposal

- [x] 🔥(frontend) remove Beta from logo


