### PR TITLE
Enhance cors_proxy endpoint

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1481,10 +1481,10 @@ class DocumentViewSet(
             return proxy_response
 
         except requests.RequestException as e:
-            logger.error("Proxy request failed: %s", str(e))
-            return drf_response.Response(
-                {"error": f"Failed to fetch resource: {e!s}"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            logger.exception(e)
+            return drf.response.Response(
+                {"error": f"Failed to fetch resource from {url}"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
 


### PR DESCRIPTION
## Purpose

Validate the url parameters and don't return information when the fetched url is failing.


## Proposal

- [x] ♻️(back) validate url used in cors_proxy endpoint
- [x] ♻️(back) stop returning a 500 on cors_proxy on request failure
