### PR TITLE
🐛(back) allow / and = characters in user sub field

### DIFF
--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -137,21 +137,21 @@ class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
     """User model to work with OIDC only authentication."""
 
     sub_validator = validators.RegexValidator(
-        regex=r"^[\w.@+-:]+\Z",
+        regex=r"^[\w.@+-:=/]+\Z",
         message=_(
             "Enter a valid sub. This value may contain only letters, "
-            "numbers, and @/./+/-/_/: characters."
+            "numbers, and @.+-_:=/ characters."
         ),
     )
 
     sub = models.CharField(
         _("sub"),
         help_text=_(
-            "Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_/: characters only."
+            "Required. 255 characters or fewer. Letters, numbers, and @.+-_:=/ characters only."
         ),
         max_length=255,
-        unique=True,
         validators=[sub_validator],
+        unique=True,
         blank=True,
         null=True,
     )

--- a/src/backend/core/tests/test_models_users.py
+++ b/src/backend/core/tests/test_models_users.py
@@ -44,3 +44,27 @@ def test_models_users_send_mail_main_missing():
         user.email_user("my subject", "my message")
 
     assert str(excinfo.value) == "User has no email address."
+
+
+@pytest.mark.parametrize(
+    "sub,is_valid",
+    [
+        ("valid_sub.@+-:=/", True),
+        ("invalid sub", False),
+    ],
+)
+def test_models_users_sub_validator(sub, is_valid):
+    """The "sub" field should be validated."""
+    user = factories.UserFactory()
+    user.sub = sub
+    if is_valid:
+        user.full_clean()
+    else:
+        with pytest.raises(
+            ValidationError,
+            match=(
+                "Enter a valid sub. This value may contain only letters,"
+                " numbers, and @.+-_:=/ characters."
+            ),
+        ):
+            user.full_clean()


### PR DESCRIPTION
## Purpose

We want to keep a restricted list of allowed characters in the user sub field. We allow now the = and /


## Proposal

- [x] 🐛(back) allow / and = characters in user sub field

Fix #1280