### PR TITLE
🔒(frontend) prevent readers from changing callout emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to
 - 🐛(frontend) fix legacy role computation #1376
 - 🛂(frontend) block editing title when not allowed #1412
 - 🐛(frontend) scroll back to top when navigate to a document #1406
+- 🔒(frontend) prevent readers from changing callout emoji #1449
 
 ## [3.7.0] - 2025-09-12
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/CalloutBlock.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/CalloutBlock.tsx
@@ -25,8 +25,12 @@ export const CalloutBlock = createReactBlockSpec(
   {
     render: ({ block, editor, contentRef }) => {
       const [openEmojiPicker, setOpenEmojiPicker] = useState(false);
+      const isEditable = editor.isEditable;
 
       const toggleEmojiPicker = (e: React.MouseEvent) => {
+        if (!isEditable) {
+          return;
+        }
         e.preventDefault();
         e.stopPropagation();
         setOpenEmojiPicker(!openEmojiPicker);
@@ -65,9 +69,13 @@ export const CalloutBlock = createReactBlockSpec(
             onClick={toggleEmojiPicker}
             $css={css`
               font-size: 1.125rem;
-              &:hover {
-                background-color: rgba(0, 0, 0, 0.1);
-              }
+              cursor: ${isEditable ? 'pointer' : 'default'};
+              ${isEditable &&
+              `
+                &:hover {
+                  background-color: rgba(0, 0, 0, 0.1);
+                }
+              `}
             `}
             $align="center"
             $height="28px"


### PR DESCRIPTION
## Purpose

Ensure proper permissions handling in callouts by preventing users with reader role from editing the emoji.

https://github.com/user-attachments/assets/37f71fb8-ef3d-4cc7-b356-3c649aa9a0d3

issue : [1410](https://github.com/suitenumerique/docs/issues/1410)

## Proposal

- [x] Restrict callout emoji editing to users with sufficient permissions
- [x] Readers can still view callouts but cannot modify the emoji
- [x] Editors and above keep full editing rights
- [x] Remove UX feedback in reader mode to avoid users thinking they can take action.