### PR TITLE
🐛(frontend) prevent duplicate as first character in title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
   - ♿(frontend) improve screen reader support in DocShare modal #1628
 - 🐛(frontend) fix toolbar not activated when reader #1640
 - 🐛(frontend) preserve left panel width on window resize #1588
+- 🐛(frontend) prevent duplicate as first character in title #1595
 
 ## [3.10.0] - 2025-11-18
 

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocTitle.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocTitle.tsx
@@ -122,11 +122,17 @@ const DocTitleInput = ({ doc }: DocTitleProps) => {
       if (isTopRoot) {
         const sanitizedTitle = updateDocTitle(doc, inputText);
         setTitleDisplay(sanitizedTitle);
+        return sanitizedTitle;
       } else {
-        const sanitizedTitle = updateDocTitle(
-          doc,
-          emoji ? `${emoji} ${inputText}` : inputText,
-        );
+        const { emoji: pastedEmoji } = getEmojiAndTitle(inputText);
+        const textPreservingPastedEmoji = pastedEmoji
+          ? `\u200B${inputText}`
+          : inputText;
+        const finalTitle = emoji
+          ? `${emoji} ${textPreservingPastedEmoji}`
+          : textPreservingPastedEmoji;
+
+        const sanitizedTitle = updateDocTitle(doc, finalTitle);
         const { titleWithoutEmoji: sanitizedTitleWithoutEmoji } =
           getEmojiAndTitle(sanitizedTitle);
 

--- a/src/frontend/apps/impress/src/features/docs/doc-management/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/utils.ts
@@ -26,12 +26,13 @@ export const getEmojiAndTitle = (title: string) => {
   // Use emoji-regex library for comprehensive emoji detection compatible with ES5
   const regex = emojiRegex();
 
-  // Check if the title starts with an emoji
-  const match = title.match(regex);
+  // Ignore leading spaces when checking for a leading emoji
+  const trimmedTitle = title.trimStart();
+  const match = trimmedTitle.match(regex);
 
-  if (match && title.startsWith(match[0])) {
+  if (match && trimmedTitle.startsWith(match[0])) {
     const emoji = match[0];
-    const titleWithoutEmoji = title.substring(emoji.length).trim();
+    const titleWithoutEmoji = trimmedTitle.substring(emoji.length).trim();
     return { emoji, titleWithoutEmoji };
   }
 


### PR DESCRIPTION
## Purpose

Fix duplicated emoji when pasting an emoji at the beginning of a sub‑doc title. The pasted emoji must stay in the title and must not be turned into the sub‑doc icon.

issue : [1592](https://github.com/suitenumerique/docs/issues/1592)

https://github.com/user-attachments/assets/2615d86f-390a-43ae-8026-93b9af59cc16

## Proposal

- [x] Preserve pasted leading emoji in title; prevent icon capture via zero‑width space in DocTitle.tsx
- [x] Keep existing icon unchanged; icon only changes via “Add/Remove emoji”
- [x] Make emoji detection ignore leading spaces in `getEmojiAndTitle`