### PR TITLE
🐛(export) fix export unsupported colors

### DIFF
--- a/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/paragraphPDF.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/paragraphPDF.tsx
@@ -23,8 +23,9 @@ export const blockMappingParagraphPDF: DocsExporterPDF['mappings']['blockMapping
         });
       }
     }
+
     return (
-      <Text key={block.id}>
+      <Text key={'paragraph' + block.id}>
         {exporter.transformInlineContent(block.content)}
       </Text>
     );

--- a/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/tablePDF.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/tablePDF.tsx
@@ -2,7 +2,7 @@
  * We use mainly the Blocknotes code, mixed with @ag-media/react-pdf-table
  * to have a better Table support.
  * See:
- * https://github.com/TypeCellOS/BlockNote/blob/004c0bf720fe1415c497ad56449015c5f4dd7ba0/packages/xl-pdf-exporter/src/pdf/util/table/Table.tsx
+ * https://github.com/TypeCellOS/BlockNote/blob/main/packages/xl-pdf-exporter/src/pdf/util/table/Table.tsx
  *
  * We succeeded to manage the colspan, but rowspan is not supported yet.
  */
@@ -92,11 +92,12 @@ export const blockMappingTablePDF: DocsExporterPDF['mappings']['blockMapping']['
                     color:
                       cellProps.textColor === 'default'
                         ? undefined
-                        : options.colors[cellProps.textColor].text,
+                        : options.colors?.[cellProps.textColor]?.text,
                     backgroundColor:
                       cellProps.backgroundColor === 'default'
                         ? undefined
-                        : options.colors[cellProps.backgroundColor].background,
+                        : options.colors?.[cellProps.backgroundColor]
+                            ?.background,
                     textAlign: cellProps.textAlignment,
                   },
                 ];

--- a/src/frontend/apps/impress/src/features/docs/doc-export/mappingDocx.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/mappingDocx.tsx
@@ -39,5 +39,39 @@ export const docxDocsSchemaMappings: DocsExporterDocx['mappings'] = {
             shading: { fill: 'DCDCDC' },
           }
         : {},
+    // If the color is not defined, we fall back to default colors
+    backgroundColor: (val, exporter) => {
+      if (!val) {
+        return {};
+      }
+
+      const backgroundColor = exporter.options.colors?.[val]?.background;
+
+      if (!backgroundColor) {
+        return {};
+      }
+
+      return {
+        shading: {
+          fill: backgroundColor.slice(1),
+        },
+      };
+    },
+    // If the color is not defined, we fall back to default colors
+    textColor: (val, exporter) => {
+      if (!val) {
+        return {};
+      }
+
+      const color = exporter.options.colors?.[val]?.text;
+
+      if (!color) {
+        return {};
+      }
+
+      return {
+        color: color.slice(1),
+      };
+    },
   },
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-export/mappingODT.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/mappingODT.ts
@@ -32,5 +32,30 @@ export const odtDocsSchemaMappings: DocsExporterODT['mappings'] = {
   },
   styleMapping: {
     ...odtDefaultSchemaMappings.styleMapping,
+    textColor: (val, exporter): Record<string, string> => {
+      if (!val) {
+        return {};
+      }
+      const color = exporter.options.colors?.[val]?.text;
+
+      if (!color) {
+        return {};
+      }
+
+      return { 'fo:color': color };
+    },
+
+    backgroundColor: (val, exporter): Record<string, string> => {
+      if (!val) {
+        return {};
+      }
+      const color = exporter.options.colors?.[val]?.background;
+
+      if (!color) {
+        return {};
+      }
+
+      return { 'fo:background-color': color };
+    },
   },
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-export/mappingPDF.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/mappingPDF.tsx
@@ -39,5 +39,37 @@ export const pdfDocsSchemaMappings: DocsExporterPDF['mappings'] = {
     // that is not available in italics
     code: (enabled?: boolean) =>
       enabled ? { fontFamily: 'Courier', backgroundColor: '#dcdcdc' } : {},
+    // If the color is not defined, we fall back to default colors
+    textColor: (val, exporter) => {
+      if (!val) {
+        return {};
+      }
+
+      const color = exporter.options.colors?.[val]?.text;
+
+      if (!color) {
+        return {};
+      }
+
+      return {
+        color,
+      };
+    },
+    // If the color is not defined, we fall back to default colors
+    backgroundColor: (val, exporter) => {
+      if (!val) {
+        return {};
+      }
+
+      const backgroundColor = exporter.options.colors?.[val]?.background;
+
+      if (!backgroundColor) {
+        return {};
+      }
+
+      return {
+        backgroundColor,
+      };
+    },
   },
 };


### PR DESCRIPTION
## Purpose

Partial fix of https://github.com/suitenumerique/docs/issues/1552

Some colors bind to a text style are not supported. It comes often from a paste style. 
We don't display them if they are not supported by the editor.

