### PR TITLE
✨(frontend) unify tab focus style for better visual consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
-### Added 
+- ⚡️(frontend) improve accessibility:
+  - #1341
+
+### Added
 
 - ✨(api) add API route to fetch document content #1206
 

--- a/src/frontend/apps/impress/src/components/DropButton.tsx
+++ b/src/frontend/apps/impress/src/components/DropButton.tsx
@@ -28,17 +28,18 @@ const StyledButton = styled(Button)<StyledButtonProps>`
   border: none;
   background: none;
   outline: none;
-  transition: all 0.2s ease-in-out;
   font-weight: 500;
   font-size: 0.938rem;
   padding: 0;
   ${({ $css }) => $css};
-
+  &:hover {
+    background-color: var(
+      --c--components--button--primary-text--background--color-hover
+    );
+  }
   &:focus-visible {
-    outline: 2px solid var(--c--theme--colors--primary-500);
-    outline-offset: 2px;
+    box-shadow: 0 0 0 2px var(--c--theme--colors--primary-400);
     border-radius: 4px;
-    transition: none;
   }
 `;
 

--- a/src/frontend/apps/impress/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/frontend/apps/impress/src/components/dropdown-menu/DropdownMenu.tsx
@@ -207,14 +207,13 @@ export const DropdownMenu = ({
                   }
 
                   &:focus-visible {
-                    outline: 2px solid var(--c--theme--colors--primary-500);
+                    outline: 2px solid var(--c--theme--colors--primary-400);
                     outline-offset: -2px;
                     background-color: var(--c--theme--colors--greyscale-050);
                   }
 
                   ${isFocused &&
                   css`
-                    outline: 2px solid var(--c--theme--colors--primary-500);
                     outline-offset: -2px;
                     background-color: var(--c--theme--colors--greyscale-050);
                   `}

--- a/src/frontend/apps/impress/src/features/auth/components/ButtonLogin.tsx
+++ b/src/frontend/apps/impress/src/features/auth/components/ButtonLogin.tsx
@@ -2,7 +2,8 @@ import { Button } from '@openfun/cunningham-react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
-import { BoxButton } from '@/components';
+import { Box, BoxButton } from '@/components';
+import { useCunninghamTheme } from '@/cunningham';
 
 import ProConnectImg from '../assets/button-proconnect.svg';
 import { useAuth } from '../hooks';
@@ -11,6 +12,7 @@ import { gotoLogin, gotoLogout } from '../utils';
 export const ButtonLogin = () => {
   const { t } = useTranslation();
   const { authenticated } = useAuth();
+  const { colorsTokens } = useCunninghamTheme();
 
   if (!authenticated) {
     return (
@@ -26,14 +28,23 @@ export const ButtonLogin = () => {
   }
 
   return (
-    <Button
-      onClick={gotoLogout}
-      color="primary-text"
-      aria-label={t('Logout')}
-      className="--docs--button-logout"
+    <Box
+      $css={css`
+        .--docs--button-logout:focus-visible {
+          box-shadow: 0 0 0 2px ${colorsTokens['primary-400']} !important;
+          border-radius: 4px;
+        }
+      `}
     >
-      {t('Logout')}
-    </Button>
+      <Button
+        onClick={gotoLogout}
+        color="primary-text"
+        aria-label={t('Logout')}
+        className="--docs--button-logout"
+      >
+        {t('Logout')}
+      </Button>
+    </Box>
   );
 };
 

--- a/src/frontend/apps/impress/src/features/header/components/Header.tsx
+++ b/src/frontend/apps/impress/src/features/header/components/Header.tsx
@@ -43,6 +43,13 @@ export const Header = () => {
         href="/"
         data-testid="header-logo-link"
         aria-label={t('Back to homepage')}
+        $css={css`
+          outline: none;
+          &:focus-visible {
+            box-shadow: 0 0 0 2px var(--c--theme--colors--primary-400) !important;
+            border-radius: 4px;
+          }
+        `}
       >
         <Box
           $align="center"

--- a/src/frontend/apps/impress/src/features/language/components/LanguagePicker.tsx
+++ b/src/frontend/apps/impress/src/features/language/components/LanguagePicker.tsx
@@ -41,15 +41,7 @@ export const LanguagePicker = () => {
       showArrow
       label={t('Select language')}
       buttonCss={css`
-        &:hover {
-          background-color: var(
-            --c--components--button--primary-text--background--color-hover
-          );
-        }
-        &:focus-visible {
-          outline: 2px solid var(--c--theme--colors--primary-500);
-          outline-offset: 2px;
-        }
+        transition: all 0.15s ease-in-out !important;
         border-radius: 4px;
         padding: 0.5rem 0.6rem;
         & > div {

--- a/src/frontend/apps/impress/src/features/left-panel/components/LefPanelTargetFilters.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LefPanelTargetFilters.tsx
@@ -85,8 +85,9 @@ export const LeftPanelTargetFilters = () => {
                 background-color: ${colorsTokens['greyscale-100']};
               }
               &:focus-visible {
-                outline: 2px solid ${colorsTokens['primary-500']};
-                outline-offset: 2px;
+                outline: none !important;
+                box-shadow: 0 0 0 2px ${colorsTokens['primary-500']} !important;
+                border-radius: 4px;
               }
             `}
           >

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFavoriteItem.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFavoriteItem.tsx
@@ -31,19 +31,15 @@ export const LeftPanelFavoriteItem = ({ doc }: LeftPanelFavoriteItemProps) => {
         .pinned-actions {
           opacity: ${isDesktop ? 0 : 1};
         }
-        &:hover,
+        &:hover {
+          background-color: ${colorsTokens['greyscale-100']};
+        }
         &:focus-within {
           cursor: pointer;
-
-          background-color: var(--c--theme--colors--greyscale-100);
+          box-shadow: 0 0 0 2px ${colorsTokens['primary-500']} !important;
           .pinned-actions {
             opacity: 1;
           }
-        }
-        &:focus-visible {
-          outline: 2px solid ${colorsTokens['primary-500']};
-          outline-offset: 2px;
-          border-radius: ${spacingsTokens['3xs']};
         }
       `}
       key={doc.id}
@@ -51,7 +47,10 @@ export const LeftPanelFavoriteItem = ({ doc }: LeftPanelFavoriteItemProps) => {
     >
       <StyledLink
         href={`/docs/${doc.id}`}
-        $css="overflow: auto;"
+        $css={css`
+          overflow: auto;
+          outline: none !important;
+        `}
         aria-label={`${doc.title}, ${t('Updated')} ${DateTime.fromISO(doc.updated_at).toRelative()}`}
       >
         <SimpleDocItem showAccesses doc={doc} />


### PR DESCRIPTION
standardizes keyboard focus appearance to improve UI coherence

## Purpose

This pull request unifies the focus style only in the header and the left panel.
It replaces default outlines with box-shadow and border-radius to deliver a
smoother, less abrupt experience for keyboard users.

⚠️ The main documentation page are excluded,
as they will be part of a broader accessibility rework in a future PR.

## Proposal
- [x] Replace focus outlines with box-shadow for header and left panel elements
- [x] Apply consistent border-radius to improve visual feedback
- [x] Enhance keyboard navigation aesthetics
- [x] Exclude pinned docs and central doc page (pending future a11y overhaul)