### PR TITLE
♿(frontend) inject language attribute to pdf export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ⚡️(frontend) improve accessibility:
+  - #1248
+  - #1235
+
 ## [3.5.0] - 2025-07-31
 
 ### Added
@@ -25,9 +31,7 @@ and this project adheres to
 - ♻️(frontend) redirect to doc after duplicate #1175
 - 🔧(project) change env.d system by using local files #1200
 - ⚡️(frontend) improve tree stability #1207
-- ⚡️(frontend) improve accessibility
-  - #1232
-  - #1248
+- ⚡️(frontend) improve accessibility #1232
 - 🛂(frontend) block drag n drop when not desktop #1239
 
 ### Fixed

--- a/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
@@ -10,7 +10,8 @@ import {
   useToastProvider,
 } from '@openfun/cunningham-react';
 import { DocumentProps, pdf } from '@react-pdf/renderer';
-import { useMemo, useState } from 'react';
+import i18next from 'i18next';
+import { cloneElement, isValidElement, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
@@ -92,9 +93,14 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
       const exporter = new PDFExporter(editor.schema, pdfDocsSchemaMappings, {
         resolveFileUrl: async (url) => exportCorsResolveFileUrl(doc.id, url),
       });
-      const pdfDocument = (await exporter.toReactPDFDocument(
+      const rawPdfDocument = (await exporter.toReactPDFDocument(
         exportDocument,
       )) as React.ReactElement<DocumentProps>;
+
+      // Inject language for screen reader support
+      const pdfDocument = isValidElement(rawPdfDocument)
+        ? cloneElement(rawPdfDocument, { language: i18next.language })
+        : rawPdfDocument;
 
       blobExport = await pdf(pdfDocument).toBlob();
     } else {


### PR DESCRIPTION
## Purpose

This PR improves the accessibility of exported PDF documents by explicitly setting the document language to fr-FR as suggested in the issue [1133](https://github.com/suitenumerique/docs/issues/1133)

This ensures proper pronunciation by screen readers (e.g. VoiceOver, NVDA), especially for homographs like “mobile” that differ between French and English.

## Proposal

- [x] Inject language="fr-FR" into the <Document /> element returned by toReactPDFDocument() using cloneElement()
- [x] Add inline comment explaining the purpose (screen reader compatibility)

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)