### PR TITLE
🐛(backend) cast DOCUMENT_IMAGE_MAX_SIZE in integer

### DIFF
--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -142,7 +142,7 @@ class Base(Configuration):
     )
 
     # Document images
-    DOCUMENT_IMAGE_MAX_SIZE = values.Value(
+    DOCUMENT_IMAGE_MAX_SIZE = values.IntegerValue(
         10 * (2**20),  # 10MB
         environ_name="DOCUMENT_IMAGE_MAX_SIZE",
         environ_prefix=None,


### PR DESCRIPTION
## Purpose

The expected type for the settings DOCUMENT_IMAGE_MAX_SIZE is an integer. By not using django configurations IntegerValue, the value is used as it and most of the time will be a string. We must use the IntegerValue in order to cast the value in string.


## Proposal

- [x] 🐛(backend) cast DOCUMENT_IMAGE_MAX_SIZE in integer