### PR TITLE
🌐(backend) internationalize demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 ### Changed
 
 - 🚸(backend) use unaccented full name for user search #1637
+- 🌐(backend) internationalize demo #1644
 
 ## [4.1.0] - 2025-12-09
 

--- a/src/backend/demo/management/commands/create_demo.py
+++ b/src/backend/demo/management/commands/create_demo.py
@@ -17,7 +17,8 @@ from core import models
 
 from demo import defaults
 
-fake = Faker()
+languages = [x for (x, y) in settings.LANGUAGES]
+fake = Faker(languages)
 
 logger = logging.getLogger("impress.commands.demo.create_demo")
 
@@ -127,7 +128,7 @@ def create_demo(stdout):
                     is_staff=False,
                     short_name=first_name,
                     full_name=f"{first_name:s} {random.choice(last_names):s}",
-                    language=random.choice(settings.LANGUAGES)[0],
+                    language=random.choice(languages),
                 )
             )
         queue.flush()
@@ -179,8 +180,7 @@ def create_demo(stdout):
                     is_superuser=False,
                     is_active=True,
                     is_staff=False,
-                    language=dev_user["language"]
-                    or random.choice(settings.LANGUAGES)[0],
+                    language=dev_user["language"] or random.choice(languages),
                 )
             )
 


### PR DESCRIPTION
## Purpose
This allows the demo to generate user and filenames with other locales than English, for all languages defined in the project's settings. In particular, it allows the generation of accented names, which were previously missing.


## Proposal
- [x] Use the list of languages defined in settings in the call to `Faker()`

## Image
<img width="984" height="809" alt="Capture d’écran du 2025-11-23 11-46-05" src="https://github.com/user-attachments/assets/fb470de2-6568-4240-b4c9-44f8555213c1" />
<img width="810" height="351" alt="Capture d’écran du 2025-11-23 11-48-36" src="https://github.com/user-attachments/assets/2fe2a80a-de30-4396-a8a4-19cba8fc5380" />
