### PR TITLE
✨(frontend) fix pdf embed to use full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
   - ♿(frontend) improve accessibility and styling of summary table #1528
 - 🐛(docx) fix image overflow by limiting width to 600px during export #1525
 - 🐛(frontend) preserve @ character when esc is pressed after typing it #1512
+- 🐛(frontend) fix pdf embed to use full width #1526
 
 ## [3.9.0] - 2025-11-10
 
@@ -32,6 +33,7 @@ and this project adheres to
 
 - 🐛(frontend) fix duplicate document entries in grid #1479
 - 🐛(backend) fix trashbin list #1520
+
 - ♿(frontend) improve accessibility:
   - ♿(frontend) remove empty alt on logo due to Axe a11y error #1516
 - 🐛(backend) fix s3 version_id validation #1543

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/PdfBlock.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/PdfBlock.tsx
@@ -22,8 +22,8 @@ import { Box, Icon } from '@/components';
 import { DocsBlockNoteEditor } from '../../types';
 
 const PDFBlockStyle = createGlobalStyle`
-  .bn-block-content[data-content-type="pdf"] {
-    width: fit-content;
+  .bn-block-content[data-content-type="pdf"] .bn-file-block-content-wrapper[style*="fit-content"] {
+    width: 100% !important;
   }
 `;
 


### PR DESCRIPTION
## Purpose

Fix a styling issue where embedded PDFs appeared too narrow due to `width: fit-content` on their wrapper.

issue : [1492](https://github.com/suitenumerique/docs/issues/1492)

<img width="980" height="423" alt="pdfwidth" src="https://github.com/user-attachments/assets/65f03fdc-c5f2-45b1-8140-cd15c8a6c338" />

## Proposal

- [x] Override wrapper style for PDF blocks to force `width: 100%`
- [x] Maintain default height at 450px
- [x] Improve visual consistency of PDF previews in the document editor