### PR TITLE
🐛(backend) manage invitation partial update without email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 ### Fixed
 
 - ⚡️(backend) improve trashbin endpoint performance
+- 🐛(backend) manage invitation partial update without email #1494
+
 
 ## [3.8.0] - 2025-10-14
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -749,7 +749,8 @@ class InvitationSerializer(serializers.ModelSerializer):
         if self.instance is None:
             attrs["issuer"] = user
 
-        attrs["email"] = attrs["email"].lower()
+        if attrs.get("email"):
+            attrs["email"] = attrs["email"].lower()
 
         return attrs
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-member-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-member-create.spec.ts
@@ -202,8 +202,18 @@ test.describe('Document create member', () => {
     );
     await expect(userInvitation).toBeVisible();
 
+    const responsePromisePatchInvitation = page.waitForResponse(
+      (response) =>
+        response.url().includes('/invitations/') &&
+        response.status() === 200 &&
+        response.request().method() === 'PATCH',
+    );
+
     await userInvitation.getByLabel('doc-role-dropdown').click();
     await page.getByRole('menuitem', { name: 'Reader' }).click();
+
+    const responsePatchInvitation = await responsePromisePatchInvitation;
+    expect(responsePatchInvitation.ok()).toBeTruthy();
 
     const moreActions = userInvitation.getByRole('button', {
       name: 'Open invitation actions menu',


### PR DESCRIPTION
## Purpose

An invitation can be updated to change its role. The front use a PATCH sending only the changed role, so the email is missing in the InivtationSerializer.validate method. We have to check first if an email is present before working on it.


## Proposal

- [x] 🐛(backend) manage invitation partial update without email