### PR TITLE
⚡️(frontend) improve export table width calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
   - #1282
 - ♻️(backend) fallback to email identifier when no name #1298
 - 🐛(backend) allow ASCII characters in user sub field #1295 
+- ⚡️(frontend) improve fallback width calculation #1333
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-export/__tests__/TablePDF.test.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/__tests__/TablePDF.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { utilTable } from '../blocks-mapping/tablePDF';
+
+/**
+ * Tests for utilTable utility.
+ * Scenarios covered:
+ *  - All widths specified and below full width
+ *  - Mix of known / unknown widths (fallback distribution)
+ *  - All widths unknown
+ *  - Widths exceeding full table width (clamping & scale=100)
+ *  - Sum exceeding full width without unknowns (no division by zero side-effects)
+ */
+
+describe('utilTable', () => {
+  it('returns unchanged widths and correct scale when all widths are known and below full width', () => {
+    const input = [165, 200];
+    const { columnWidths, tableScale } = utilTable(730, input);
+    expect(columnWidths).toEqual(input); // unchanged
+    expect(tableScale).toBe(50);
+  });
+
+  it('distributes fallback width equally among unknown columns', () => {
+    const input: (number | undefined)[] = [100, undefined, 200, undefined];
+    const { columnWidths, tableScale } = utilTable(730, input);
+    expect(columnWidths).toEqual([100, 215, 200, 215]);
+    expect(tableScale).toBe(100); // fills full width exactly
+  });
+
+  it('handles all columns unknown', () => {
+    const input: (number | undefined)[] = [undefined, undefined];
+    const { columnWidths, tableScale } = utilTable(730, input);
+    expect(columnWidths).toEqual([365, 365]);
+    expect(tableScale).toBe(100);
+  });
+
+  it('clamps total width to full width when sum exceeds it (single large column)', () => {
+    const input = [800];
+    const { columnWidths, tableScale } = utilTable(730, input);
+    expect(columnWidths).toEqual([800]);
+    expect(tableScale).toBe(100);
+  });
+
+  it('clamps total width to full width when multiple columns exceed it', () => {
+    const input = [500, 300]; // sum = 800 > 730
+    const { columnWidths, tableScale } = utilTable(730, input);
+    expect(columnWidths).toEqual([500, 300]);
+    expect(tableScale).toBe(100);
+  });
+
+  it('does not assign fallback when there are no unknown widths (avoid division by zero impact)', () => {
+    const input = [400, 400];
+    const { columnWidths, tableScale } = utilTable(730, input);
+    expect(columnWidths).toEqual([400, 400]);
+    expect(tableScale).toBe(100);
+  });
+
+  it('computes proportional scale with custom fullWidth', () => {
+    const input = [100, 200]; // total 300
+    const { columnWidths, tableScale } = utilTable(1000, input);
+    expect(columnWidths).toEqual([100, 200]);
+    expect(tableScale).toBe(30);
+  });
+});


### PR DESCRIPTION
## Purpose

Sometimes we do not have the width of some columns in a table. In such cases, we need to calculate a fallback width to ensure the table is rendered correctly.

## Proposal

We were previously using 120 points as the fallback width, but this has been improved to better fit the content.
We now check the size left and distribute it among the unknown columns.

## Demo

### Before:
<img width="850" height="687" alt="image" src="https://github.com/user-attachments/assets/d54276ce-b670-4c72-85c4-bec78903ae23" />

### After
<img width="880" height="572" alt="image" src="https://github.com/user-attachments/assets/42c2c8f3-848d-4b8a-be49-680e673e8a3e" />
