### PR TITLE
🚚(docker) use static path for certifi ca certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,14 @@ RUN chmod g=u /etc/passwd
 # Copy installed python dependencies
 COPY --from=back-builder /install /usr/local
 
+# Link certifi certificate from a static path /cert/cacert.pem to avoid issues
+# when python is upgraded and the path to the certificate changes.
+# The space between print and the ( is intended otherwise the git lint is failing
+RUN mkdir /cert && \
+    path=`python -c 'import certifi;print (certifi.where())'` && \
+    mv $path /cert/ && \
+    ln -s /cert/cacert.pem $path
+
 # Copy impress application (see .dockerignore)
 COPY ./src/backend /app/
 

--- a/docs/examples/helm/impress.values.yaml
+++ b/docs/examples/helm/impress.values.yaml
@@ -82,7 +82,7 @@ backend:
   # Extra volume to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumeMounts:
     - name: certs
-      mountPath: /usr/local/lib/python3.13/site-packages/certifi/cacert.pem
+      mountPath: /cert/cacert.pem
       subPath: cacert.pem
 
   # Extra volume to manage our local custom CA and avoid to set ssl_verify: false

--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -114,7 +114,7 @@ backend:
   # Extra volume mounts to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumeMounts:
     - name: certs
-      mountPath: /usr/local/lib/python3.13/site-packages/certifi/cacert.pem
+      mountPath: /cert/cacert.pem
       subPath: cacert.pem
 
   # Extra volumes to manage our local custom CA and avoid to set ssl_verify: false


### PR DESCRIPTION
## Purpose

The certifi ca certificate is now stored under a static path (/cert/cacert.pem) to avoid issues when python is upgraded and the path to the certificate changes.

## Proposal

- Move the certifi cacert to a static path and create a symlink to this path

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)