### PR TITLE
🐛(backend) fix s3 version_id validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - 🐛(backend) fix trashbin list
 - ♿(frontend) improve accessibility:
   - ♿(frontend) remove empty alt on logo due to Axe a11y error #1516
+- 🐛(backend) fix s3 version_id validation
 
 ## [3.8.2] - 2025-10-17
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1105,7 +1105,7 @@ class DocumentViewSet(
     @drf.decorators.action(
         detail=True,
         methods=["get", "delete"],
-        url_path="versions/(?P<version_id>[0-9a-z-]+)",
+        url_path=r"versions/(?P<version_id>[A-Za-z0-9._+\-=~]{1,1024})",
     )
     # pylint: disable=unused-argument
     def versions_detail(self, request, pk, version_id, *args, **kwargs):


### PR DESCRIPTION
## Purpose

The regex used on the version_detail endpoint path is not fully compatible with the S3 spec. In the S3 specs, Version IDs are Unicode, UTF-8 encoded, URL-ready, opaque strings that are no more than 1,024 bytes long. We don't accept all unicode characters but enough to be compliant.


## Proposal

- [x] 🐛(backend) fix s3 version_id validation
