### PR TITLE
♿(frontend) add focus trap and enter key support to remove doc modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - ♿(frontend) improve accessibility:
   - ♿(frontend) improve ARIA in doc grid and editor for a11y #1519
   - ♿(frontend) improve accessibility and styling of summary table #1528
+  - ♿(frontend) add focus trap and enter key support to remove doc modal #1531
 - 🐛(docx) fix image overflow by limiting width to 600px during export #1525
 - 🐛(frontend) preserve @ character when esc is pressed after typing it #1512
 - 🐛(frontend) fix pdf embed to use full width #1526

--- a/src/frontend/apps/impress/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/frontend/apps/impress/src/components/dropdown-menu/DropdownMenu.tsx
@@ -12,6 +12,7 @@ import { css } from 'styled-components';
 
 import { Box, BoxButton, BoxProps, DropButton, Icon, Text } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
+import { useKeyboardAction } from '@/hooks';
 
 import { useDropdownKeyboardNav } from './hook/useDropdownKeyboardNav';
 
@@ -57,6 +58,7 @@ export const DropdownMenu = ({
   testId,
 }: PropsWithChildren<DropdownMenuProps>) => {
   const { spacingsTokens, colorsTokens } = useCunninghamTheme();
+  const keyboardAction = useKeyboardAction();
   const [isOpen, setIsOpen] = useState(opened ?? false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const blockButtonRef = useRef<HTMLDivElement>(null);
@@ -92,6 +94,14 @@ export const DropdownMenu = ({
       }
     }
   }, [isOpen, options]);
+
+  const triggerOption = useCallback(
+    (option: DropdownMenuOption) => {
+      onOpenChange?.(false);
+      void option.callback?.();
+    },
+    [onOpenChange],
+  );
 
   if (disabled) {
     return children;
@@ -170,9 +180,9 @@ export const DropdownMenu = ({
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
-                  onOpenChange?.(false);
-                  void option.callback?.();
+                  triggerOption(option);
                 }}
+                onKeyDown={keyboardAction(() => triggerOption(option))}
                 key={option.label}
                 $align="center"
                 $justify="space-between"

--- a/src/frontend/apps/impress/src/hooks/index.ts
+++ b/src/frontend/apps/impress/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useKeyboardAction';

--- a/src/frontend/apps/impress/src/hooks/useKeyboardAction.ts
+++ b/src/frontend/apps/impress/src/hooks/useKeyboardAction.ts
@@ -1,0 +1,22 @@
+import { KeyboardEvent, useCallback } from 'react';
+
+type KeyboardActionCallback = () => void | Promise<unknown>;
+type KeyboardActionHandler = (event: KeyboardEvent<HTMLElement>) => void;
+
+/**
+ * Hook to create keyboard handlers that trigger the provided callback
+ * when the user presses Enter or Space.
+ */
+export const useKeyboardAction = () => {
+  return useCallback(
+    (callback: KeyboardActionCallback): KeyboardActionHandler =>
+      (event: KeyboardEvent<HTMLElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          event.stopPropagation();
+          void callback();
+        }
+      },
+    [],
+  );
+};


### PR DESCRIPTION
## Purpose

Improve accessibility and keyboard interactions for remove modal component

issue : [1530](https://github.com/suitenumerique/docs/issues/1530)

## Proposal

- [x] Add a focus trap inside `ModalRemoveDoc`
- [x] Allow opening the modal via Enter key
- [x] Create reusable `useKeyboardAction` hook for Enter/Space handlers