### PR TITLE
🔧(back) remove usage of deprecated db engine

### DIFF
--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -76,7 +76,7 @@ class Base(Configuration):
     DATABASES = {
         "default": {
             "ENGINE": values.Value(
-                "django.db.backends.postgresql_psycopg2",
+                "django.db.backends.postgresql",
                 environ_name="DB_ENGINE",
                 environ_prefix=None,
             ),


### PR DESCRIPTION
## Purpose

The db engine postgresql_psycopg2 does not exists anymore in django but for BC compat it is possible to use it in the configuration and it is replace by postgresql at runtime. We changed this settings to use the good one.


## Proposal

- [x] 🔧(back) remove usage of deprecated db engine 
