### PR TITLE
🐛(frontend) fix legacy role computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(frontend) fix callout emoji list #1366
+- 🐛(frontend) fix legacy role computation #1376
 
 ## [3.6.0] - 2025-09-04
 

--- a/docker/auth/realm.json
+++ b/docker/auth/realm.json
@@ -60,7 +60,7 @@
     },
     {
       "username": "user-e2e-chromium",
-      "email": "user@chromium.test",
+      "email": "user.test@chromium.test",
       "firstName": "E2E",
       "lastName": "Chromium",
       "enabled": true,
@@ -74,7 +74,7 @@
     },
     {
       "username": "user-e2e-webkit",
-      "email": "user@webkit.test",
+      "email": "user.test@webkit.test",
       "firstName": "E2E",
       "lastName": "Webkit",
       "enabled": true,
@@ -88,7 +88,7 @@
     },
     {
       "username": "user-e2e-firefox",
-      "email": "user@firefox.test",
+      "email": "user.test@firefox.test",
       "firstName": "E2E",
       "lastName": "Firefox",
       "enabled": true,

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-create.spec.ts
@@ -89,8 +89,8 @@ test.describe('Doc Create: Not logged', () => {
     const data = {
       title,
       content: markdown,
-      sub: `user@${browserName}.test`,
-      email: `user@${browserName}.test`,
+      sub: `user.test@${browserName}.test`,
+      email: `user.test@${browserName}.test`,
     };
 
     const newDoc = await request.post(

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
@@ -238,17 +238,7 @@ test.describe('Doc Editor', () => {
 
   test('it cannot edit if viewer', async ({ page }) => {
     await mockedDocument(page, {
-      abilities: {
-        destroy: false, // Means not owner
-        link_configuration: false,
-        versions_destroy: false,
-        versions_list: true,
-        versions_retrieve: true,
-        accesses_manage: false, // Means not admin
-        update: false,
-        partial_update: false, // Means not editor
-        retrieve: true,
-      },
+      user_role: 'reader',
     });
 
     await goToGridDoc(page);
@@ -257,6 +247,9 @@ test.describe('Doc Editor', () => {
     await expect(card).toBeVisible();
 
     await expect(card.getByText('Reader')).toBeVisible();
+
+    const editor = page.locator('.ProseMirror');
+    await expect(editor).toHaveAttribute('contenteditable', 'false');
   });
 
   test('it adds an image to the doc editor', async ({ page, browserName }) => {

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
@@ -28,7 +28,7 @@ test.describe('Documents Grid mobile', () => {
                     id: '8c1e047a-24e7-4a80-942b-8e9c7ab43e1f',
                     user: {
                       id: '7380f42f-02eb-4ad5-b8f0-037a0e66066d',
-                      email: 'test@test.test',
+                      email: 'test.test@test.test',
                       full_name: 'John Doe',
                       short_name: 'John',
                     },

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
@@ -164,7 +164,7 @@ test.describe('Doc Header', () => {
     const invitationCard = shareModal.getByLabel('List invitation card');
     await expect(invitationCard).toBeVisible();
     await expect(
-      invitationCard.getByText('test@invitation.test').first(),
+      invitationCard.getByText('test.test@invitation.test').first(),
     ).toBeVisible();
     const invitationRole = invitationCard.getByLabel('doc-role-dropdown');
     await expect(invitationRole).toBeVisible();
@@ -178,7 +178,7 @@ test.describe('Doc Header', () => {
     const roles = memberCard.getByLabel('doc-role-dropdown');
     await expect(memberCard).toBeVisible();
     await expect(
-      memberCard.getByText('test@accesses.test').first(),
+      memberCard.getByText('test.test@accesses.test').first(),
     ).toBeVisible();
     await expect(roles).toBeVisible();
 
@@ -239,7 +239,7 @@ test.describe('Doc Header', () => {
     const invitationCard = shareModal.getByLabel('List invitation card');
     await expect(invitationCard).toBeVisible();
     await expect(
-      invitationCard.getByText('test@invitation.test').first(),
+      invitationCard.getByText('test.test@invitation.test').first(),
     ).toBeVisible();
     await expect(invitationCard.getByLabel('Document role text')).toBeVisible();
     await expect(
@@ -247,7 +247,7 @@ test.describe('Doc Header', () => {
     ).toBeHidden();
 
     const memberCard = shareModal.getByLabel('List members card');
-    await expect(memberCard.getByText('test@accesses.test')).toBeVisible();
+    await expect(memberCard.getByText('test.test@accesses.test')).toBeVisible();
     await expect(memberCard.getByLabel('Document role text')).toBeVisible();
     await expect(
       memberCard.getByRole('button', { name: 'more_horiz' }),
@@ -302,7 +302,7 @@ test.describe('Doc Header', () => {
     const invitationCard = shareModal.getByLabel('List invitation card');
     await expect(invitationCard).toBeVisible();
     await expect(
-      invitationCard.getByText('test@invitation.test').first(),
+      invitationCard.getByText('test.test@invitation.test').first(),
     ).toBeVisible();
     await expect(invitationCard.getByLabel('Document role text')).toBeVisible();
     await expect(
@@ -310,7 +310,7 @@ test.describe('Doc Header', () => {
     ).toBeHidden();
 
     const memberCard = shareModal.getByLabel('List members card');
-    await expect(memberCard.getByText('test@accesses.test')).toBeVisible();
+    await expect(memberCard.getByText('test.test@accesses.test')).toBeVisible();
     await expect(memberCard.getByLabel('Document role text')).toBeVisible();
     await expect(
       memberCard.getByRole('button', { name: 'more_horiz' }),

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-inherited-share.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-inherited-share.spec.ts
@@ -18,7 +18,7 @@ test.describe('Inherited share accesses', () => {
     ).toBeVisible();
 
     const user = page.getByTestId(
-      `doc-share-member-row-user@${browserName}.test`,
+      `doc-share-member-row-user.test@${browserName}.test`,
     );
     await expect(user).toBeVisible();
     await expect(user.getByText('E2E Chromium')).toBeVisible();

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-member-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-member-create.spec.ts
@@ -280,7 +280,7 @@ test.describe('Document create member: Multiple login', () => {
     await expect(page.getByText('Access Requests')).toBeVisible();
     await expect(page.getByText(`E2E ${otherBrowser}`)).toBeVisible();
 
-    const emailRequest = `user@${otherBrowser}.test`;
+    const emailRequest = `user.test@${otherBrowser}.test`;
     await expect(page.getByText(emailRequest)).toBeVisible();
     const container = page.getByTestId(
       `doc-share-access-request-row-${emailRequest}`,

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-member-list.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-member-list.spec.ts
@@ -139,7 +139,7 @@ test.describe('Document list members', () => {
     const list = page.getByTestId('doc-share-quick-search');
     await expect(list).toBeVisible();
     const currentUser = list.getByTestId(
-      `doc-share-member-row-user@${browserName}.test`,
+      `doc-share-member-row-user.test@${browserName}.test`,
     );
     const currentUserRole = currentUser.getByLabel('doc-role-dropdown');
     await expect(currentUser).toBeVisible();
@@ -190,7 +190,7 @@ test.describe('Document list members', () => {
 
     const list = page.getByTestId('doc-share-quick-search');
 
-    const emailMyself = `user@${browserName}.test`;
+    const emailMyself = `user.test@${browserName}.test`;
     const mySelf = list.getByTestId(`doc-share-member-row-${emailMyself}`);
     const mySelfRole = mySelf.getByRole('button', {
       name: 'doc-role-dropdown',

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-tree.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-tree.spec.ts
@@ -235,6 +235,12 @@ test.describe('Doc Tree', () => {
       'doc-tree-detach-child',
     );
 
+    await expect(
+      page
+        .getByLabel('It is the card information about the document.')
+        .getByText('Administrator ·'),
+    ).toBeVisible();
+
     const docTree = page.getByTestId('doc-tree');
     await expect(docTree.getByText(docChild)).toBeVisible();
     await docTree.click();

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-tree.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-tree.spec.ts
@@ -220,7 +220,7 @@ test.describe('Doc Tree', () => {
 
     const list = page.getByTestId('doc-share-quick-search');
     const currentUser = list.getByTestId(
-      `doc-share-member-row-user@${browserName}.test`,
+      `doc-share-member-row-user.test@${browserName}.test`,
     );
     const currentUserRole = currentUser.getByLabel('doc-role-dropdown');
     await currentUserRole.click();

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-visibility.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-visibility.spec.ts
@@ -156,7 +156,7 @@ test.describe('Doc Visibility: Restricted', () => {
     if (!otherBrowser) {
       throw new Error('No alternative browser found');
     }
-    const username = `user@${otherBrowser}.test`;
+    const username = `user.test@${otherBrowser}.test`;
     await inputSearch.fill(username);
     await page.getByRole('option', { name: username }).click();
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-share.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-share.ts
@@ -72,7 +72,7 @@ export const mockedInvitations = async (page: Page, json?: object) => {
         retrieve: true,
       },
       created_at: '2024-10-03T12:19:26.107687Z',
-      email: 'test@invitation.test',
+      email: 'test.test@invitation.test',
       document: '4888c328-8406-4412-9b0b-c0ba5b9e5fb6',
       role: 'editor',
       issuer: '7380f42f-02eb-4ad5-b8f0-037a0e66066d',
@@ -129,7 +129,7 @@ export const mockedAccesses = async (page: Page, json?: object) => {
             id: 'bc8bbbc5-a635-4f65-9817-fd1e9ec8ef87',
             user: {
               id: 'b4a21bb3-722e-426c-9f78-9d190eda641c',
-              email: 'test@accesses.test',
+              email: 'test.test@accesses.test',
             },
             team: '',
             max_ancestors_role: null,

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeader.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeader.tsx
@@ -7,7 +7,6 @@ import {
   Doc,
   LinkReach,
   Role,
-  currentDocRole,
   getDocLinkReach,
   useIsCollaborativeEditable,
   useTrans,
@@ -73,7 +72,7 @@ export const DocHeader = ({ doc }: DocHeaderProps) => {
                     >
                       {transRole(
                         isEditable
-                          ? currentDocRole(doc.abilities)
+                          ? doc.user_role || doc.link_role
                           : Role.READER,
                       )}
                       &nbsp;·&nbsp;

--- a/src/frontend/apps/impress/src/features/docs/doc-management/__tests__/utils.test.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/__tests__/utils.test.tsx
@@ -1,11 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as Y from 'yjs';
 
-import { LinkReach, LinkRole, Role } from '../types';
+import { LinkReach, LinkRole } from '../types';
 import {
   base64ToBlocknoteXmlFragment,
   base64ToYDoc,
-  currentDocRole,
   getDocLinkReach,
   getDocLinkRole,
   getEmojiAndTitle,
@@ -22,56 +21,6 @@ vi.mock('yjs', () => ({
 describe('doc-management utils', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('currentDocRole', () => {
-    it('should return OWNER when destroy ability is true', () => {
-      const abilities = {
-        destroy: true,
-        accesses_manage: false,
-        partial_update: false,
-      } as any;
-
-      const result = currentDocRole(abilities);
-
-      expect(result).toBe(Role.OWNER);
-    });
-
-    it('should return ADMIN when accesses_manage ability is true and destroy is false', () => {
-      const abilities = {
-        destroy: false,
-        accesses_manage: true,
-        partial_update: false,
-      } as any;
-
-      const result = currentDocRole(abilities);
-
-      expect(result).toBe(Role.ADMIN);
-    });
-
-    it('should return EDITOR when partial_update ability is true and higher abilities are false', () => {
-      const abilities = {
-        destroy: false,
-        accesses_manage: false,
-        partial_update: true,
-      } as any;
-
-      const result = currentDocRole(abilities);
-
-      expect(result).toBe(Role.EDITOR);
-    });
-
-    it('should return READER when no higher abilities are true', () => {
-      const abilities = {
-        destroy: false,
-        accesses_manage: false,
-        partial_update: false,
-      } as any;
-
-      const result = currentDocRole(abilities);
-
-      expect(result).toBe(Role.READER);
-    });
   });
 
   describe('base64ToYDoc', () => {

--- a/src/frontend/apps/impress/src/features/docs/doc-management/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/utils.ts
@@ -1,17 +1,7 @@
 import emojiRegex from 'emoji-regex';
 import * as Y from 'yjs';
 
-import { Doc, LinkReach, LinkRole, Role } from './types';
-
-export const currentDocRole = (abilities: Doc['abilities']): Role => {
-  return abilities.destroy
-    ? Role.OWNER
-    : abilities.accesses_manage
-      ? Role.ADMIN
-      : abilities.partial_update
-        ? Role.EDITOR
-        : Role.READER;
-};
+import { Doc, LinkReach, LinkRole } from './types';
 
 export const base64ToYDoc = (base64: string) => {
   const uint8Array = Buffer.from(base64, 'base64');


### PR DESCRIPTION
## Purpose

When we invited a user, this user on a child doc had his role indicating "owner" even if he was a "administrator".
Before the subpages feature, the user role was computed thanks to the abilities.
This is not the correct way to do it anymore, the abilities are now different.
We now have `user_role` in the doc response which is the correct way to get the user role for the current document.

## Proposal

- [x] 🐛(frontend) fix legacy role computation
- [x] 🩹(demo) update the email in realm.json

## Demo

<img width="686" height="221" alt="image" src="https://github.com/user-attachments/assets/97669c10-fe9c-49e7-b3f8-f6f72678603e" />

