### PR TITLE
♿(frontend) add missing aria-label to add sub-doc button for accessib…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♿(frontend) improve accessibility:
+  - ♿ add missing aria-label to add sub-doc button for accessib… #1480
+
 ## [3.8.0] - 2025-10-14
 
 ### Added

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeItemActions.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeItemActions.tsx
@@ -178,6 +178,7 @@ export const DocTreeItemActions = ({
               });
             }}
             color="primary"
+            aria-label={t('Add a sub page')}
             data-testid="doc-tree-item-actions-add-child"
           >
             <Icon


### PR DESCRIPTION
## Purpose

Improve accessibility by adding a missing `aria-label` to the "add sub-doc" button.  
This allows screen readers to correctly identify the purpose of the button and improves the experience for users relying on assistive technologies.

issue : [1391](https://github.com/suitenumerique/docs/issues/1391)

## Proposal

- [x] Add descriptive `aria-label` to the "add sub-doc" button
- [x] Ensure compliance with accessibility best practices
