### PR TITLE
🐛(frontend) 401 redirection overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 
 - 🐛(service-worker) Fix useOffline Maximum update depth exceeded #1196
 - 🐛(helm) charts generate invalid YAML for collaboration API / WS #890
+- 🐛(frontend) 401 redirection overridden #1214
 
 ## [3.4.2] - 2025-07-18
 

--- a/src/frontend/apps/impress/src/features/docs/doc-management/api/useUpdateDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/api/useUpdateDoc.tsx
@@ -52,10 +52,16 @@ export function useUpdateDoc(queryConfig?: UseUpdateDoc) {
         void queryConfig.onSuccess(data, variables, context);
       }
     },
-    onError: () => {
+    onError: (error, variables, context) => {
+      // If error it means the user is probably not allowed to edit the doc
+      // so we invalidate the canEdit query to update the UI accordingly
       void queryClient.invalidateQueries({
         queryKey: [KEY_CAN_EDIT],
       });
+
+      if (queryConfig?.onError) {
+        queryConfig.onError(error, variables, context);
+      }
     },
   });
 }


### PR DESCRIPTION
## Purpose

To capture a 401 we were using `onError` in the queryClient default mutation options. 
The problem is this way does not capture globally the `onError`, if a mutation uses as well is own `onError`, it will override the default one, causing the 401 to not be captured anymore.

## Proposal

We now use [MutationCache](https://tanstack.com/query/latest/docs/reference/MutationCache), which allows us to capture globally the `onError`, even if a mutation has its own `onError` defined, this global one will still be called.