### PR TITLE
Fix/link contrast editor

### DIFF
--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -108,50 +108,6 @@ export const cssEditor = (readonly: boolean) => css`
       border-left: 4px solid var(--c--theme--colors--greyscale-300);
       font-style: italic;
     }
-
-    /**
-    * Lists - Fix contrast issues for BlockNote bullet points
-    * Only target cases where text color matches background color (problematic contrast)
-    */
-
-    /* Red background with red text - fix contrast */
-    .bn-block[data-background-color='red'][data-text-color='red']
-      .bn-block-content[data-content-type='bulletListItem'],
-    .bn-block.bg-red-500[data-text-color='red']
-      .bn-block-content[data-content-type='bulletListItem'] {
-      color: #990000 !important;
-    }
-
-    /* Yellow background with yellow text - fix contrast */
-    .bn-block[data-background-color='yellow'][data-text-color='yellow']
-      .bn-block-content[data-content-type='bulletListItem'],
-    .bn-block.bg-yellow-500[data-text-color='yellow']
-      .bn-block-content[data-content-type='bulletListItem'] {
-      color: #8b6914 !important;
-    }
-
-    /* Orange background with orange text - fix contrast */
-    .bn-block[data-background-color='orange'][data-text-color='orange']
-      .bn-block-content[data-content-type='bulletListItem'],
-    .bn-block.bg-orange-500[data-text-color='orange']
-      .bn-block-content[data-content-type='bulletListItem'] {
-      color: #a0522d !important;
-    }
-
-    /* Ensure text inside list items inherits the corrected color */
-    .bn-block-content[data-content-type='bulletListItem'] .bn-inline-content {
-      color: inherit !important;
-    }
-
-    /* Override any inline styles that might be applied */
-    .bn-block-content[data-content-type='bulletListItem'] .bn-inline-content * {
-      color: inherit !important;
-    }
-
-    /* Keep links readable but ensure they don't inherit problematic colors */
-    .bn-block-content[data-content-type='bulletListItem'] .bn-inline-content a {
-      color: var(--c--theme--colors--greyscale-700) !important;
-    }
   }
 
   & .bn-block-outer:not(:first-child) {


### PR DESCRIPTION
## Purpose

Improve text accessibility by enhancing the contrast of links on colored backgrounds.

## Proposal

- Changed link color from greyscale-500 to greyscale-700 to make it easier to read on colored backgrounds.
 
- Tried to fix the case where text color === background color (like red on red) using CSS overrides.
 
- But it didn’t work, because BlockNote.js uses inline styles that are too strong to override.
 
- We may need to fix this directly inside BlockNote.js to allow better control of contrast for colored texts.l

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)


<img width="1152" height="648" alt="link" src="https://github.com/user-attachments/assets/ef4733e4-ad36-44ad-a117-f13faafd1036" />
