### PR TITLE
🔧(ci) always run all git-lint steps

### DIFF
--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -25,14 +25,18 @@ jobs:
       - name: show
         run: git log
       - name: Enforce absence of print statements in code
+        if: always()
         run: |
           ! git diff origin/${{ github.event.pull_request.base.ref }}..HEAD -- . ':(exclude)**/impress.yml' | grep "print("
       - name: Check absence of fixup commits
+        if: always()
         run: |
           ! git log | grep 'fixup!'
       - name: Install gitlint
+        if: always()
         run: pip install --user requests gitlint
       - name: Lint commit messages added to main
+        if: always()
         run: ~/.local/bin/gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
 
   check-changelog:


### PR DESCRIPTION
## Purpose

git-lint steps are independant and we would like to have all checks at once. Using the `if: always()` instruction should ensure all steps should be run event if the previous fails.


## Proposal

- [x] 🔧(ci) always run all git-lint steps