### PR TITLE
🐛(pdf) preserve image aspect ratio in PDF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - 🐛(frontend) fix pdf embed to use full width #1526
 - 🐛(frontend) fix fallback translations with Trans #1620
 - 🐛(pdf) fix table cell alignment issue in exported documents #1582
+- 🐛(pdf) preserve image aspect ratio in PDF export #1622
 
 ### Security
 

--- a/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/imageDocx.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/imageDocx.tsx
@@ -31,15 +31,10 @@ export const blockMappingImageDocx: DocsExporterDocx['mappings']['blockMapping']
       const svgText = await blob.text();
       const FALLBACK_SIZE = 536;
       previewWidth = previewWidth || blob.size || FALLBACK_SIZE;
-      pngConverted = await convertSvgToPng(svgText, previewWidth);
-      const img = new Image();
-      img.src = pngConverted;
-      await new Promise((resolve) => {
-        img.onload = () => {
-          dimensions = { width: img.width, height: img.height };
-          resolve(null);
-        };
-      });
+
+      const result = await convertSvgToPng(svgText, previewWidth);
+      pngConverted = result.png;
+      dimensions = { width: result.width, height: result.height };
     } else {
       dimensions = await getImageDimensions(blob);
     }

--- a/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/imageODT.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/blocks-mapping/imageODT.tsx
@@ -28,15 +28,10 @@ export const blockMappingImageODT: DocsExporterODT['mappings']['blockMapping']['
         const svgText = await blob.text();
         const FALLBACK_SIZE = 536;
         previewWidth = previewWidth || blob.size || FALLBACK_SIZE;
-        pngConverted = await convertSvgToPng(svgText, previewWidth);
-        const img = new Image();
-        img.src = pngConverted;
-        await new Promise((resolve) => {
-          img.onload = () => {
-            dimensions = { width: img.width, height: img.height };
-            resolve(null);
-          };
-        });
+
+        const result = await convertSvgToPng(svgText, previewWidth);
+        pngConverted = result.png;
+        dimensions = { width: result.width, height: result.height };
       } else {
         dimensions = await getImageDimensions(blob);
       }

--- a/src/frontend/apps/impress/src/features/docs/doc-export/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/utils.ts
@@ -20,18 +20,21 @@ export function downloadFile(blob: Blob, filename: string) {
 }
 
 /**
- * Converts an SVG string into a PNG image and returns it as a data URL.
+ * Converts an SVG string into a PNG image and returns it as a data URL with dimensions.
  *
  * This function creates a canvas, parses the SVG, calculates the appropriate height
  * to preserve the aspect ratio, and renders the SVG onto the canvas using Canvg.
  *
  * @param {string} svgText - The raw SVG markup to convert.
  * @param {number} width - The desired width of the output PNG (height is auto-calculated to preserve aspect ratio).
- * @returns {Promise<string>} A Promise that resolves to a PNG image encoded as a base64 data URL.
+ * @returns {Promise<{ png: string; width: number; height: number }>} A Promise that resolves to an object containing the PNG data URL and its dimensions.
  *
  * @throws Will throw an error if the canvas context cannot be initialized.
  */
-export async function convertSvgToPng(svgText: string, width: number) {
+export async function convertSvgToPng(
+  svgText: string,
+  width: number,
+): Promise<{ png: string; width: number; height: number }> {
   // Create a canvas and render the SVG onto it
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d', {
@@ -64,7 +67,11 @@ export async function convertSvgToPng(svgText: string, width: number) {
   svg.resize(width, height, true);
   await svg.render();
 
-  return canvas.toDataURL('image/png');
+  return {
+    png: canvas.toDataURL('image/png'),
+    width,
+    height: height || width,
+  };
 }
 
 export function docxBlockPropsToStyles(


### PR DESCRIPTION
## Purpose

Ensure images maintain their original aspect ratio in PDF exports, aligning behavior with DOCX/ODT exports 

<img width="247" height="586" alt="image" src="https://github.com/user-attachments/assets/61769f81-5cc2-4ea0-b79b-3b553b4b05b8" />

## Proposal 

- [x] Ensure getImageDimensions() supports both SVG and raster formats
- [x] Apply proportional height calculation in the PDF renderer
- [x] Add MAX_WIDTH constraint to match DOCX/ODT behavior
