### PR TITLE
🔥(backend) remove treebeard form for the document admin

### DIFF
--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -5,7 +5,6 @@ from django.contrib.auth import admin as auth_admin
 from django.utils.translation import gettext_lazy as _
 
 from treebeard.admin import TreeAdmin
-from treebeard.forms import movenodeform_factory
 
 from . import models
 
@@ -157,7 +156,6 @@ class DocumentAdmin(TreeAdmin):
             },
         ),
     )
-    form = movenodeform_factory(models.Document)
     inlines = (DocumentAccessInline,)
     list_display = (
         "id",


### PR DESCRIPTION
## Purpose

The document change admin page is unusable. The django treebeard library can change the form used by one provided but this one is really slow. And it is collapsing the configuration made with the other fields and readonly fields declared on the DocumentAdmin class. In a first time we remove the form usage, it seems useless. Later we have to provide more information on this admin page.


## Proposal

- [x] 🔥(backend) remove treebeard form for the document admin