### PR TITLE
🔥Available soon

### DIFF
--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
@@ -164,7 +164,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     },
     {
       label: t('Duplicate'),
-      icon: 'call_split',
+      icon: 'content_copy',
       disabled: !doc.abilities.duplicate,
       callback: () => {
         duplicateDoc({

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridActions.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridActions.tsx
@@ -72,7 +72,7 @@ export const DocsGridActions = ({
     },
     {
       label: t('Duplicate'),
-      icon: 'call_split',
+      icon: 'content_copy',
       disabled: !doc.abilities.duplicate,
       callback: () => {
         duplicateDoc({

--- a/src/frontend/apps/impress/src/features/home/components/HomeContent.tsx
+++ b/src/frontend/apps/impress/src/features/home/components/HomeContent.tsx
@@ -221,7 +221,7 @@ export function HomeContent() {
               }
               title={t('A new way to organize knowledge.')}
               tag={t('Organize')}
-              availableSoon={true}
+              availableSoon={false}
               description={t(
                 'Docs transforms your documents into knowledge bases thanks to subpages, powerful search and the ability to pin your important documents.',
               )}


### PR DESCRIPTION
## Purpose

Multipage is available now, so we remove the "Available soon" tag from the home page.


## Proposal

- [x] 🚩(frontend) remove "Available soon" tag about multipage
- [x] 💄(frontend) change icon duplicate feature
