### PR TITLE
✨(frontend) preserve @ character when esc is pressed after typing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 - ♿(frontend) improve accessibility:
   - ♿(frontend) improve ARIA in doc grid and editor for a11y #1519
 - 🐛(docx) fix image overflow by limiting width to 600px during export #1525
+- 🐛(frontend) preserve @ character when esc is pressed after typing it #1512
 
 ## [3.9.0] - 2025-11-10
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-editor.spec.ts
@@ -806,6 +806,12 @@ test.describe('Doc Editor', () => {
     });
     await expect(interlinkChild1).toBeVisible({ timeout: 10000 });
     await expect(interlinkChild1.locator('svg').first()).toBeVisible();
+
+    await page.keyboard.press('@');
+
+    await page.keyboard.press('Escape');
+
+    await expect(editor.getByText('@')).toBeVisible();
   });
 
   test('it checks multiple big doc scroll to the top', async ({


### PR DESCRIPTION
## Purpose

Fix unintended removal of the @ symbol when pressing Esc during mention input.
This improves text editing flow, especially when @ is intended as plain text.


https://github.com/user-attachments/assets/35bc8bb9-8c8b-47c2-b243-632464eb610d

issue [1487](https://github.com/suitenumerique/docs/issues/1487)

## Proposal

- [x] Prevent deletion of @ when mention suggestion is cancelled with Esc
- [x]  Ensure consistency across platforms and editors
- [x] Add e2e test
