### PR TITLE
🐛(frontend) make summary button fixed to remain visible during scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
   - ♿(frontend) add focus trap and enter key support to remove doc modal #1531
 - 🐛(docx) fix image overflow by limiting width to 600px during export #1525
 - 🐛(frontend) preserve @ character when esc is pressed after typing it #1512
+- 🐛(frontend) make summary button fixed to remain visible during scroll #1581
 - 🐛(frontend) fix pdf embed to use full width #1526
 - 🐛(pdf) fix table cell alignment issue in exported documents #1582
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/DocEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/DocEditor.tsx
@@ -99,6 +99,7 @@ export const DocEditor = ({ doc }: DocEditorProps) => {
     <>
       {isDesktop && (
         <Box
+          $height="100vh"
           $position="absolute"
           $css={css`
             top: 72px;

--- a/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
@@ -108,9 +108,10 @@ export const TableContent = () => {
       $align="center"
       $padding={isHover ? 'xs' : '0'}
       $justify="center"
-      $position="relative"
+      $position="sticky"
       aria-label={t('Summary')}
       $css={css`
+        top: 0;
         border: 1px solid ${colorsTokens['greyscale-300']};
         overflow: hidden;
         border-radius: ${spacingsTokens['3xs']};


### PR DESCRIPTION
## Purpose

Ensure the "Summary" button remains visible during user scrolls, especially on long documents

issue : https://github.com/suitenumerique/docs/issues/1578

## Proposal

- [x] Change button position from relative to fixed
- [x] Add right: 30px offset to keep it anchored to the viewport

