### PR TITLE
🦺(renovate) filter dependencies with minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "prCreation": "not-pending",
   "rebaseWhen": "conflicted",
   "updateNotScheduled": false,
+  "minimumReleaseAge": "15 days",
   "packageRules": [
     {
       "enabled": false,


### PR DESCRIPTION
## Purpose

To avoid updating to very recent releases that might still have undiscovered issues, this commit adds a minimum release age of 15 days to the Renovate configuration.


