### PR TITLE
♿(frontend) add missing aria-label to more options button on sub-docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 - ♿(frontend) improve accessibility:
   - ♿ add missing aria-label to add sub-doc button for accessib… #1480
+  - ♿ add missing aria-label to more options button on sub-docs #1481
 
 ## [3.8.0] - 2025-10-14
 

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeItemActions.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeItemActions.tsx
@@ -152,7 +152,6 @@ export const DocTreeItemActions = ({
           options={options}
           isOpen={isOpen}
           onOpenChange={onOpenChange}
-          aria-label={t('Open document actions menu')}
         >
           <Icon
             onClick={(e) => {
@@ -164,7 +163,7 @@ export const DocTreeItemActions = ({
             variant="filled"
             $theme="primary"
             $variation="600"
-            aria-hidden="true"
+            aria-label={t('More options')}
           />
         </DropdownMenu>
         {doc.abilities.children_create && (


### PR DESCRIPTION
## Purpose

Improve accessibility by adding a missing `aria-label` to the "more options" button  
for sub-documents. This ensures the button is clearly identified by screen readers.

issue : [1392](https://github.com/suitenumerique/docs/issues/1392)

<img width="944" height="241" alt="Capture d'écran 2025-10-14 092920" src="https://github.com/user-attachments/assets/10d1c4f2-58da-486d-a07b-70a209f2c80f" />

## Proposal

- [x] Add descriptive `aria-label` to the "more options" button on sub-docs