### PR TITLE
🐛(pdf) fix table cell alignment issue in exported documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - 🐛(docx) fix image overflow by limiting width to 600px during export #1525
 - 🐛(frontend) preserve @ character when esc is pressed after typing it #1512
 - 🐛(frontend) fix pdf embed to use full width #1526
+- 🐛(pdf) fix table cell alignment issue in exported documents #1582
 
 ## [3.9.0] - 2025-11-10
 

--- a/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/tablePDF.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/tablePDF.tsx
@@ -103,7 +103,15 @@ export const blockMappingTablePDF: DocsExporterPDF['mappings']['blockMapping']['
 
                 return (
                   <TD key={colIndex} style={arrayStyle}>
-                    <Text style={styles.cell}>
+                    <Text
+                      style={[
+                        styles.cell,
+                        {
+                          width: '100%',
+                          textAlign: cellProps.textAlignment ?? 'left',
+                        },
+                      ]}
+                    >
                       {exporter.transformInlineContent(cell)}
                     </Text>
                   </TD>


### PR DESCRIPTION
## Purpose

Improve the visual rendering of tables in PDF exports by aligning cell content according to the specified alignment (textAlign) in the editor.

issue : https://github.com/suitenumerique/docs/issues/1579

<img width="980" height="423" alt="alignment" src="https://github.com/user-attachments/assets/91a1fe3e-4e28-48a0-b333-192c29b474ce" />

## Proposal

- [x]  Add textAlign and width: 100% directly to the <Text> node inside <TD>
- [x]  Preserve fallback to left alignment if none is specified

