### PR TITLE
🐛(nginx) fix / location to handle new static pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to
 - ♿(frontend) improve accessibility:
   - ♿(frontend) add skip to content button for keyboard accessibility #1624
 
+### Fixed
+
+- 🐛(nginx) fix / location to handle new static pages
+
 ## [4.0.0] - 2025-12-01
 
 ### Added

--- a/src/frontend/apps/impress/conf/default.conf
+++ b/src/frontend/apps/impress/conf/default.conf
@@ -6,7 +6,7 @@ server {
   root /usr/share/nginx/html;
 
   location / {
-      try_files $uri index.html $uri/ =404;
+      try_files $uri index.html $uri/index.html =404;
 
       add_header X-Frame-Options DENY always;
   }


### PR DESCRIPTION
## Purpose

The / location is not trying the $uri/index.html file. We should try
this instad of $uri/ because when a new static page is added, we always
have this pattern.


## Proposal

- [x] 🐛(nginx) fix / location to handle new static pages