### PR TITLE
🔧(action) publish a comment when label preview is added

### DIFF
--- a/.github/workflows/label_preview.yml
+++ b/.github/workflows/label_preview.yml
@@ -1,0 +1,27 @@
+name: Label Preview
+
+on:
+  pull_request:
+    types: [labeled, opened]
+
+permissions: 
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    steps:
+      - uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            :rocket: Preview will be available at [https://${{ github.event.pull_request.number }}-docs.ppr-docs.beta.numerique.gouv.fr/](https://${{ github.event.pull_request.number }}-docs.ppr-docs.beta.numerique.gouv.fr/)
+
+            You can use the existing account with these credentials:
+            - username: `docs`
+            - password: `docs`
+
+            You can also create a new account if you want to.
+
+            Once this Pull Request is merged, the preview will be destroyed.
+          comment-tag: preview-url


### PR DESCRIPTION
## Purpose

The label preview will deploy a full environment. This environment is accessible using a specific url. This commit will publish a comment with the good url.



## Proposal

- [x] 🔧(action) publish a comment when label preview is added