### PR TITLE
🐛(backend) allow creator to delete subpages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to
 - 🐛(minio) fix user permission error with Minio and Windows #1264
 - 🐛(frontend) fix export when quote block and inline code #1319
 - 🐛(frontend) fix base64 font #1324
+- 🐛(backend) allow editor to delete subpages #1296
 
 ## [3.5.0] - 2025-07-31
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -753,6 +753,12 @@ class Document(MP_Node, BaseModel):
         can_update = (
             is_owner_or_admin or role == RoleChoices.EDITOR
         ) and not is_deleted
+        can_create_children = can_update and user.is_authenticated
+        can_destroy = (
+            is_owner
+            if self.is_root()
+            else (is_owner_or_admin or (user.is_authenticated and self.creator == user))
+        )
 
         ai_allow_reach_from = settings.AI_ALLOW_REACH_FROM
         ai_access = any(
@@ -775,11 +781,11 @@ class Document(MP_Node, BaseModel):
             "media_check": can_get,
             "can_edit": can_update,
             "children_list": can_get,
-            "children_create": can_update and user.is_authenticated,
+            "children_create": can_create_children,
             "collaboration_auth": can_get,
             "cors_proxy": can_get,
             "descendants": can_get,
-            "destroy": is_owner,
+            "destroy": can_destroy,
             "duplicate": can_get and user.is_authenticated,
             "favorite": can_get and user.is_authenticated,
             "link_configuration": is_owner_or_admin,

--- a/src/backend/core/tests/documents/test_api_documents_retrieve.py
+++ b/src/backend/core/tests/documents/test_api_documents_retrieve.py
@@ -494,7 +494,7 @@ def test_api_documents_retrieve_authenticated_related_parent():
             "collaboration_auth": True,
             "descendants": True,
             "cors_proxy": True,
-            "destroy": access.role == "owner",
+            "destroy": access.role in ["administrator", "owner"],
             "duplicate": True,
             "favorite": True,
             "invite_owner": access.role == "owner",


### PR DESCRIPTION
## Purpose

An editor who created a subpages should be allowed to delete it.
We change the abilities to be coherent between the creation and the
deletion.


## Proposal

- [x] 🐛(backend) allow editor to delete subpages

Fixes #1193