### PR TITLE
🐛(frontend) preserve left panel width on window resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to
 ### Security
 
 - mitigate role escalation in the ask_for_access viewset #1580
+- 🐛(frontend) preserve left panel width on window resize #1588
 
 ### Removed
 


### PR DESCRIPTION
## Purpose

Fix a bug where the left panel unexpectedly expanded or shrank when the window was resized. The expected behavior is that the left panel width should remain constant unless manually adjusted by the user.

issue [1573](https://github.com/suitenumerique/docs/issues/1573)


https://github.com/user-attachments/assets/0cf330c7-1279-49c9-9059-c3d892a9e51c

## Proposal

- [x]  Remove global recalculation of min/max panel size on window resize
- [x]  Track panel width in pixels (savedWidthPxRef) and convert it to % only when needed
- [x]  Force the panel to maintain its width percentage equivalent after resize