### PR TITLE
✨(frontend) add document visible in list and openable via enter key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
 
 - 🐛(backend) duplicate sub docs as root for reader users
 
+### Changed
+
+- ♿(frontend) improve accessibility:
+  - ✨ add document visible in list and openable via enter key #1365
+
 ## [3.7.0] - 2025-09-12
 
 ### Added

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, useModal } from '@openfun/cunningham-react';
 import { DateTime } from 'luxon';
+import { KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
@@ -33,6 +34,13 @@ export const DocsGridItem = ({ doc, dragMode = false }: DocsGridItemProps) => {
     shareModal.open();
   };
 
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      (e.target as HTMLAnchorElement).click();
+    }
+  };
+
   return (
     <>
       <Box
@@ -52,6 +60,9 @@ export const DocsGridItem = ({ doc, dragMode = false }: DocsGridItemProps) => {
           }
         `}
         className="--docs--doc-grid-item"
+        aria-label={t('Open document: {{title}}', {
+          title: doc.title || t('Untitled document'),
+        })}
       >
         <Box
           $flex={flexLeft}
@@ -68,6 +79,7 @@ export const DocsGridItem = ({ doc, dragMode = false }: DocsGridItemProps) => {
               min-width: 0;
             `}
             href={`/docs/${doc.id}`}
+            onKeyDown={handleKeyDown}
           >
             <Box
               data-testid={`docs-grid-name-${doc.id}`}


### PR DESCRIPTION
## Purpose

Make documents visible in the list and allow users to open them using the Enter key.
Improves accessibility and user interaction with listed documents.

## Proposal

- [x]  Enable opening the document using the Enter key

Clarify interaction:
- [x] First Tab focuses the drag handle (for reordering)
- [x] Second Tab focuses the document and allows opening with Enter

https://github.com/user-attachments/assets/a0060794-4583-44b2-9dd7-f35d54b5771c


