### PR TITLE
🐛(frontend) fix fallback translations with Trans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 - 🐛(frontend) preserve @ character when esc is pressed after typing it #1512
 - 🐛(frontend) make summary button fixed to remain visible during scroll #1581
 - 🐛(frontend) fix pdf embed to use full width #1526
+- 🐛(frontend) fix fallback translations with Trans #1620
 - 🐛(pdf) fix table cell alignment issue in exported documents #1582
 
 ### Security

--- a/src/frontend/apps/e2e/__tests__/app-impress/home.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/home.spec.ts
@@ -27,6 +27,33 @@ test.describe('Home page', () => {
     // Check the titles
     const h2 = page.locator('h2');
     await expect(h2.getByText('Govs ❤️ Open Source.')).toBeVisible();
+    await expect(page.getByText('Docs is built on top of')).toBeVisible();
+    await expect(
+      page.getByRole('link', {
+        name: 'Django Rest Framework',
+      }),
+    ).toHaveAttribute('href', 'https://www.django-rest-framework.org/');
+    await expect(page.getByText('You can easily self-host Docs')).toBeVisible();
+    await expect(
+      page
+        .getByRole('link', {
+          name: 'licence',
+        })
+        .first(),
+    ).toHaveAttribute(
+      'href',
+      'https://github.com/suitenumerique/docs/blob/main/LICENSE',
+    );
+    await expect(
+      page.getByText('Docs is the result of a joint effort lead by the French'),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByRole('link', {
+          name: 'Zendis',
+        })
+        .first(),
+    ).toHaveAttribute('href', 'https://zendis.de/');
     await expect(
       h2.getByText('Collaborative writing, Simplified.'),
     ).toBeVisible();

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -62,7 +62,7 @@
     "react": "*",
     "react-aria-components": "1.13.0",
     "react-dom": "*",
-    "react-i18next": "16.2.3",
+    "react-i18next": "16.3.3",
     "react-intersection-observer": "10.0.0",
     "react-resizable-panels": "3.0.6",
     "react-select": "5.10.2",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -12518,10 +12518,10 @@ react-dom@*, react-dom@19.2.0:
   dependencies:
     scheduler "^0.27.0"
 
-react-i18next@16.2.3:
-  version "16.2.3"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-16.2.3.tgz#079e3c54c85334ce9ab9732be3553516a7b7b42d"
-  integrity sha512-O0t2zvmIz7nHWKNfIL+O/NTIbpTaOPY0vZov779hegbep3IZ+xcqkeVPKWBSXwzdkiv77q8zmq9toKIUys1x3A==
+react-i18next@16.3.3:
+  version "16.3.3"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-16.3.3.tgz#098ff5443d0436a78692ca76303b2219aca32989"
+  integrity sha512-IaY2W+ueVd/fe7H6Wj2S4bTuLNChnajFUlZFfCTrTHWzGcOrUHlVzW55oXRSl+J51U8Onn6EvIhQ+Bar9FUcjw==
   dependencies:
     "@babel/runtime" "^7.27.6"
     html-parse-stringify "^3.0.1"


### PR DESCRIPTION
## Purpose

The fallback of the Trans component didn't work anymore after upgrade to 16.2.3 of react-i18next.
Upgrading to 16.3.3 fixed the issue.
We added a test to cover this case.

Only the english language is impacted.


## Demo

https://docs.numerique.gouv.fr/home/

<img width="856" height="479" alt="image" src="https://github.com/user-attachments/assets/51176f7b-7820-4f36-bdd6-0de97e90d563" />


