### PR TITLE
✨(frontend) add default background to left panel for better accessibi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
   - ♿ add pdf outline property to enable bookmarks display #1368
   - ♿ hide decorative icons from assistive tech with aria-hidden #1404
   - ♿ remove redundant aria-label to avoid over-accessibility #1420
+  - ♿ add default background to left panel for better accessibility #1423
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
@@ -43,6 +43,7 @@ export const LeftPanel = () => {
             min-width: 300px;
             overflow: hidden;
             border-right: 1px solid ${colorsTokens['greyscale-200']};
+            background-color: ${colorsTokens['greyscale-000']};
           `}
           className="--docs--left-panel-desktop"
         >


### PR DESCRIPTION
## Purpose

Fix visual accessibility issue caused by missing background color in the custom LeftPanel used in DOCS.

issue : [896](https://github.com/suitenumerique/docs/issues/896)

## Proposal

- [x]  Add default background color to the LeftPanel used in DOCS
- [x]  Ensure alignment with UI Kit behavior, which already defines a background color
- [x]  Improve accessibility for users applying custom styles (e.g., via Stylus extension)

Note: The LeftPanel from the UI Kit has default background color but DOCS uses a custom implementation of a LeftPanel.