### PR TITLE
🤡(e2e) mock PATCH language switch

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-export.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-export.spec.ts
@@ -484,8 +484,6 @@ test.describe('Doc Export', () => {
     const pdfString = pdfBuffer.toString('latin1');
 
     expect(pdfString).toContain('/Lang (fr)');
-
-    await waitForLanguageSwitch(page, TestLanguage.English);
   });
 
   test('it exports the doc with interlinking', async ({

--- a/src/frontend/apps/e2e/__tests__/app-impress/language.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/language.spec.ts
@@ -1,26 +1,10 @@
-import { Page, expect, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 import { TestLanguage, createDoc, waitForLanguageSwitch } from './utils-common';
 
-test.describe.serial('Language', () => {
-  let page: Page;
-
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
-  });
-
-  test.afterAll(async () => {
-    await page.close();
-  });
-
+test.describe('Language', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await waitForLanguageSwitch(page, TestLanguage.English);
-  });
-
-  test.afterEach(async ({ page }) => {
-    // Switch back to English - important for other tests to run as expected
-    await waitForLanguageSwitch(page, TestLanguage.English);
   });
 
   test('checks language switching', async ({ page }) => {


### PR DESCRIPTION
## Purpose

We add some flaky tests because the aria label selectors were not everytime in english language.
It was because the language switch was not mocked in the e2e tests, impacting the consistency of other concurrent tests.

## Proposal

We mock the language switch in the e2e tests to ensure that the other tests are not impacted by the language switch.