### PR TITLE
🐛(frontend) force emoji picker to fixed position to stay visible on zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to
 - 🐛(frontend) fix overlapping placeholders in multi-column layout #1455
 - 🐛(backend) filter invitation with case insensitive email
 - 🐛(frontend) reduce no access image size from 450 to 300 #1463
+- 🐛(frontend) force emoji picker to fixed position to stay visible on zoom #1466
+
 
 ## [3.7.0] - 2025-09-12
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -13,6 +13,7 @@ import { useCreateBlockNote } from '@blocknote/react';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { createGlobalStyle } from 'styled-components';
 import * as Y from 'yjs';
 
 import { Box, TextErrors } from '@/components';
@@ -48,6 +49,16 @@ import XLMultiColumn from './xl-multi-column';
 
 const multiColumnLocales = XLMultiColumn?.locales;
 const withMultiColumn = XLMultiColumn?.withMultiColumn;
+
+/*
+ * Force position:fixed on emoji picker to prevent it from being hidden under the left sidebar
+ * when zooming in/out. Without this, the picker's position could end up under the left sidebar.
+ */
+const BlockNoteEmojiPickerStyle = createGlobalStyle`
+  div[data-floating-ui-focusable]:has(.bn-grid-suggestion-menu) {
+    position: fixed !important;
+  }
+`;
 
 const baseBlockNoteSchema = withPageBreak(
   BlockNoteSchema.create({
@@ -177,33 +188,36 @@ export const BlockNoteEditor = ({ doc, provider }: BlockNoteEditorProps) => {
   }, [setEditor, editor]);
 
   return (
-    <Box
-      $padding={{ top: 'md' }}
-      $background="white"
-      $css={cssEditor(readOnly)}
-      className="--docs--editor-container"
-    >
-      {errorAttachment && (
-        <Box $margin={{ bottom: 'big', top: 'none', horizontal: 'large' }}>
-          <TextErrors
-            causes={errorAttachment.cause}
-            canClose
-            $textAlign="left"
-          />
-        </Box>
-      )}
-
-      <BlockNoteView
-        editor={editor}
-        formattingToolbar={false}
-        slashMenu={false}
-        editable={!readOnly}
-        theme="light"
+    <>
+      <BlockNoteEmojiPickerStyle />
+      <Box
+        $padding={{ top: 'md' }}
+        $background="white"
+        $css={cssEditor(readOnly)}
+        className="--docs--editor-container"
       >
-        <BlockNoteSuggestionMenu />
-        <BlockNoteToolbar />
-      </BlockNoteView>
-    </Box>
+        {errorAttachment && (
+          <Box $margin={{ bottom: 'big', top: 'none', horizontal: 'large' }}>
+            <TextErrors
+              causes={errorAttachment.cause}
+              canClose
+              $textAlign="left"
+            />
+          </Box>
+        )}
+
+        <BlockNoteView
+          editor={editor}
+          formattingToolbar={false}
+          slashMenu={false}
+          editable={!readOnly}
+          theme="light"
+        >
+          <BlockNoteSuggestionMenu />
+          <BlockNoteToolbar />
+        </BlockNoteView>
+      </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
## Purpose

Improve the visibility of the emoji picker in the BlockNote editor by forcing its position to fixed. This prevents it from being visually hidden under the left sidebar, especially when zooming in or out.

issue : [1221](https://github.com/suitenumerique/docs/issues/1221)

In the screenshot, I intentionally forced the tranform / translate to the left, to demonstrate the behavior.

<img width="1905" height="801" alt="Capture d'écran 2025-10-08 130717" src="https://github.com/user-attachments/assets/d1ba2a84-3672-4ab5-8189-786bc5979de0" />

## Proposal

- [x] Add global CSS rule via createGlobalStyle to target emoji suggestion container 
- [x] Force position: fixed on emoji picker using a data attribute selector
- [x] Prevent clipping behind sidebar or other layout containers
- [x]  Verified via manual testing and visual confirmation on zoomed layout
