### PR TITLE
⚡️(ci) use setup-python cache option

### DIFF
--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -23,9 +23,10 @@ jobs:
         uses: actions/checkout@v4
       # Backend i18n
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13.3"
+          cache: "pip"
       - name: Upgrade pip and setuptools
         run: pip install --upgrade pip setuptools
       - name: Install development dependencies

--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -89,9 +89,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13.3"
+          cache: "pip"
       - name: Upgrade pip and setuptools
         run: pip install --upgrade pip setuptools
       - name: Install development dependencies
@@ -184,9 +185,10 @@ jobs:
             mc version enable impress/impress-media-storage"
 
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13.3"
+          cache: "pip"
 
       - name: Install development dependencies
         run: pip install --user .[dev]


### PR DESCRIPTION
## Purpose

The setup-python action is able to cache the dependencies and reuse this cache while the pyproject file has not changed. It is easy to setup, just the package manager used has to be declared in the cache settings.

## Proposal

- [x] ⚡️(ci) use setup-python cache option