### PR TITLE
🐛(backend) improve prompt to not use code blocks delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to
 
 - ⚡️(docker) Optimize Dockerfile to use apk with --no-cache #743
 
+### Fixed
+
+- 🐛(backend) improve prompt to not use code blocks delimiter #1188
+
+
 ## [3.4.1] - 2025-07-15
 
 ### Fixed
@@ -31,7 +36,7 @@ and this project adheres to
 - ✨Ask for access #1081
 - ✨(frontend) add customization for translations #857
 - ✨(backend) add ancestors links definitions to document abilities #846
-- ✨(backend) include ancestors accesses on document accesses list view # 846
+- ✨(backend) include ancestors accesses on document accesses list view #846
 - ✨(backend) add ancestors links reach and role to document API #846
 - 📝(project) add troubleshoot doc #1066
 - 📝(project) add system-requirement doc #1066

--- a/src/backend/core/services/ai_services.py
+++ b/src/backend/core/services/ai_services.py
@@ -9,7 +9,8 @@ from core import enums
 
 AI_ACTIONS = {
     "prompt": (
-        "Answer the prompt in markdown format. "
+        "Answer the prompt using markdown formatting for structure and emphasis. "
+        "Return the content directly without wrapping it in code blocks or markdown delimiters. "
         "Preserve the language and markdown formatting. "
         "Do not provide any other information. "
         "Preserve the language."

--- a/src/backend/core/tests/documents/test_api_documents_ai_transform.py
+++ b/src/backend/core/tests/documents/test_api_documents_ai_transform.py
@@ -175,8 +175,11 @@ def test_api_documents_ai_transform_authenticated_success(mock_create, reach, ro
             {
                 "role": "system",
                 "content": (
-                    "Answer the prompt in markdown format. Preserve the language and markdown "
-                    "formatting. Do not provide any other information. Preserve the language."
+                    "Answer the prompt using markdown formatting for structure and emphasis. "
+                    "Return the content directly without wrapping it in code blocks or markdown delimiters. "
+                    "Preserve the language and markdown formatting. "
+                    "Do not provide any other information. "
+                    "Preserve the language."
                 ),
             },
             {"role": "user", "content": "Hello"},
@@ -249,8 +252,11 @@ def test_api_documents_ai_transform_success(mock_create, via, role, mock_user_te
             {
                 "role": "system",
                 "content": (
-                    "Answer the prompt in markdown format. Preserve the language and markdown "
-                    "formatting. Do not provide any other information. Preserve the language."
+                    "Answer the prompt using markdown formatting for structure and emphasis. "
+                    "Return the content directly without wrapping it in code blocks or markdown delimiters. "
+                    "Preserve the language and markdown formatting. "
+                    "Do not provide any other information. "
+                    "Preserve the language."
                 ),
             },
             {"role": "user", "content": "Hello"},


### PR DESCRIPTION
## Purpose

The AI answer was activating the code block feature in the editor, which was not desired.

## Proposal

The prompt for AI actions has been updated to instruct the AI to return content directly without wrapping it in code blocks or markdown delimiters.