### PR TITLE
🚨(eslint) add missing rules

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-common.ts
@@ -48,7 +48,7 @@ export const overrideConfig = async (
 export const keyCloakSignIn = async (
   page: Page,
   browserName: string,
-  fromHome: boolean = true,
+  fromHome = true,
 ) => {
   if (fromHome) {
     await page.getByRole('button', { name: 'Start Writing' }).first().click();
@@ -79,8 +79,8 @@ export const createDoc = async (
   page: Page,
   docName: string,
   browserName: string,
-  length: number = 1,
-  isMobile: boolean = false,
+  length = 1,
+  isMobile = false,
 ) => {
   const randomDocs = randomName(docName, browserName, length);
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-editor.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-editor.ts
@@ -22,6 +22,6 @@ export const writeInEditor = async ({
   text: string;
 }) => {
   const editor = await getEditor({ page });
-  editor.locator('.bn-block-outer').last().fill(text);
+  await editor.locator('.bn-block-outer').last().fill(text);
   return editor;
 };

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-share.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-share.ts
@@ -15,7 +15,7 @@ export const addNewMember = async (
   page: Page,
   index: number,
   role: 'Administrator' | 'Owner' | 'Editor' | 'Reader',
-  fillText: string = 'user.test',
+  fillText = 'user.test',
 ) => {
   const responsePromiseSearchUser = page.waitForResponse(
     (response) =>

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-sub-pages.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-sub-pages.ts
@@ -12,7 +12,7 @@ export const createRootSubPage = async (
   page: Page,
   browserName: BrowserName,
   docName: string,
-  isMobile: boolean = false,
+  isMobile = false,
 ) => {
   if (isMobile) {
     await page

--- a/src/frontend/apps/impress/src/api/config.ts
+++ b/src/frontend/apps/impress/src/api/config.ts
@@ -18,5 +18,5 @@ export const backendUrl = () =>
  * @param apiVersion - The version of the API (defaults to '1.0').
  * @returns The full versioned API base URL as a string.
  */
-export const baseApiUrl = (apiVersion: string = '1.0') =>
+export const baseApiUrl = (apiVersion = '1.0') =>
   `${backendUrl()}/api/v${apiVersion}/`;

--- a/src/frontend/apps/impress/src/features/auth/conf.ts
+++ b/src/frontend/apps/impress/src/features/auth/conf.ts
@@ -1,6 +1,6 @@
 import { baseApiUrl } from '@/api';
 
-export const HOME_URL: string = '/home';
+export const HOME_URL = '/home';
 export const LOGIN_URL = `${baseApiUrl()}authenticate/`;
 export const LOGOUT_URL = `${baseApiUrl()}logout/`;
 export const PATH_AUTH_LOCAL_STORAGE = 'docs-path-auth';

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/MarkdownButton.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/MarkdownButton.tsx
@@ -22,7 +22,7 @@ function isBlock(block: Block): block is Block {
   );
 }
 
-const recursiveContent = (content: Block[], base: string = '') => {
+const recursiveContent = (content: Block[], base = '') => {
   let fullContent = base;
   for (const innerContent of content) {
     if (innerContent.type === 'text') {

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/InterlinkingLinkInlineContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/InterlinkingLinkInlineContent.tsx
@@ -56,7 +56,7 @@ const LinkSelected = ({ url, title }: LinkSelectedProps) => {
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
-    router.push(url);
+    void router.push(url);
   };
 
   return (

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/__tests__/DocsGridItemDate.test.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/__tests__/DocsGridItemDate.test.tsx
@@ -64,8 +64,8 @@ describe('DocsGridItemDate', () => {
     });
   });
 
-  it(`should render rendered the updated_at field in the correct language`, () => {
-    i18next.changeLanguage('fr');
+  it(`should render rendered the updated_at field in the correct language`, async () => {
+    await i18next.changeLanguage('fr');
 
     render(
       <DocsGridItemDate
@@ -83,7 +83,7 @@ describe('DocsGridItemDate', () => {
     expect(screen.getByRole('link')).toBeInTheDocument();
     expect(screen.getByText('il y a 5 jours')).toBeInTheDocument();
 
-    i18next.changeLanguage('en');
+    await i18next.changeLanguage('en');
   });
 
   [

--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -115,7 +115,9 @@ const DocPage = ({ id }: DocProps) => {
   // Invalidate when provider store reports a lost connection
   useEffect(() => {
     if (hasLostConnection && doc?.id) {
-      queryClient.invalidateQueries({ queryKey: [KEY_DOC, { id: doc.id }] });
+      void queryClient.invalidateQueries({
+        queryKey: [KEY_DOC, { id: doc.id }],
+      });
       resetLostConnection();
     }
   }, [hasLostConnection, doc?.id, queryClient, resetLostConnection]);

--- a/src/frontend/packages/eslint-plugin-docs/typescript.js
+++ b/src/frontend/packages/eslint-plugin-docs/typescript.js
@@ -22,7 +22,9 @@ const typescriptConfig = {
     '@typescript-eslint': typescriptEslint,
   },
   rules: {
+    '@typescript-eslint/no-inferrable-types': 'error',
     '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-non-null-assertion': 'error',
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',
     '@typescript-eslint/no-unsafe-argument': 'error',


### PR DESCRIPTION
## Purpose

We recently upgraded to Eslint v9, it seems that
it is missing some rules that we had previously.
We add them back:
- @typescript-eslint/no-inferrable-types
- @typescript-eslint/no-floating-promises
