### PR TITLE
⚡️(sw) stop to cache external resources likes videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to
 - ✨ Add comments feature to the editor #1330
 - ✨(backend) Comments on text editor #1330
 
+### Changed
+
+- ⚡️(sw) stop to cache external resources likes videos #1655
+
 ### Fixed
 
 - ♿(frontend) improve accessibility:

--- a/src/frontend/apps/impress/src/features/service-worker/service-worker.ts
+++ b/src/frontend/apps/impress/src/features/service-worker/service-worker.ts
@@ -158,33 +158,6 @@ registerRoute(
 );
 
 /**
- * External urls cache strategy
- */
-registerRoute(
-  ({ url }) => !url.href.includes(self.location.origin),
-  new NetworkFirst({
-    cacheName: getCacheNameVersion('default-external'),
-    plugins: [
-      new CacheableResponsePlugin({ statuses: [0, 200] }),
-      new ExpirationPlugin({
-        maxAgeSeconds: 24 * 60 * 60 * DAYS_EXP,
-      }),
-      new OfflinePlugin(),
-    ],
-  }),
-  'GET',
-);
-
-/**
- * Admin cache strategy
- */
-registerRoute(
-  ({ url }) =>
-    url.href.includes(self.location.origin) && url.href.includes('/admin/'),
-  new NetworkOnly(),
-);
-
-/**
  * Cache strategy static files images (images / svg)
  */
 registerRoute(
@@ -215,6 +188,24 @@ registerRoute(
       }),
     ],
   }),
+);
+
+/**
+ * External urls cache strategy
+ */
+registerRoute(
+  ({ url }) => !url.href.includes(self.location.origin),
+  new NetworkOnly(),
+  'GET',
+);
+
+/**
+ * Admin cache strategy
+ */
+registerRoute(
+  ({ url }) =>
+    url.href.includes(self.location.origin) && url.href.includes('/admin/'),
+  new NetworkOnly(),
 );
 
 /**


### PR DESCRIPTION
## Purpose

Some videos from external sources can be very large and slow to cache. 
To improve performance, we decided to stop caching these resources in the service worker.
We will cache only images and fonts from external sources.
The videos will maybe not be available when offline mode.