### PR TITLE
♿(frontend) improve semantic structure and aria roles of leftpanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
   - ♿ add pdf outline property to enable bookmarks display #1368
   - ♿ hide decorative icons from assistive tech with aria-hidden #1404
   - ♿ remove redundant aria-label to avoid over-accessibility #1420
+  - ♿ improve semantic structure and aria roles of leftpanel #1431
   - ♿ add default background to left panel for better accessibility #1423
 
 ### Fixed

--- a/src/frontend/apps/impress/src/features/left-panel/components/LefPanelTargetFilters.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LefPanelTargetFilters.tsx
@@ -49,8 +49,6 @@ export const LeftPanelTargetFilters = () => {
 
   return (
     <Box
-      as="nav"
-      aria-label={t('Document sections')}
       $justify="center"
       $padding={{ horizontal: 'sm' }}
       $gap={spacingsTokens['2xs']}

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
@@ -1,5 +1,6 @@
 import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createGlobalStyle, css } from 'styled-components';
 
 import { Box, SeparatedSection } from '@/components';
@@ -22,6 +23,7 @@ const MobileLeftPanelStyle = createGlobalStyle`
 
 export const LeftPanel = () => {
   const { isDesktop } = useResponsiveStore();
+  const { t } = useTranslation();
 
   const { colorsTokens, spacingsTokens } = useCunninghamTheme();
   const { togglePanel, isPanelOpen } = useLeftPanelStore();
@@ -46,6 +48,8 @@ export const LeftPanel = () => {
             background-color: ${colorsTokens['greyscale-000']};
           `}
           className="--docs--left-panel-desktop"
+          as="nav"
+          aria-label={t('Document sections')}
         >
           <Box
             $css={css`
@@ -78,6 +82,8 @@ export const LeftPanel = () => {
           >
             <Box
               data-testid="left-panel-mobile"
+              as="nav"
+              aria-label={t('Document sections')}
               $css={css`
                 width: 100%;
                 justify-content: center;

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFavorites.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFavorites.tsx
@@ -24,8 +24,8 @@ export const LeftPanelFavorites = () => {
 
   return (
     <Box
-      as="nav"
-      aria-label={t('Pinned documents')}
+      as="section"
+      aria-labelledby="pinned-docs-title"
       className="--docs--left-panel-favorites"
     >
       <HorizontalSeparator $withPadding={false} />
@@ -41,6 +41,7 @@ export const LeftPanelFavorites = () => {
           $variation="700"
           $padding={{ horizontal: '3xs' }}
           $weight="700"
+          id="pinned-docs-title"
         >
           {t('Pinned documents')}
         </Text>


### PR DESCRIPTION
## Purpose

This PR improves the semantic structure and accessibility of the left panel ( TargetFilters and Favorites too) .

<img width="716" height="50" alt="leftpaneltonav" src="https://github.com/user-attachments/assets/f8c9dc19-fb8a-4929-9e9c-1f96b3594470" />

issue : [1429](https://github.com/suitenumerique/docs/issues/1429)

## Proposal

- [x]  Wrap main navigation areas in `nav `with appropriate aria-labels
- [x]  Replace `nav `with `section `for grouped pinned content
- [x]  Use aria-labelledby and element id for better labeling