### PR TITLE
♻️(back) exclude /admin from CSP rules

### DIFF
--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -730,7 +730,7 @@ class Base(Configuration):
     # See https://content-security-policy.com/ for more information.
     CONTENT_SECURITY_POLICY = {
         "EXCLUDE_URL_PREFIXES": values.ListValue(
-            [],
+            ["/admin"],
             environ_name="CONTENT_SECURITY_POLICY_EXCLUDE_URL_PREFIXES",
             environ_prefix=None,
         ),


### PR DESCRIPTION
## Purpose

We have to exclude the /admin prefix to allow loading static files when the django admin is used.

## Proposal

- [x] ♻️(back) exclude /admin from CSP rules