### PR TITLE
♿(frontend) improve contrast for links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - ♻️(frontend) redirect to doc after duplicate #1175
 - 🔧(project) change env.d system by using local files #1200
 - ⚡️(frontend) improve tree stability #1207
+- ⚡️(frontend) improve accessibility #1232
 
 ### Fixed
 
@@ -45,7 +46,7 @@ and this project adheres to
 ### Fixed
 
 - 🌐(frontend) keep simple tag during export #1154
-- 🐛(back) manage can-edit endpoint without created room 
+- 🐛(back) manage can-edit endpoint without created room
   in the ws #1152
 - 🐛(frontend) fix action buttons not clickable #1162
 - 🐛(frontend) fix crash share modal on grid options #1174
@@ -65,11 +66,11 @@ and this project adheres to
 - 📝(project) add troubleshoot doc #1066
 - 📝(project) add system-requirement doc #1066
 - 🔧(frontend) configure x-frame-options to DENY in nginx conf #1084
-- ✨(backend) allow to disable checking unsafe mimetype on 
+- ✨(backend) allow to disable checking unsafe mimetype on
   attachment upload #1099
 - ✨(doc) add documentation to install with compose #855
-- ✨ Give priority to users connected to collaboration server 
-  (aka no websocket feature) #1093 
+- ✨ Give priority to users connected to collaboration server
+  (aka no websocket feature) #1093
 
 ### Changed
 
@@ -94,7 +95,6 @@ and this project adheres to
 ### Removed
 
 - 🔥(frontend) remove Beta from logo #1095
-
 
 ## [3.3.0] - 2025-05-06
 
@@ -121,12 +121,12 @@ and this project adheres to
 - ⬆️(docker) upgrade node images to alpine 3.21 #973
 
 ### Fixed
+
 - 🐛(y-provider) increase JSON size limits for transcription conversion #989
 
 ### Removed
 
 - 🔥(back) remove footer endpoint #948
-
 
 ## [3.2.1] - 2025-05-06
 
@@ -134,7 +134,6 @@ and this project adheres to
 
 - 🐛(frontend) fix list copy paste #943
 - 📝(doc) update contributing policy (commit signatures are now mandatory) #895
-
 
 ## [3.2.0] - 2025-05-05
 
@@ -146,7 +145,7 @@ and this project adheres to
 - ✨(settings) Allow configuring PKCE for the SSO #886
 - 🌐(i18n) activate chinese and spanish languages #884
 - 🔧(backend) allow overwriting the data directory #893
-- ➕(backend) add  `django-lasuite` dependency #839
+- ➕(backend) add `django-lasuite` dependency #839
 - ✨(frontend) advanced table features #908
 
 ## Changed
@@ -197,7 +196,6 @@ and this project adheres to
 - 🐛(backend) compute ancestor_links in get_abilities if needed #725
 - 🔒️(back) restrict access to document accesses #801
 
-
 ## [2.6.0] - 2025-03-21
 
 ## Added
@@ -215,7 +213,6 @@ and this project adheres to
 - 🔒️(backend) require at least 5 characters to search for users #636
 - 🔒️(back) throttle user list endpoint #636
 - 🔒️(back) remove pagination and limit to 5 for user list endpoint #636
-
 
 ## [2.5.0] - 2025-03-18
 
@@ -239,14 +236,13 @@ and this project adheres to
 ## Fixed
 
 - 🐛(frontend) SVG export #706
-- 🐛(frontend) remove scroll listener table content  #688
+- 🐛(frontend) remove scroll listener table content #688
 - 🔒️(back) restrict access to favorite_list endpoint #690
-- 🐛(backend) refactor to fix filtering on children 
-    and descendants views #695
+- 🐛(backend) refactor to fix filtering on children
+  and descendants views #695
 - 🐛(action) fix notify-argocd workflow #713
 - 🚨(helm) fix helmfile lint #736
 - 🚚(frontend) redirect to 401 page when 401 error #759
-
 
 ## [2.4.0] - 2025-03-06
 
@@ -261,7 +257,6 @@ and this project adheres to
 ## Fixed
 
 - 🐛(frontend) fix collaboration error #684
-
 
 ## [2.3.0] - 2025-03-03
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -88,7 +88,7 @@ export const cssEditor = (readonly: boolean) => css`
       font-size: 1.25rem;
     }
     a {
-      color: var(--c--theme--colors--greyscale-500);
+      color: var(--c--theme--colors--greyscale-600);
       cursor: pointer;
     }
     .bn-block-group


### PR DESCRIPTION
## Purpose

Improve text accessibility by enhancing the contrast of links on colored backgrounds.

## Proposal

- Changed link color from greyscale-500 to greyscale-600 to make it easier to read on colored backgrounds as suggested in the issue
.

- Tried to fix the case where text color === background color (like red on red) using CSS overrides.
 
- But it didn’t work, because BlockNote.js uses inline styles that are too strong to override.
 
- We may need to fix this directly inside BlockNote.js to allow better control of contrast for colored texts.l
 

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)

<img width="1152" height="648" alt="link" src="https://github.com/user-attachments/assets/5f4c8d77-a79e-426d-b9a6-519df09a8eb4" />
