### PR TITLE
♿(frontend) add missing label and fix Axes errors to improve a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to
 - 🔒(helm) Set default security context #1750
 - ✨(backend) use langfuse to monitor AI actions
 
-### Fixed 
+### Fixed
 
 - ✅(backend) reduce flakiness on backend test #1769
+- 🐛(frontend) fix clickable main content regression #1773
 - 🐛(backend) fix TRASHBIN_CUTOFF_DAYS type error #1778
 
 ### Security
@@ -27,6 +28,7 @@ and this project adheres to
 
 - ♿(frontend) improve accessibility:
   - ♿(frontend) make html export accessible to screen reader users #1743
+  - ♿(frontend) add missing label and fix Axes errors to improve a11y #1693
 
 ## [4.3.0] - 2026-01-05
 
@@ -46,7 +48,6 @@ and this project adheres to
 
 - 🐛(frontend) fix tables deletion #1739
 - 🐛(frontend) fix children not display when first resize #1753
-- 🐛(frontend) fix clickable main content regression #1773
 
 ## [4.2.0] - 2025-12-17
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -259,7 +259,6 @@ export const BlockNoteReader = ({
   const { user } = useAuth();
   const { setEditor } = useEditorStore();
   const { threadStore } = useComments(docId, false, user);
-  const { t } = useTranslation();
   const editor = useCreateBlockNote(
     {
       collaboration: {
@@ -305,7 +304,6 @@ export const BlockNoteReader = ({
         editor={editor}
         editable={false}
         theme="light"
-        aria-label={t('Document viewer')}
         formattingToolbar={false}
         slashMenu={false}
         comments={false}

--- a/src/frontend/apps/impress/src/features/docs/doc-management/components/DocIcon.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/components/DocIcon.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 
 import { BoxButton, BoxButtonType, Text, TextType } from '@/components';
 import { EmojiPicker, emojidata } from '@/docs/doc-editor/';
@@ -30,6 +31,7 @@ export const DocIcon = ({
   ...textProps
 }: DocIconProps) => {
   const { updateDocEmoji } = useDocTitleUpdate();
+  const { t } = useTranslation();
 
   const iconRef = useRef<HTMLDivElement>(null);
 
@@ -42,6 +44,14 @@ export const DocIcon = ({
   if (!withEmojiPicker && !emoji) {
     return defaultIcon;
   }
+
+  const emojiLabel = withEmojiPicker
+    ? emoji
+      ? t('Edit document emoji')
+      : t('Add emoji')
+    : emoji
+      ? t('Document emoji')
+      : undefined;
 
   const toggleEmojiPicker = (e: MouseEvent) => {
     if (withEmojiPicker) {
@@ -83,6 +93,8 @@ export const DocIcon = ({
         ref={iconRef}
         onClick={toggleEmojiPicker}
         color="tertiary-text"
+        aria-label={emojiLabel}
+        title={emojiLabel}
         {...buttonProps}
       >
         {!emoji ? (

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
@@ -199,7 +199,6 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
             <ButtonCloseModal
               aria-label={t('Close the share modal')}
               onClick={onClose}
-              tabIndex={-1}
             />
           </Box>
         }


### PR DESCRIPTION
## Purpose

Fix several Axe accessibility issues (landmarks, button names, editor label, modals).

## Proposal

- [x] Move the footer on `/home` outside of `<main>` so `contentinfo` is a sibling landmark.  
- [x] Add `aria-label`/`title` to icon-only buttons (e.g. document emoji) so they have discernible text.  
- [x] In `BlockNoteEditor`, label the real editable node `.ProseMirror.bn-edito and remove `aria-label` from `BlockNoteView`.  s a 
- [x] Fix close button that was'nt focusable in `DocShareModal.tsx`
