### PR TITLE
🌐(frontend) set html lang attribute dynamically based on current loc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to
 - ♻️(frontend) redirect to doc after duplicate #1175
 - 🔧(project) change env.d system by using local files #1200
 - ⚡️(frontend) improve tree stability #1207
-- ⚡️(frontend) improve accessibility #1232
+- ⚡️(frontend) improve accessibility
+  - #1232
+  - #1248
 - 🛂(frontend) block drag n drop when not desktop #1239
 
 ### Fixed

--- a/src/frontend/apps/e2e/__tests__/app-impress/language.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/language.spec.ts
@@ -26,6 +26,8 @@ test.describe.serial('Language', () => {
   test('checks language switching', async ({ page }) => {
     const header = page.locator('header').first();
 
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-us');
+
     // initial language should be english
     await expect(
       page.getByRole('button', {
@@ -35,6 +37,8 @@ test.describe.serial('Language', () => {
 
     // switch to french
     await waitForLanguageSwitch(page, TestLanguage.French);
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
 
     await expect(
       header.getByRole('button').getByText('Français'),
@@ -47,6 +51,8 @@ test.describe.serial('Language', () => {
     await expect(header.getByRole('button').getByText('Deutsch')).toBeVisible();
 
     await expect(page.getByLabel('Abmelden')).toBeVisible();
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'de');
   });
 
   test('checks that backend uses the same language as the frontend', async ({

--- a/src/frontend/apps/impress/src/i18n/config.ts
+++ b/src/frontend/apps/impress/src/i18n/config.ts
@@ -1,0 +1,1 @@
+export const fallbackLng = 'en';

--- a/src/frontend/apps/impress/src/i18n/initI18n.ts
+++ b/src/frontend/apps/impress/src/i18n/initI18n.ts
@@ -2,6 +2,7 @@ import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
+import { fallbackLng } from './config';
 import resources from './translations.json';
 
 // Add an initialization guard
@@ -16,7 +17,7 @@ if (!isInitialized && !i18next.isInitialized) {
     .use(initReactI18next)
     .init({
       resources,
-      fallbackLng: 'en',
+      fallbackLng,
       debug: false,
       detection: {
         order: ['cookie', 'navigator'],
@@ -34,6 +35,17 @@ if (!isInitialized && !i18next.isInitialized) {
       lowerCaseLng: true,
       nsSeparator: false,
       keySeparator: false,
+    })
+    .then(() => {
+      if (typeof document !== 'undefined') {
+        document.documentElement.setAttribute(
+          'lang',
+          i18next.language || fallbackLng,
+        );
+        i18next.on('languageChanged', (lang) => {
+          document.documentElement.setAttribute('lang', lang);
+        });
+      }
     })
     .catch((e) => console.error('i18n initialization failed:', e));
 }

--- a/src/frontend/apps/impress/src/pages/_document.tsx
+++ b/src/frontend/apps/impress/src/pages/_document.tsx
@@ -1,13 +1,33 @@
-import { Head, Html, Main, NextScript } from 'next/document';
+import Document, {
+  DocumentContext,
+  Head,
+  Html,
+  Main,
+  NextScript,
+} from 'next/document';
 
-export default function RootLayout() {
-  return (
-    <Html>
-      <Head />
-      <body suppressHydrationWarning={process.env.NODE_ENV === 'development'}>
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
+import { fallbackLng } from '../i18n/config';
+
+class MyDocument extends Document<{ locale: string }> {
+  static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return {
+      ...initialProps,
+      locale: ctx.locale || fallbackLng,
+    };
+  }
+
+  render() {
+    return (
+      <Html lang={this.props.locale}>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }
+
+export default MyDocument;


### PR DESCRIPTION
## Purpose

Add a new HtmlLangUpdater component to dynamically update the <html lang> attribute based on the current locale from i18next. This improves accessibility.

issue : [875](https://github.com/suitenumerique/docs/issues/875)

## Proposal

- [x]  Create HtmlLangUpdater component using useTranslation and useEffect
- [x]  Integrate HtmlLangUpdater in the main app and document.tsx layout


https://github.com/user-attachments/assets/ba8d01d9-c3c6-4c94-bd9e-b01892558fd1



## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)