### PR TITLE
🐛(frontend) scroll back to top when navigate to a document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 - ⚗️(service-worker) remove index from cache first strategy #1395
 - 🐛(frontend) fix 404 page when reload 403 page #1402
 - 🐛(frontend) fix legacy role computation #1376
+- 🐛(frontend) scroll back to top when navigate to a document #1406
 
 ## [3.7.0] - 2025-09-12
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-table-content.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-table-content.spec.ts
@@ -8,8 +8,6 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Doc Table Content', () => {
   test('it checks the doc table content', async ({ page, browserName }) => {
-    test.setTimeout(60000);
-
     const [randomDoc] = await createDoc(
       page,
       'doc-table-content',

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-editor.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-editor.ts
@@ -1,0 +1,27 @@
+import { Page } from '@playwright/test';
+
+export const getEditor = async ({ page }: { page: Page }) => {
+  const editor = page.locator('.ProseMirror');
+  await editor.click();
+  return editor;
+};
+
+export const openSuggestionMenu = async ({ page }: { page: Page }) => {
+  const editor = await getEditor({ page });
+  await editor.click();
+  await page.locator('.bn-block-outer').last().fill('/');
+
+  return editor;
+};
+
+export const writeInEditor = async ({
+  page,
+  text,
+}: {
+  page: Page;
+  text: string;
+}) => {
+  const editor = await getEditor({ page });
+  editor.locator('.bn-block-outer').last().fill(text);
+  return editor;
+};

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-sub-pages.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-sub-pages.ts
@@ -3,6 +3,7 @@ import { Page, expect } from '@playwright/test';
 import {
   randomName,
   updateDocTitle,
+  verifyDocName,
   waitForResponseCreateDoc,
 } from './utils-common';
 
@@ -64,4 +65,16 @@ export const clickOnAddRootSubPage = async (page: Page) => {
   await expect(rootItem).toBeVisible();
   await rootItem.hover();
   await rootItem.getByRole('button', { name: /add subpage/i }).click();
+};
+
+export const navigateToPageFromTree = async ({
+  page,
+  title,
+}: {
+  page: Page;
+  title: string;
+}) => {
+  const docTree = page.getByTestId('doc-tree');
+  await docTree.getByText(title).click();
+  await verifyDocName(page, title);
 };

--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -20,6 +20,7 @@ import {
 import { KEY_AUTH, setAuthUrl, useAuth } from '@/features/auth';
 import { getDocChildren, subPageToTree } from '@/features/docs/doc-tree/';
 import { MainLayout } from '@/layouts';
+import { MAIN_LAYOUT_ID } from '@/layouts/conf';
 import { useBroadcastStore } from '@/stores';
 import { NextPageWithLayout } from '@/types/next';
 
@@ -88,6 +89,26 @@ const DocPage = ({ id }: DocProps) => {
   useCollaboration(doc?.id, doc?.content);
   const { t } = useTranslation();
   const { authenticated } = useAuth();
+
+  /**
+   * Scroll to top when navigating to a new document
+   * We use a timeout to ensure the scroll happens after the layout has updated.
+   */
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | undefined;
+    const mainElement = document.getElementById(MAIN_LAYOUT_ID);
+    if (mainElement) {
+      timeoutId = setTimeout(() => {
+        mainElement.scrollTop = 0;
+      }, 150);
+    }
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [id]);
 
   // Invalidate when provider store reports a lost connection
   useEffect(() => {


### PR DESCRIPTION
## Purpose

When navigating to a new document, the scroll position was preserved. 
This PR changes this behavior to scroll back to the top of the page when navigating to a new document.

Fixe: #1393


