### PR TITLE
🐛(frontend) fix export when quote block and inline code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to
 
 - 🐛(makefile) Windows compatibility fix for Docker volume mounting #1264
 - 🐛(minio) fix user permission error with Minio and Windows #1264
+- 🐛(frontend) fix export when quote block and inline code #1319
 
 ## [3.5.0] - 2025-07-31
 

--- a/src/frontend/apps/impress/src/features/docs/doc-export/mappingDocx.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/mappingDocx.tsx
@@ -24,4 +24,16 @@ export const docxDocsSchemaMappings: DocsExporterDocx['mappings'] = {
     interlinkingSearchInline: () => new Paragraph(''),
     interlinkingLinkInline: inlineContentMappingInterlinkingLinkDocx,
   },
+  styleMapping: {
+    ...docxDefaultSchemaMappings.styleMapping,
+    // Switch to core PDF "Courier" font to avoid relying on GeistMono
+    // that is not available in italics
+    code: (enabled?: boolean) =>
+      enabled
+        ? {
+            font: 'Courier New',
+            shading: { fill: 'DCDCDC' },
+          }
+        : {},
+  },
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-export/mappingPDF.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/mappingPDF.tsx
@@ -29,4 +29,11 @@ export const pdfDocsSchemaMappings: DocsExporterPDF['mappings'] = {
     interlinkingSearchInline: () => <></>,
     interlinkingLinkInline: inlineContentMappingInterlinkingLinkPDF,
   },
+  styleMapping: {
+    ...pdfDefaultSchemaMappings.styleMapping,
+    // Switch to core PDF "Courier" font to avoid relying on GeistMono
+    // that is not available in italics
+    code: (enabled?: boolean) =>
+      enabled ? { fontFamily: 'Courier', backgroundColor: '#dcdcdc' } : {},
+  },
 };


### PR DESCRIPTION
## Purpose

When exporting documents, if a inline code was inside a quote block, the PDF export was failing because the inline code was searching the GeistMono font in italics, which was not available.

## Proposal

We switch to the core "Courier" font for code marks, which is available in italics.
