### PR TITLE
:memo:(typo) fix link to kubernetes.md in compose.md

### DIFF
--- a/docs/installation/compose.md
+++ b/docs/installation/compose.md
@@ -1,6 +1,6 @@
 # Installation with docker compose
 
-We provide a sample configuration for running Docs using Docker Compose. Please note that this configuration is experimental, and the official way to deploy Docs in production is to use [k8s](../installation/k8s.md)
+We provide a sample configuration for running Docs using Docker Compose. Please note that this configuration is experimental, and the official way to deploy Docs in production is to use [k8s](../installation/kubernetes.md)
 
 ## Requirements
 


### PR DESCRIPTION
## Purpose

This commit fixes a typo in `docs/installation/compose.md`, where a link was wrongly pointing to `k8s.md` while it should have been pointing to `kubernetes.md`.

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)