### PR TITLE
✨(frontend) improve placeholder contrast in blocknote for wcag compli…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ and this project adheres to
   - ♿️(frontend) keyboard interaction with menu #1244
   - ♿(frontend) improve header accessibility #1270
   - ♿(frontend) improve accessibility for decorative images in editor #1282
+  - #1338
 - ♻️(backend) fallback to email identifier when no name #1298
-- 🐛(backend) allow ASCII characters in user sub field #1295 
+- 🐛(backend) allow ASCII characters in user sub field #1295
 - ⚡️(frontend) improve fallback width calculation #1333
 
 ### Fixed

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -7,6 +7,19 @@ export const cssEditor = (readonly: boolean) => css`
     height: 100%;
     padding-bottom: 2rem;
 
+    /**
+     * WCAG Accessibility contrast fixes for BlockNote editor
+     */
+    .bn-block-content[data-is-empty-and-focused][data-content-type='paragraph']
+      .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {
+      color: #767676 !important;
+      font-weight: 400;
+    }
+
+    .bn-side-menu .mantine-UnstyledButton-root svg {
+      color: #767676 !important;
+    }
+
     img.bn-visual-media[src*='-unsafe'] {
       pointer-events: none;
     }


### PR DESCRIPTION
## Purpose

This PR introduces accessibility fixes for placeholder contrast in the BlockNote editor.
The goal is to ensure WCAG compliance while waiting for the fix from BlockNote

this solves this issues : [1304](https://github.com/suitenumerique/docs/issues/1304#event-19389584094) & [1303](https://github.com/suitenumerique/docs/issues/1303#event-19389590295)

<img width="892" height="235" alt="1160 contrast" src="https://github.com/user-attachments/assets/3860c1bc-f016-413b-82bf-88f154b7c7df" />


Create issue on BlockNote side : [here](https://github.com/TypeCellOS/BlockNote/issues/1983)

## Proposal
- [x]  Create accessibility-fixes file with WCAG contrast improvements
- [x] Improve placeholder text and side menu icon contrast (4.5:1 minimum)
- [x]  Provide a quick win for users while awaiting BlockNote PR acceptance
