### PR TITLE
🐛(docx) fix image overflow by limiting width to 600px during export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 - ♿(frontend) improve accessibility:
   - ♿(frontend) improve ARIA in doc grid and editor for a11y #1519
+- 🐛(docx) fix image overflow by limiting width to 600px during export #1525
 
 ## [3.9.0] - 2025-11-10
 

--- a/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/imageDocx.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/imageDocx.tsx
@@ -50,9 +50,9 @@ export const blockMappingImageDocx: DocsExporterDocx['mappings']['blockMapping']
 
     const { width, height } = dimensions;
 
-    if (previewWidth && previewWidth > MAX_WIDTH) {
-      previewWidth = MAX_WIDTH;
-    }
+    // Ensure the final width never exceeds MAX_WIDTH to prevent images
+    // from overflowing the page width in the exported document
+    const finalWidth = Math.min(previewWidth || width, MAX_WIDTH);
 
     return [
       new Paragraph({
@@ -71,8 +71,8 @@ export const blockMappingImageDocx: DocsExporterDocx['mappings']['blockMapping']
                 }
               : undefined,
             transformation: {
-              width: previewWidth || width,
-              height: ((previewWidth || width) / width) * height,
+              width: finalWidth,
+              height: (finalWidth / width) * height,
             },
           }),
         ],


### PR DESCRIPTION
## Purpose

Fix a bug causing images to overflow page width during DOCX export.

issue [1505](https://github.com/suitenumerique/docs/issues/1505)

<img width="826" height="656" alt="DocxImage" src="https://github.com/user-attachments/assets/d28e4738-bb86-4a22-b0a4-dd53d6432983" />

## Proposal

- [x] Calculate a final width capped at 600px using `Math.min(previewWidth || width, MAX_WIDTH)`
- [x] Ensure proportional height scaling
- [x] Prevent images from exceeding the page width when no preview width is defined
