### PR TITLE
🐛(frontend) fix unfold subdocs not clickable at the bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to
   in the ws #1152
 - 🐛(frontend) fix action buttons not clickable #1162
 - 🐛(frontend) fix crash share modal on grid options #1174
+- 🐛(frontend) fix unfold subdocs not clickable at the bottom #1179
 
 ## [3.4.0] - 2025-07-09
 

--- a/src/frontend/apps/impress/src/cunningham/cunningham-style.css
+++ b/src/frontend/apps/impress/src/cunningham/cunningham-style.css
@@ -51,6 +51,17 @@
   filter: var(--c--components--image-system-filter);
 }
 
+/**
+* Toast
+*/
+.c__toast__container {
+  z-index: -1;
+}
+
+.c__toast__container:has(.c__toast) {
+  z-index: 10000;
+}
+
 @font-face {
   font-family: Inter;
   font-style: italic;


### PR DESCRIPTION
## Purpose

At the bottom of the tree panel, the subdocs were not clickable due to a CSS issue.
This commit adjusts the CSS to ensure that the subdocs can be unfolded properly.

## Demo


https://github.com/user-attachments/assets/e265b983-eada-4938-ab1e-d3eea351c4a0

