### PR TITLE
🐛(helm) fix OIDC authentication with standard scopes

### DIFF
--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -31,8 +31,8 @@ backend:
     LOGGING_LEVEL_HANDLERS_CONSOLE: ERROR
     LOGGING_LEVEL_LOGGERS_ROOT: INFO
     LOGGING_LEVEL_LOGGERS_APP: INFO
-    OIDC_USERINFO_SHORTNAME_FIELD: "given_name"
-    OIDC_USERINFO_FULLNAME_FIELDS: "given_name,usual_name"
+    OIDC_USERINFO_SHORTNAME_FIELD: "first_name"
+    OIDC_USERINFO_FULLNAME_FIELDS: "name"
     OIDC_OP_JWKS_ENDPOINT: https://docs-keycloak.127.0.0.1.nip.io/realms/docs/protocol/openid-connect/certs
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://docs-keycloak.127.0.0.1.nip.io/realms/docs/protocol/openid-connect/auth
     OIDC_OP_TOKEN_ENDPOINT: https://docs-keycloak.127.0.0.1.nip.io/realms/docs/protocol/openid-connect/token
@@ -42,7 +42,7 @@ backend:
     OIDC_RP_CLIENT_ID: docs
     OIDC_RP_CLIENT_SECRET: ThisIsAnExampleKeyForDevPurposeOnly
     OIDC_RP_SIGN_ALGO: RS256
-    OIDC_RP_SCOPES: "openid email given_name usual_name"
+    OIDC_RP_SCOPES: "openid email profile"
     LOGIN_REDIRECT_URL: https://docs.127.0.0.1.nip.io
     LOGIN_REDIRECT_URL_FAILURE: https://docs.127.0.0.1.nip.io
     LOGOUT_REDIRECT_URL: https://docs.127.0.0.1.nip.io

--- a/src/helm/env.d/feature/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/feature/values.impress.yaml.gotmpl
@@ -32,8 +32,8 @@ backend:
     LOGGING_LEVEL_HANDLERS_CONSOLE: ERROR
     LOGGING_LEVEL_LOGGERS_ROOT: INFO
     LOGGING_LEVEL_LOGGERS_APP: INFO
-    OIDC_USERINFO_SHORTNAME_FIELD: "given_name"
-    OIDC_USERINFO_FULLNAME_FIELDS: "given_name,usual_name"
+    OIDC_USERINFO_SHORTNAME_FIELD: "first_name"
+    OIDC_USERINFO_FULLNAME_FIELDS: "name"
     OIDC_OP_JWKS_ENDPOINT: https://{{ .Values.feature }}-docs-keycloak.{{ .Values.domain }}/realms/docs/protocol/openid-connect/certs
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://{{ .Values.feature }}-docs-keycloak.{{ .Values.domain }}/realms/docs/protocol/openid-connect/auth
     OIDC_OP_TOKEN_ENDPOINT: https://{{ .Values.feature }}-docs-keycloak.{{ .Values.domain }}/realms/docs/protocol/openid-connect/token
@@ -43,7 +43,7 @@ backend:
     OIDC_RP_CLIENT_ID: docs
     OIDC_RP_CLIENT_SECRET: ThisIsAnExampleKeyForDevPurposeOnly
     OIDC_RP_SIGN_ALGO: RS256
-    OIDC_RP_SCOPES: "openid email given_name usual_name"
+    OIDC_RP_SCOPES: "openid email profile"
     LOGIN_REDIRECT_URL: https://{{ .Values.feature }}-docs.{{ .Values.domain }}
     LOGIN_REDIRECT_URL_FAILURE: https://{{ .Values.feature }}-docs.{{ .Values.domain }}
     LOGOUT_REDIRECT_URL: https://{{ .Values.feature }}-docs.{{ .Values.domain }}


### PR DESCRIPTION
## Purpose

"usual_name" in `OIDC_RP_SCOPES` does not seem to be standard, it gives error during login.
We replace "usual_name" by "first_name".

OpenId standard:
https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims

Keyclock scopes configured: 
https://1740-docs-keycloak.ppr-docs.beta.numerique.gouv.fr/admin/master/console/#/docs/client-scopes

## Demo

<img width="617" height="647" alt="user2" src="https://github.com/user-attachments/assets/42b2539c-1b68-44a2-8c62-95d60590ad1b" />

Gives:
<img width="365" height="145" alt="image" src="https://github.com/user-attachments/assets/a238f35f-4366-465f-8db6-c799536504a0" />



