### PR TITLE
♿(frontend) improve editor a11y and brand/neutral contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to
 - ♿(frontend) improve accessibility:
   - ♿(frontend) add skip to content button for keyboard accessibility #1624
 
+
 ### Fixed
 
 - 🐛(nginx) fix / location to handle new static pages
+- ♿(frontend) improve accessibility:
+  - ♿(frontend) improve editor a11y and brand/neutral contrast #1683
+
 
 ## [4.0.0] - 2025-12-01
 


### PR DESCRIPTION
## Purpose

Fix AXE accessibility issues related to color contrast

<img width="1902" height="847" alt="contrasterror" src="https://github.com/user-attachments/assets/c5168627-0da7-4bbc-8fa7-5660433bf345" />

@rl-83 I made a small adjusment to pass WCAG AA requirements, do you think it is ok for you ? the ratio was a bit low 

##  Proposal

- [x] - Show AXE report: previous colors failed WCAG AA (contrast ratios were ~4.48–4.49, below the 4.5:1 threshold).
- [x] - Propose and implement color changes to meet WCAG AA requirements.
- [x] - Updated tertiary text colors:
- [x]   - from `--c--globals--colors--brand-500` → `--c--globals--colors--brand-550`
- [x]   - from `--c--globals--colors--gray-500` → `--c--globals--colors--gray-550`
