### PR TITLE
♻️(documentation) remove unused environment variables

### DIFF
--- a/docs/examples/helm/impress.values.yaml
+++ b/docs/examples/helm/impress.values.yaml
@@ -46,9 +46,6 @@ backend:
     DB_USER: dinum
     DB_PASSWORD: pass
     DB_PORT: 5432
-    POSTGRES_DB: impress
-    POSTGRES_USER: dinum
-    POSTGRES_PASSWORD: pass
     REDIS_URL: redis://default:pass@redis-master:6379/1
     AWS_S3_ENDPOINT_URL: http://minio.impress.svc.cluster.local:9000
     AWS_S3_ACCESS_KEY_ID: root

--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -168,9 +168,6 @@ DB_NAME: impress
 DB_USER: dinum
 DB_PASSWORD: pass
 DB_PORT: 5432
-POSTGRES_DB: impress
-POSTGRES_USER: dinum
-POSTGRES_PASSWORD: pass
 ```
 
 ### Find s3 bucket connection values

--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -50,9 +50,6 @@ backend:
     DB_USER: dinum
     DB_PASSWORD: pass
     DB_PORT: 5432
-    POSTGRES_DB: impress
-    POSTGRES_USER: dinum
-    POSTGRES_PASSWORD: pass
     REDIS_URL: redis://default:pass@redis-master:6379/1
     DJANGO_CELERY_BROKER_URL: redis://default:pass@redis-master:6379/1
     AWS_S3_ENDPOINT_URL: http://minio.impress.svc.cluster.local:9000


### PR DESCRIPTION
Yesterday during a deployment, we discovered that these variables are unused:
POSTGRES_DB
POSTGRES_USER
POSTGRES_PASSWORD