### PR TITLE
♻️(backend) fallback to email identifier when no name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
   - #1244
   - #1270
   - #1282
+- ♻️(backend) fallback to email identifier when no name #1298
 
 ### Fixed
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -7,6 +7,7 @@ from base64 import b64decode
 from django.conf import settings
 from django.db.models import Q
 from django.utils.functional import lazy
+from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
 import magic
@@ -32,10 +33,29 @@ class UserSerializer(serializers.ModelSerializer):
 class UserLightSerializer(UserSerializer):
     """Serialize users with limited fields."""
 
+    full_name = serializers.SerializerMethodField(read_only=True)
+    short_name = serializers.SerializerMethodField(read_only=True)
+
     class Meta:
         model = models.User
         fields = ["full_name", "short_name"]
         read_only_fields = ["full_name", "short_name"]
+
+    def get_full_name(self, instance):
+        """Return the full name of the user."""
+        if not instance.full_name:
+            email = instance.email.split("@")[0]
+            return slugify(email)
+
+        return instance.full_name
+
+    def get_short_name(self, instance):
+        """Return the short name of the user."""
+        if not instance.short_name:
+            email = instance.email.split("@")[0]
+            return slugify(email)
+
+        return instance.short_name
 
 
 class TemplateAccessSerializer(serializers.ModelSerializer):

--- a/src/backend/core/tests/serializers/test_user_light_serializer.py
+++ b/src/backend/core/tests/serializers/test_user_light_serializer.py
@@ -1,0 +1,44 @@
+"""Test user light serializer."""
+
+import pytest
+
+from core import factories
+from core.api.serializers import UserLightSerializer
+
+pytestmark = pytest.mark.django_db
+
+
+def test_user_light_serializer():
+    """Test user light serializer."""
+    user = factories.UserFactory(
+        email="test@test.com",
+        full_name="John Doe",
+        short_name="John",
+    )
+    serializer = UserLightSerializer(user)
+    assert serializer.data["full_name"] == "John Doe"
+    assert serializer.data["short_name"] == "John"
+
+
+def test_user_light_serializer_no_full_name():
+    """Test user light serializer without full name."""
+    user = factories.UserFactory(
+        email="test_foo@test.com",
+        full_name=None,
+        short_name="John",
+    )
+    serializer = UserLightSerializer(user)
+    assert serializer.data["full_name"] == "test_foo"
+    assert serializer.data["short_name"] == "John"
+
+
+def test_user_light_serializer_no_short_name():
+    """Test user light serializer without short name."""
+    user = factories.UserFactory(
+        email="test_foo@test.com",
+        full_name=None,
+        short_name=None,
+    )
+    serializer = UserLightSerializer(user)
+    assert serializer.data["full_name"] == "test_foo"
+    assert serializer.data["short_name"] == "test_foo"


### PR DESCRIPTION
## Purpose

In the UserlightSerializer, if the user has no short_name or full_name, we have no info about the user. We decided to use the email identifier and slugify it to have a little bit information.


## Proposal

- [x] ♻️(backend) fallback to email identifier when no name

Fix #1210