### PR TITLE
📝(compose) Fix command to get fetch pg env variables

### DIFF
--- a/docs/installation/compose.md
+++ b/docs/installation/compose.md
@@ -35,7 +35,7 @@ curl -o compose.yaml https://raw.githubusercontent.com/suitenumerique/docs/refs/
 curl -o env.d/common https://raw.githubusercontent.com/suitenumerique/docs/refs/heads/main/env.d/production.dist/common
 curl -o env.d/backend https://raw.githubusercontent.com/suitenumerique/docs/refs/heads/main/env.d/production.dist/backend
 curl -o env.d/yprovider https://raw.githubusercontent.com/suitenumerique/docs/refs/heads/main/env.d/production.dist/yprovider
-curl -o env.d/common https://raw.githubusercontent.com/suitenumerique/docs/refs/heads/main/env.d/production.dist/postgresql
+curl -o env.d/postgresql https://raw.githubusercontent.com/suitenumerique/docs/refs/heads/main/env.d/production.dist/postgresql
 ```
 
 ## Step 2: Configuration


### PR DESCRIPTION
Minor fix, postgresql variables should be fetched in `env.d/postgresql`not `env.d/common`