### PR TITLE
✨(frontend) add /new route for document creation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 - ♿(frontend) improve accessibility:
   - ♿(frontend) improve share modal button accessibility #1626
-
+- ✨(frontend) add /new route for document creation #1641
 ## [3.10.0] - 2025-11-18
 
 ### Added

--- a/src/frontend/apps/impress/src/pages/new/index.tsx
+++ b/src/frontend/apps/impress/src/pages/new/index.tsx
@@ -1,0 +1,79 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+import { Loading } from '@/components';
+import { gotoLogin, useAuth } from '@/features/auth';
+import { useCreateDoc } from '@/features/docs/doc-management';
+import { useSkeletonStore } from '@/features/skeletons';
+import { NextPageWithLayout } from '@/types/next';
+
+const Page: NextPageWithLayout = () => {
+  const router = useRouter();
+  const { authenticated } = useAuth();
+  const { setIsSkeletonVisible } = useSkeletonStore();
+  const [isNavigating, setIsNavigating] = useState(false);
+  const [hasCreated, setHasCreated] = useState(false);
+
+  const { mutate: createDoc, isPending: isDocCreating } = useCreateDoc({
+    onSuccess: (doc) => {
+      setIsNavigating(true);
+      setHasCreated(true);
+      // Wait for navigation to complete
+      router
+        .replace(`/docs/${doc.id}`)
+        .then(() => {
+          // The skeleton will be disabled by the [id] page once the data is loaded
+          setIsNavigating(false);
+        })
+        .catch(() => {
+          // In case of navigation error, disable the skeleton
+          setIsSkeletonVisible(false);
+          setIsNavigating(false);
+        });
+    },
+    onError: () => {
+      // If there's an error, disable the skeleton
+      setIsSkeletonVisible(false);
+      setIsNavigating(false);
+    },
+  });
+
+  /**
+   * Redirect to login if user is not authenticated
+   */
+  useEffect(() => {
+    // If not authenticated, redirect to login
+    if (!authenticated) {
+      gotoLogin();
+      return;
+    }
+  }, [authenticated]);
+
+  /**
+   * Create a new document when the page is visited
+   * Only create if user is authenticated
+   */
+  useEffect(() => {
+    // Don't create if not authenticated (will be redirected)
+    if (!authenticated) {
+      return;
+    }
+
+    // Create document only if authenticated and not already created
+    if (!hasCreated && !isDocCreating && !isNavigating) {
+      setIsSkeletonVisible(true);
+      createDoc();
+    }
+  }, [
+    authenticated,
+    hasCreated,
+    isDocCreating,
+    isNavigating,
+    createDoc,
+    setIsSkeletonVisible,
+  ]);
+
+  return <Loading />;
+};
+
+export default Page;


### PR DESCRIPTION
Introduce a /new route that automatically creates a document and redirects users to it. This enables direct document creation via URL, bookmarks, or automation scripts.

When unauthenticated users access /new, they are redirected to login instead of home page since user intent is explicit.

This addresses user requests for programmatic document creation and provides a shareable link for "create new document" actions.