### PR TITLE
🐛(frontend) fix new document button text wrapping in german

### DIFF
--- a/src/frontend/apps/impress/src/pages/globals.css
+++ b/src/frontend/apps/impress/src/pages/globals.css
@@ -103,3 +103,9 @@ nextjs-portal {
   white-space: nowrap !important;
   border: 0 !important;
 }
+
+/* Fix for New Document button text wrapping issue */
+[data-testid="new-doc-button"] {
+  white-space: nowrap !important;
+  min-width: fit-content !important;
+}


### PR DESCRIPTION
Prevent text wrapping in New Document button when German language is selected. Added CSS rules to ensure button text displays on single line for all languages. Fixes issue #1490.

## Purpose

This pull request fixes a UI issue where the "New Document" button text wraps to multiple lines when longer translations are used, particularly noticeable with German "Neues Dokument". This creates an unprofessional appearance and inconsistent button sizing across different languages.

## Proposal

- [x] Add CSS rule targeting `[data-testid="new-doc-button"]` to prevent text wrapping
- [x] Apply `white-space: nowrap !important` to keep text on single line
- [x] Add `min-width: fit-content !important` to allow button to expand for longer text
- [x] Ensure fix works for all language translations (tested with longest ones: Spanish/Italian "Nuevo documento"/"Nuovo documento")
- [x] Update CHANGELOG.md with fix entry