### PR TITLE
♻️(backend) rename `convert_markdown` to `convert`

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -408,9 +408,7 @@ class ServerCreateDocumentSerializer(serializers.Serializer):
             language = user.language or language
 
         try:
-            document_content = YdocConverter().convert_markdown(
-                validated_data["content"]
-            )
+            document_content = YdocConverter().convert(validated_data["content"])
         except ConversionError as err:
             raise serializers.ValidationError(
                 {"content": ["Could not convert content"]}

--- a/src/backend/core/services/converter_services.py
+++ b/src/backend/core/services/converter_services.py
@@ -34,7 +34,7 @@ class YdocConverter:
         # Note: Yprovider microservice accepts only raw token, which is not recommended
         return settings.Y_PROVIDER_API_KEY
 
-    def convert_markdown(self, text):
+    def convert(self, text):
         """Convert a Markdown text into our internal format using an external microservice."""
 
         if not text:

--- a/src/backend/core/tests/documents/test_api_documents_create_for_owner.py
+++ b/src/backend/core/tests/documents/test_api_documents_create_for_owner.py
@@ -23,10 +23,10 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def mock_convert_md():
-    """Mock YdocConverter.convert_markdown to return a converted content."""
+    """Mock YdocConverter.convert to return a converted content."""
     with patch.object(
         YdocConverter,
-        "convert_markdown",
+        "convert",
         return_value="Converted document content",
     ) as mock:
         yield mock

--- a/src/backend/core/tests/test_services_converter_services.py
+++ b/src/backend/core/tests/test_services_converter_services.py
@@ -21,15 +21,15 @@ def test_auth_header(settings):
     assert converter.auth_header == "test-key"
 
 
-def test_convert_markdown_empty_text():
+def test_convert_empty_text():
     """Should raise ValidationError when text is empty."""
     converter = YdocConverter()
     with pytest.raises(ValidationError, match="Input text cannot be empty"):
-        converter.convert_markdown("")
+        converter.convert("")
 
 
 @patch("requests.post")
-def test_convert_markdown_service_unavailable(mock_post):
+def test_convert_service_unavailable(mock_post):
     """Should raise ServiceUnavailableError when service is unavailable."""
     converter = YdocConverter()
 
@@ -39,11 +39,11 @@ def test_convert_markdown_service_unavailable(mock_post):
         ServiceUnavailableError,
         match="Failed to connect to conversion service",
     ):
-        converter.convert_markdown("test text")
+        converter.convert("test text")
 
 
 @patch("requests.post")
-def test_convert_markdown_http_error(mock_post):
+def test_convert_http_error(mock_post):
     """Should raise ServiceUnavailableError when HTTP error occurs."""
     converter = YdocConverter()
 
@@ -55,11 +55,11 @@ def test_convert_markdown_http_error(mock_post):
         ServiceUnavailableError,
         match="Failed to connect to conversion service",
     ):
-        converter.convert_markdown("test text")
+        converter.convert("test text")
 
 
 @patch("requests.post")
-def test_convert_markdown_invalid_json_response(mock_post):
+def test_convert_invalid_json_response(mock_post):
     """Should raise InvalidResponseError when response is not valid JSON."""
     converter = YdocConverter()
 
@@ -71,11 +71,11 @@ def test_convert_markdown_invalid_json_response(mock_post):
         InvalidResponseError,
         match="Could not parse conversion service response",
     ):
-        converter.convert_markdown("test text")
+        converter.convert("test text")
 
 
 @patch("requests.post")
-def test_convert_markdown_missing_content_field(mock_post, settings):
+def test_convert_missing_content_field(mock_post, settings):
     """Should raise MissingContentError when response is missing required field."""
 
     settings.CONVERSION_API_CONTENT_FIELD = "expected_field"
@@ -90,11 +90,11 @@ def test_convert_markdown_missing_content_field(mock_post, settings):
         MissingContentError,
         match="Response missing required field: expected_field",
     ):
-        converter.convert_markdown("test text")
+        converter.convert("test text")
 
 
 @patch("requests.post")
-def test_convert_markdown_full_integration(mock_post, settings):
+def test_convert_full_integration(mock_post, settings):
     """Test full integration with all settings."""
 
     settings.Y_PROVIDER_API_BASE_URL = "http://test.com/"
@@ -110,7 +110,7 @@ def test_convert_markdown_full_integration(mock_post, settings):
     mock_response.json.return_value = {"content": expected_content}
     mock_post.return_value = mock_response
 
-    result = converter.convert_markdown("test markdown")
+    result = converter.convert("test markdown")
 
     assert result == expected_content
     mock_post.assert_called_once_with(
@@ -126,7 +126,7 @@ def test_convert_markdown_full_integration(mock_post, settings):
 
 
 @patch("requests.post")
-def test_convert_markdown_timeout(mock_post):
+def test_convert_timeout(mock_post):
     """Should raise ServiceUnavailableError when request times out."""
     converter = YdocConverter()
 
@@ -136,12 +136,12 @@ def test_convert_markdown_timeout(mock_post):
         ServiceUnavailableError,
         match="Failed to connect to conversion service",
     ):
-        converter.convert_markdown("test text")
+        converter.convert("test text")
 
 
-def test_convert_markdown_none_input():
+def test_convert_none_input():
     """Should raise ValidationError when input is None."""
     converter = YdocConverter()
 
     with pytest.raises(ValidationError, match="Input text cannot be empty"):
-        converter.convert_markdown(None)
+        converter.convert(None)


### PR DESCRIPTION
Renamed the `convert_markdown` method to `convert` to prepare for an all-purpose conversion endpoint, enabling support for multiple formats and simplifying future extension.

## Purpose

Renamed the `convert_markdown` method to `convert` to prepare for an all-purpose conversion endpoint, enabling support for multiple formats and simplifying future extension.

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change) **N/A**
- [x] I have added corresponding tests for new features or bug fixes (if applicable)