### PR TITLE
💄(frontend) visibility icon near title

### DIFF
--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
@@ -27,8 +27,7 @@ export const DocsGridItem = ({ doc, dragMode = false }: DocsGridItemProps) => {
   const shareModal = useModal();
   const isPublic = doc.link_reach === LinkReach.PUBLIC;
   const isAuthenticated = doc.link_reach === LinkReach.AUTHENTICATED;
-
-  const showAccesses = isPublic || isAuthenticated;
+  const isShared = isPublic || isAuthenticated;
 
   const handleShareClick = () => {
     shareModal.open();
@@ -67,12 +66,11 @@ export const DocsGridItem = ({ doc, dragMode = false }: DocsGridItemProps) => {
             $direction="row"
             $align="center"
             $gap={spacingsTokens.xs}
-            $flex={flexLeft}
             $padding={{ right: isDesktop ? 'md' : '3xs' }}
             $maxWidth="100%"
           >
             <SimpleDocItem isPinned={doc.is_favorite} doc={doc} />
-            {showAccesses && (
+            {isShared && (
               <Box
                 $padding={{ top: !isDesktop ? '4xs' : undefined }}
                 $css={


### PR DESCRIPTION
## Purpose

It was decided to add a visibility icon near the title of the document in the grid view.

## Demo

### Before 
<img width="2010" height="340" alt="f8673bec-1971-4986-99a1-d490beed9f43" src="https://github.com/user-attachments/assets/83c36df5-a1da-40f2-8059-17f74db8ba70" />

### After

<img width="1045" height="390" alt="image" src="https://github.com/user-attachments/assets/7dc03473-3299-4573-8308-a7bf953ea282" />

