### PR TITLE
🐛(frontend) include root parent in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to
 - 🐛(frontend) fix empty left panel after deleting root doc #1197
 - 🐛(helm) charts generate invalid YAML for collaboration API / WS #890
 - 🐛(frontend) 401 redirection overridden #1214
+- 🐛(frontend) include root parent in search #1243
 
 ## [3.4.2] - 2025-07-18
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-search.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-search.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { createDoc, randomName, verifyDocName } from './utils-common';
+import { createDoc, verifyDocName } from './utils-common';
 import { createRootSubPage } from './utils-sub-pages';
 
 test.beforeEach(async ({ page }) => {
@@ -163,20 +163,12 @@ test.describe('Document search', () => {
     await verifyDocName(page, firstDocTitle);
 
     // Create a new doc - for the moment without children
-    await page.getByRole('button', { name: 'New doc' }).click();
-    await verifyDocName(page, '');
-    await page.getByRole('textbox', { name: 'doc title input' }).click();
-    await page
-      .getByRole('textbox', { name: 'doc title input' })
-      .press('ControlOrMeta+a');
-    const [secondDocTitle] = randomName(
+    const [secondDocTitle] = await createDoc(
+      page,
       'My second sub page search',
       browserName,
       1,
     );
-    await page
-      .getByRole('textbox', { name: 'doc title input' })
-      .fill(secondDocTitle);
 
     const searchButton = page
       .getByTestId('left-panel-desktop')
@@ -199,15 +191,22 @@ test.describe('Document search', () => {
     await page.getByRole('button', { name: 'close' }).click();
 
     // Create a sub page
-    await createRootSubPage(page, browserName, secondDocTitle);
+    const { name: secondChildDocTitle } = await createRootSubPage(
+      page,
+      browserName,
+      'second - Child doc',
+    );
     await searchButton.click();
     await page
       .getByRole('combobox', { name: 'Quick search input' })
-      .fill('sub page search');
+      .fill('second');
 
     // Now there is a sub page - expect to have the focus on the current doc
     await expect(
       page.getByRole('presentation').getByLabel(secondDocTitle),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('presentation').getByLabel(secondChildDocTitle),
     ).toBeVisible();
     await expect(
       page.getByRole('presentation').getByLabel(firstDocTitle),

--- a/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchSubPageContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchSubPageContent.tsx
@@ -45,6 +45,16 @@ export const DocSearchSubPageContent = ({
   const docsData: QuickSearchData<Doc> = useMemo(() => {
     const subDocs = subDocsData?.pages.flatMap((page) => page.results) || [];
 
+    if (treeContext?.root) {
+      const isRootTitleIncludeSearch = treeContext.root?.title
+        ?.toLowerCase()
+        .includes(search.toLowerCase());
+
+      if (isRootTitleIncludeSearch) {
+        subDocs.unshift(treeContext.root);
+      }
+    }
+
     return {
       groupName: subDocs.length > 0 ? t('Select a page') : '',
       elements: search ? subDocs : [],
@@ -57,7 +67,13 @@ export const DocSearchSubPageContent = ({
           ]
         : [],
     };
-  }, [search, subDocsData, subDocsFetchNextPage, subDocsHasNextPage]);
+  }, [
+    search,
+    subDocsData?.pages,
+    subDocsFetchNextPage,
+    subDocsHasNextPage,
+    treeContext?.root,
+  ]);
 
   useEffect(() => {
     onLoadingChange?.(loading);


### PR DESCRIPTION
## Purpose

The root parent was not included in the search.

## Proposal

When searching for documents, the root parent document is now included in the search results if it matches the search query.
