### PR TITLE
⚡️(backend) improve trashbin endpoint performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
   - ♿ add missing aria-label to add sub-doc button for accessib… #1480
   - ♿ add missing aria-label to more options button on sub-docs #1481
 
+### Fixed
+
+- ⚡️(backend) improve trashbin endpoint performance
+
 ## [3.8.0] - 2025-10-14
 
 ### Added

--- a/src/backend/core/tests/documents/test_api_documents_trashbin.py
+++ b/src/backend/core/tests/documents/test_api_documents_trashbin.py
@@ -166,10 +166,10 @@ def test_api_documents_trashbin_authenticated_direct(django_assert_num_queries):
 
     expected_ids = {str(document1.id), str(document2.id), str(document3.id)}
 
-    with django_assert_num_queries(10):
+    with django_assert_num_queries(11):
         response = client.get("/api/v1.0/documents/trashbin/")
 
-    with django_assert_num_queries(4):
+    with django_assert_num_queries(5):
         response = client.get("/api/v1.0/documents/trashbin/")
 
     assert response.status_code == 200
@@ -208,10 +208,10 @@ def test_api_documents_trashbin_authenticated_via_team(
 
     expected_ids = {str(deleted_document_team1.id), str(deleted_document_team2.id)}
 
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(8):
         response = client.get("/api/v1.0/documents/trashbin/")
 
-    with django_assert_num_queries(3):
+    with django_assert_num_queries(4):
         response = client.get("/api/v1.0/documents/trashbin/")
 
     assert response.status_code == 200


### PR DESCRIPTION
## Purpose

The trashbin endpoint is slow. To filter documents the user has owner access, we use a subquery to compute the roles and then filter on this subquery. This is very slow. To improve it, we use the same way to filter children used in the tree endpoint. First we look for all highest ancestors the user has access on with the owner role. Then we create one queryset filtering on all the docs starting by the given path and are deleted.



## Proposal

- [x]  ⚡️(backend) improve trashbin endpoint performance