### PR TITLE
💬(copy) wrong permission mentionned on move doc

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-grid-dnd.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-grid-dnd.spec.ts
@@ -106,7 +106,7 @@ test.describe('Doc grid dnd', () => {
 
     await expect(dragOverlay).toBeVisible();
     await expect(dragOverlay).toHaveText(
-      'You must be at least the editor of the target document',
+      'You must be at least the administrator of the target document',
     );
 
     await page.mouse.up();

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocGridContentList.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocGridContentList.tsx
@@ -141,7 +141,7 @@ export const DraggableDocGridContentList = ({
       return t('You must be the owner to move the document');
     }
     if (!canDrop) {
-      return t('You must be at least the editor of the target document');
+      return t('You must be at least the administrator of the target document');
     }
 
     return selectedDoc?.title || t('Unnamed document');


### PR DESCRIPTION
## Purpose

To move a doc you have to be at least admin of the destination doc.
It was written editor in the alert banner.


## Proposal
Change editor for administrator

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)