### PR TITLE
✨(frontend) restyle checked checkboxes: removing strikethrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
   - ♿ remove redundant aria-label on hidden icons and update tests #1432
   - ♿ improve semantic structure and aria roles of leftpanel #1431
   - ♿ add default background to left panel for better accessibility #1423
+  - ♿ restyle checked checkboxes: removing strikethrough #1439  
   - ♿ add h1 for SR on 40X pages and remove alt texts #1438
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -91,6 +91,11 @@ export const cssEditor = (readonly: boolean) => css`
       border-radius: var(--c--theme--spacings--3xs);
     }
 
+    .bn-block-content[data-content-type='checkListItem'][data-checked='true']
+      .bn-inline-content {
+      text-decoration: none;
+    }
+
     h1 {
       font-size: 1.875rem;
     }


### PR DESCRIPTION
## Purpose

Improve the visual styling of checked checkboxes by removing the strikethrough and ensuring the text remains accessible while appearing visually distinct.

issue [1153](https://github.com/suitenumerique/docs/issues/1153)

<img width="312" height="107" alt="checkboxonly" src="https://github.com/user-attachments/assets/eab5fa2f-e43c-4a70-aadd-33ad1afea46c" />

Why ? 
Users with dyslexia or cognitive impairments often struggle to read strikethrough text, which reduces clarity and comprehension.

## Proposal

- [x]  Remove strikethrough effect from checked checkbox labels
