### PR TITLE
💄(frontend) remove margin from modal title

### DIFF
--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/ModalConfirmDownloadUnsafe.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/ModalConfirmDownloadUnsafe.tsx
@@ -54,6 +54,7 @@ export const ModalConfirmDownloadUnsafe = ({
           $align="flex-start"
           $variation="1000"
           $direction="row"
+          $margin="0"
         >
           <Icon iconName="warning" $theme="warning" />
           {t('Warning')}

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
@@ -146,6 +146,7 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
               $align="flex-start"
               $size="small"
               $weight="600"
+              $margin="0"
             >
               {t('Share the document')}
             </Text>


### PR DESCRIPTION
## Purpose

Recent improvement changes the modal title with a h1 tag, h1 tag adds margin by default.
We remove the margin from the h1 tag to stick to the design system.


## Demo

<img width="675" height="461" alt="image" src="https://github.com/user-attachments/assets/ce0a618f-eb33-4b3b-908d-53d42b0af499" />
