### PR TITLE
🔧(helm) create a symlink between helmfile config

### DIFF
--- a/src/helm/helmfile.gotmpl
+++ b/src/helm/helmfile.gotmpl
@@ -1,0 +1,1 @@
+helmfile.yaml


### PR DESCRIPTION


## Purpose

We want to have both helmfile.yaml and helmfile.gotmpl present. helmfile.gotmpl is for now a symlink of helmfile.yaml


## Proposal

- [x] 🔧(helm) create a symlink between helmfile config
