### PR TITLE
♻️(frontend) search on all docs if no children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 ### Changed
 
+- ♻️(frontend) search on all docs if no children #1184
 - ♻️(frontend) redirect to doc after duplicate #1175
 - 🔧(project) change env.d system by using local files #1200
 - ⚡️(frontend) improve tree stability #1207

--- a/src/frontend/apps/impress/src/features/docs/doc-management/hooks/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useCollaboration';
 export * from './useCopyDocLink';
+export * from './useDocUtils';
 export * from './useIsCollaborativeEditable';
 export * from './useTrans';

--- a/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useDocUtils.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useDocUtils.tsx
@@ -1,9 +1,10 @@
 import { Doc } from '@/docs/doc-management';
 
-export const useTreeUtils = (doc: Doc) => {
+export const useDocUtils = (doc: Doc) => {
   return {
     isTopRoot: doc.depth === 1,
     isChild: doc.depth > 1,
+    hasChildren: doc.numchild > 0,
     isDesynchronized: !!(
       doc.ancestors_link_reach &&
       (doc.computed_link_reach !== doc.ancestors_link_reach ||

--- a/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchModal.tsx
@@ -7,9 +7,9 @@ import { useDebouncedCallback } from 'use-debounce';
 
 import { Box } from '@/components';
 import { QuickSearch } from '@/components/quick-search';
+import { Doc, useDocUtils } from '@/docs/doc-management';
 import { useResponsiveStore } from '@/stores';
 
-import { Doc } from '../../doc-management';
 import EmptySearchIcon from '../assets/illustration-docs-empty.png';
 
 import { DocSearchContent } from './DocSearchContent';
@@ -20,18 +20,18 @@ import {
 } from './DocSearchFilters';
 import { DocSearchSubPageContent } from './DocSearchSubPageContent';
 
-type DocSearchModalProps = {
+type DocSearchModalGlobalProps = {
   onClose: () => void;
   isOpen: boolean;
   showFilters?: boolean;
   defaultFilters?: DocSearchFiltersValues;
 };
 
-export const DocSearchModal = ({
+const DocSearchModalGlobal = ({
   showFilters = false,
   defaultFilters,
   ...modalProps
-}: DocSearchModalProps) => {
+}: DocSearchModalGlobalProps) => {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
 
@@ -125,4 +125,43 @@ export const DocSearchModal = ({
       </Box>
     </Modal>
   );
+};
+
+type DocSearchModalDetailProps = DocSearchModalGlobalProps & {
+  doc: Doc;
+};
+
+const DocSearchModalDetail = ({
+  doc,
+  ...modalProps
+}: DocSearchModalDetailProps) => {
+  const { hasChildren, isChild } = useDocUtils(doc);
+  const isWithChildren = isChild || hasChildren;
+
+  let defaultFilters = DocSearchTarget.ALL;
+  let showFilters = false;
+  if (isWithChildren) {
+    defaultFilters = DocSearchTarget.CURRENT;
+    showFilters = true;
+  }
+
+  return (
+    <DocSearchModalGlobal
+      {...modalProps}
+      showFilters={showFilters}
+      defaultFilters={{ target: defaultFilters }}
+    />
+  );
+};
+
+type DocSearchModalProps = DocSearchModalGlobalProps & {
+  doc?: Doc;
+};
+
+export const DocSearchModal = ({ doc, ...modalProps }: DocSearchModalProps) => {
+  if (doc) {
+    return <DocSearchModalDetail doc={doc} {...modalProps} />;
+  }
+
+  return <DocSearchModalGlobal {...modalProps} />;
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocVisibility.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocVisibility.tsx
@@ -17,9 +17,9 @@ import {
   LinkReach,
   LinkRole,
   getDocLinkReach,
+  useDocUtils,
   useUpdateDocLink,
 } from '@/docs/doc-management';
-import { useTreeUtils } from '@/docs/doc-tree';
 import { useResponsiveStore } from '@/stores';
 
 import { useTranslatedShareSettings } from '../hooks/';
@@ -37,7 +37,7 @@ export const DocVisibility = ({ doc }: DocVisibilityProps) => {
   const canManage = doc.abilities.accesses_manage;
   const docLinkReach = getDocLinkReach(doc);
   const docLinkRole = doc.computed_link_role ?? LinkRole.READER;
-  const { isDesynchronized } = useTreeUtils(doc);
+  const { isDesynchronized } = useDocUtils(doc);
   const { linkModeTranslations, linkReachChoices, linkReachTranslations } =
     useTranslatedShareSettings();
 

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/hooks/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './useTreeUtils';

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/index.ts
@@ -1,4 +1,3 @@
 export * from './api';
 export * from './components';
-export * from './hooks';
 export * from './utils';

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelHeader.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelHeader.tsx
@@ -3,7 +3,8 @@ import { useRouter } from 'next/router';
 import { PropsWithChildren, useCallback, useState } from 'react';
 
 import { Box, Icon, SeparatedSection } from '@/components';
-import { DocSearchModal, DocSearchTarget } from '@/docs/doc-search/';
+import { useDocStore } from '@/docs/doc-management';
+import { DocSearchModal } from '@/docs/doc-search/';
 import { useAuth } from '@/features/auth';
 import { useCmdK } from '@/hook/useCmdK';
 
@@ -12,10 +13,9 @@ import { useLeftPanelStore } from '../stores';
 import { LeftPanelHeaderButton } from './LeftPanelHeaderButton';
 
 export const LeftPanelHeader = ({ children }: PropsWithChildren) => {
+  const { currentDoc } = useDocStore();
   const router = useRouter();
   const { authenticated } = useAuth();
-  const isDoc = router.pathname === '/docs/[id]';
-
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
 
   const openSearchModal = useCallback(() => {
@@ -81,10 +81,7 @@ export const LeftPanelHeader = ({ children }: PropsWithChildren) => {
         <DocSearchModal
           onClose={closeSearchModal}
           isOpen={isSearchModalOpen}
-          showFilters={isDoc}
-          defaultFilters={{
-            target: isDoc ? DocSearchTarget.CURRENT : undefined,
-          }}
+          doc={currentDoc}
         />
       )}
     </>


### PR DESCRIPTION
## Purpose

When searching for documents, if no children are found, the search will now include all documents instead of just those with children.

## Proposal

- [x] ♻️(frontend) search on all docs if no children
