### PR TITLE
✨(frontend) remove empty alt on logo due to Axe a11y error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 - 🐛(frontend) fix duplicate document entries in grid #1479
 - 🐛(frontend) show full nested doc names with ajustable bar #1456
 - 🐛(backend) fix trashbin list
+- ♿(frontend) improve accessibility:
+  - ♿(frontend) remove empty alt on logo due to Axe a11y error #1516
 
 ## [3.8.2] - 2025-10-17
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/header.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/header.spec.ts
@@ -159,7 +159,7 @@ test.describe('Header: Override configuration', () => {
           logo: {
             src: '/assets/logo-gouv.svg',
             width: '220px',
-            alt: 'Gouvernement Logo',
+            alt: '',
           },
         },
       },
@@ -168,8 +168,11 @@ test.describe('Header: Override configuration', () => {
     await page.goto('/');
     const header = page.locator('header').first();
 
-    await expect(header.getByAltText('Gouvernement Logo')).toBeVisible();
+    const logoImage = header.getByTestId('header-icon-docs');
+    await expect(logoImage).toBeVisible();
 
-    await expect(header.getByAltText('Docs')).toBeHidden();
+    await expect(logoImage).not.toHaveAttribute('src', '/assets/icon-docs.svg');
+    await expect(logoImage).toHaveAttribute('src', '/assets/logo-gouv.svg');
+    await expect(logoImage).toHaveAttribute('alt', '');
   });
 });

--- a/src/frontend/apps/impress/src/features/header/components/Header.tsx
+++ b/src/frontend/apps/impress/src/features/header/components/Header.tsx
@@ -68,7 +68,7 @@ export const Header = () => {
             className="c__image-system-filter"
             data-testid="header-icon-docs"
             src={logo?.src || '/assets/icon-docs.svg'}
-            alt={logo?.alt || t('Docs')}
+            alt=""
             width={0}
             height={0}
             style={{

--- a/src/frontend/apps/impress/src/features/header/types.ts
+++ b/src/frontend/apps/impress/src/features/header/types.ts
@@ -3,6 +3,5 @@ export interface HeaderType {
     src?: string;
     width?: string;
     height?: string;
-    alt?: string;
   };
 }

--- a/src/helm/env.d/dev/configuration/theme/demo.json
+++ b/src/helm/env.d/dev/configuration/theme/demo.json
@@ -137,8 +137,7 @@
   "header": {
     "logo": {
       "src": "/assets/icon-docs.svg",
-      "width": "32px",
-      "alt": "Notes"
+      "width": "32px"
     }
   }
 }


### PR DESCRIPTION
## Purpose

Fix an accessibility issue raised by Axe: the logo image had an alt attribute, which was redundant with the surrounding link’s aria-label="Back to homepage". 

## Proposal

- [x] Set alt="" on the logo image to avoid redundancy
- [x] Ensure a11y remains covered by the parent link’s aria-label
