### PR TITLE
♿️(frontend) fix subdoc opening and emoji picker focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,12 @@ and this project adheres to
 - 🌐(backend) internationalize demo #1644
 - ♿(frontend) improve accessibility:
   - ♿️Improve keyboard accessibility for the document tree #1681
+  - ♿️(frontend) fix subdoc opening and emoji pick focus
 
 ### Fixed
 
 - 🐛(frontend) paste content with comments from another document #1732
 - 🐛(frontend) Select text + Go back one page crash the app #1733
-
 
 ## [4.1.0] - 2025-12-09
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/EmojiPicker.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/EmojiPicker.tsx
@@ -1,6 +1,6 @@
 import { EmojiMartData } from '@emoji-mart/data';
 import Picker from '@emoji-mart/react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box } from '@/components';
@@ -20,11 +20,29 @@ export const EmojiPicker = ({
 }: EmojiPickerProps) => {
   const { i18n } = useTranslation();
 
+  // Close picker with Escape key for keyboard users
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        event.preventDefault();
+        onClickOutside();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown, true);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [onClickOutside]);
+
   const pickerContent = (
     <Box $position="absolute" $zIndex={1000} $margin="2rem 0 0 0">
       <Picker
         data={emojiData}
         locale={i18n.resolvedLanguage}
+        autoFocus
         onClickOutside={onClickOutside}
         onEmojiSelect={onEmojiSelect}
         previewPosition="none"

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocSubPageItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocSubPageItem.tsx
@@ -18,6 +18,7 @@ import {
   useTrans,
 } from '@/docs/doc-management';
 import { useLeftPanelStore } from '@/features/left-panel';
+import { useKeyboardActivation } from '@/hooks/useKeyboardActivation';
 import { useResponsiveStore } from '@/stores';
 
 import SubPageIcon from './../assets/sub-page-logo.svg';
@@ -97,6 +98,7 @@ export const DocSubPageItem = (props: TreeViewNodeProps<Doc>) => {
   const isDisabled = !!doc.deleted_at;
   const actionsRef = useRef<HTMLDivElement>(null);
   const buttonOptionRef = useRef<HTMLDivElement | null>(null);
+  const isActive = node.isFocused;
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     // F2: focus first action button
@@ -107,6 +109,14 @@ export const DocSubPageItem = (props: TreeViewNodeProps<Doc>) => {
       return;
     }
   };
+
+  useKeyboardActivation(
+    ['Enter'],
+    isActive && !menuOpen,
+    handleActivate,
+    true,
+    '.c__tree-view',
+  );
 
   const handleActionsOpenChange = (isOpen: boolean) => {
     setMenuOpen(isOpen);

--- a/src/frontend/apps/impress/src/hooks/index.ts
+++ b/src/frontend/apps/impress/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useKeyboardAction';
+export * from './useKeyboardActivation';

--- a/src/frontend/apps/impress/src/hooks/useKeyboardActivation.ts
+++ b/src/frontend/apps/impress/src/hooks/useKeyboardActivation.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+export const useKeyboardActivation = (
+  keys: string[],
+  enabled: boolean,
+  action: () => void,
+  capture = false,
+  selector: string,
+) => {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (keys.includes(e.key)) {
+        // Ignore if focus is on interactive elements (emoji picker button, actions menu, etc.)
+        const target = e.target as HTMLElement | null;
+        if (
+          target?.closest('.--docs--doc-icon') ||
+          target?.closest('.light-doc-item-actions') ||
+          target?.closest('button') ||
+          target?.closest('[role="menu"]') ||
+          target?.closest('[role="menuitem"]')
+        ) {
+          return;
+        }
+
+        e.preventDefault();
+        action();
+      }
+    };
+    const treeEl = document.querySelector<HTMLElement>(selector);
+    if (!treeEl) {
+      return;
+    }
+    treeEl.addEventListener('keydown', onKeyDown, capture);
+    return () => {
+      treeEl.removeEventListener('keydown', onKeyDown, capture);
+    };
+  }, [keys, enabled, action, capture, selector]);
+};


### PR DESCRIPTION
## Purpose

Improve keyboard accessibility when opening the emoji picker
by focusing the input field automatically. Also fix keyboard interaction with
subdocuments using the Enter key.

## Proposal

Automatically place focus on the search input when the emoji picker opens.
Additionally, ensure that pressing Enter correctly selects subdocuments,
improving keyboard usability.

- [x] Focus emoji picker input on open
- [x] Fix Enter key handling on subdocuments