### PR TITLE
✨(frontend) add pdf outline property to enable bookmarks display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to
 - ♿(frontend) improve accessibility:
   - ✨ add document visible in list and openable via enter key #1365
 
+### Changed
+
+- ♿(frontend) improve accessibility:
+  - ♿ add pdf outline property to enable bookmarks display #1368
+
 ## [3.7.0] - 2025-09-12
 
 ### Added

--- a/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/headingPDF.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/headingPDF.tsx
@@ -2,6 +2,26 @@ import { Text } from '@react-pdf/renderer';
 
 import { DocsExporterPDF } from '../types';
 
+// Helper function to extract plain text from block content
+function extractTextFromBlockContent(content: unknown[]): string {
+  return content
+    .map((item) => {
+      if (
+        typeof item === 'object' &&
+        item !== null &&
+        'type' in item &&
+        'text' in item
+      ) {
+        if (item.type === 'text' && typeof item.text === 'string') {
+          return item.text;
+        }
+      }
+      return '';
+    })
+    .join('')
+    .trim();
+}
+
 export const blockMappingHeadingPDF: DocsExporterPDF['mappings']['blockMapping']['heading'] =
   (block, exporter) => {
     const PIXELS_PER_POINT = 0.75;
@@ -9,9 +29,18 @@ export const blockMappingHeadingPDF: DocsExporterPDF['mappings']['blockMapping']
     const FONT_SIZE = 16;
     const fontSizeEM =
       block.props.level === 1 ? 2 : block.props.level === 2 ? 1.5 : 1.17;
+
+    // Extract plain text for bookmark title
+    const bookmarkTitle =
+      extractTextFromBlockContent(block.content) || 'Untitled';
+
     return (
       <Text
         key={block.id}
+        // @ts-expect-error: bookmark is supported by react-pdf but not typed
+        bookmark={{
+          title: bookmarkTitle,
+        }}
         style={{
           fontSize: fontSizeEM * FONT_SIZE * PIXELS_PER_POINT,
           fontWeight: 700,

--- a/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
@@ -98,9 +98,12 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
         exportDocument,
       )) as React.ReactElement<DocumentProps>;
 
-      // Inject language for screen reader support
+      // Inject language for screen reader support and enable outlines (bookmarks)
       const pdfDocument = isValidElement(rawPdfDocument)
-        ? cloneElement(rawPdfDocument, { language: i18next.language })
+        ? cloneElement(rawPdfDocument, {
+            language: i18next.language,
+            pageMode: 'useOutlines',
+          })
         : rawPdfDocument;
 
       blobExport = await pdf(pdfDocument).toBlob();


### PR DESCRIPTION
**Purpose**

This pull request introduces PDF bookmarks (outline) support in exported documents.
The goal is to provide an accessible outline structure based on document headings, in line with WCAG/RGAA requirements for navigable documents.

issue [1335](https://github.com/suitenumerique/docs/issues/1135)
![SignetON](https://github.com/user-attachments/assets/fe1a841e-4e35-4b02-8d68-cd60be265c8f)


**Proposal**

- [x] Add bookmark attributes to exported headings in the PDF renderer.
- [x] Enable outlines by setting pageMode="useOutlines" so that bookmarks are visible in PDF readers.
- [x] Ensure each heading (h1, h2, h3, …) is represented in the outline structure.
- [x] Known limitation: although the outline is displayed correctly in Acrobat Reader and Firefox PDF Viewer, clicking on bookmarks does not reliably scroll to the correct heading

Investigations performed

- Tried attaching unique id values to headings.
- Tested with invisible anchors positioned before headings.
- Experimented with top, left, and fit options on bookmarks.
- Tried assigning explicit destination values (dest).

👉 In all cases, the behavior remains the same: all bookmarks on a given page point to the same destination (the last heading).

In my opinion the issue seems to be a limitation/bug in @react-pdf/renderer v4: bookmarks are generated in the outline but do not create unique destinations per heading.
