### PR TITLE
🐛(frontend) reduce no access image size from 450 to 300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to
 - 🔒(frontend) prevent readers from changing callout emoji #1449
 - 🐛(frontend) fix overlapping placeholders in multi-column layout #1455
 - 🐛(backend) filter invitation with case insensitive email
+- 🐛(frontend) reduce no access image size from 450 to 300 #1463
 
 ## [3.7.0] - 2025-09-12
 

--- a/src/frontend/apps/impress/src/features/docs/doc-management/components/DocPage403.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/components/DocPage403.tsx
@@ -59,6 +59,8 @@ export const DocPage403 = ({ id }: DocProps) => {
           className="c__image-system-filter"
           src={img403}
           alt={t('Image 403')}
+          width={300}
+          height={300}
           style={{
             maxWidth: '100%',
             height: 'auto',

--- a/src/frontend/apps/impress/src/pages/401.tsx
+++ b/src/frontend/apps/impress/src/pages/401.tsx
@@ -46,6 +46,8 @@ const Page: NextPageWithLayout = () => {
           className="c__image-system-filter"
           src={img401}
           alt=""
+          width={300}
+          height={300}
           style={{
             maxWidth: '100%',
             height: 'auto',

--- a/src/frontend/apps/impress/src/pages/404.tsx
+++ b/src/frontend/apps/impress/src/pages/404.tsx
@@ -42,6 +42,8 @@ const Page: NextPageWithLayout = () => {
           className="c__image-system-filter"
           src={img403}
           alt=""
+          width={300}
+          height={300}
           style={{
             maxWidth: '100%',
             height: 'auto',


### PR DESCRIPTION
## Purpose

Align the "no access" image size with design mockups and improve its rendering on high pixel density (HiDPI) screens. This enhances visual consistency and clarity across devices.

[709](https://github.com/suitenumerique/docs/issues/709)

## Proposal

- [x] Resize image from 450×450px to 300×300px
- [x] Apply fixed width and height props to match design specs
- [x] Improve UX consistency with other empty/error states
