### PR TITLE
🐛(frontend) remove padding from ul in left panel favorites

### DIFF
--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFavorites.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFavorites.tsx
@@ -49,6 +49,7 @@ export const LeftPanelFavorites = () => {
           hasMore={docs.hasNextPage}
           isLoading={docs.isFetchingNextPage}
           next={() => void docs.fetchNextPage()}
+          $padding="none"
         >
           {favoriteDocs.map((doc) => (
             <LeftPanelFavoriteItem key={doc.id} doc={doc} />


### PR DESCRIPTION
## Purpose

We recently change from a `div` to a `ul` for better semantics. `ul` include by default padding, we remove it to
align with the design.

## Proposal

<img width="335" height="539" alt="image" src="https://github.com/user-attachments/assets/b531622d-dbe5-4212-8c2f-bb7573870e0f" />