### PR TITLE
♿️(frontend) fix subdoc opening and emoji pick focus 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to
 
 - ✅(e2e) fix e2e test for other browsers #1799
 
+### Changed
+
+- ♿(frontend) improve accessibility:
+  - ♿️(frontend) fix subdoc opening and emoji pick focus #1745
+
 ## [4.4.0] - 2026-01-13
 
 ### Added

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/EmojiPicker.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/EmojiPicker.tsx
@@ -20,11 +20,23 @@ export const EmojiPicker = ({
 }: EmojiPickerProps) => {
   const { i18n } = useTranslation();
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      onClickOutside();
+    }
+  };
+
   const pickerContent = (
-    <Box $position="absolute" $zIndex={1000} $margin="2rem 0 0 0">
+    <Box
+      $position="absolute"
+      $zIndex={1000}
+      $margin="2rem 0 0 0"
+      onKeyDownCapture={handleKeyDown}
+    >
       <Picker
         data={emojiData}
         locale={i18n.resolvedLanguage}
+        autoFocus
         onClickOutside={onClickOutside}
         onEmojiSelect={onEmojiSelect}
         previewPosition="none"

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/CalloutBlock.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/CalloutBlock.tsx
@@ -106,11 +106,6 @@ const CalloutComponent = ({
         <BoxButton
           contentEditable={false}
           onClick={toggleEmojiPicker}
-          onKeyDown={(e) => {
-            if (e.key === 'Escape' && openEmojiPicker) {
-              setOpenEmojiPicker(false);
-            }
-          }}
           $css={css`
             font-size: 1.125rem;
             cursor: ${isEditable ? 'pointer' : 'default'};

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
@@ -128,6 +128,27 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
     }
   }, []);
 
+  const handleRowKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== 'Enter') {
+      return;
+    }
+
+    const target = e.target as HTMLElement | null;
+    if (
+      !target ||
+      !(
+        target.classList.contains('c__tree-view--row') ||
+        target.classList.contains('c__tree-view--node')
+      )
+    ) {
+      return;
+    }
+
+    e.currentTarget
+      .querySelector<HTMLDivElement>('.c__tree-view--node')
+      ?.click();
+  }, []);
+
   /**
    * This effect is used to reset the tree when a new document
    * that is not part of the current tree is loaded.
@@ -357,6 +378,9 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
               }}
               rootNodeId={treeContext.root.id}
               renderNode={DocSubPageItem}
+              rowProps={{
+                onKeyDown: handleRowKeyDown,
+              }}
             />
           </Overlayer>
         )}


### PR DESCRIPTION
## Purpose

Improve keyboard accessibility when opening the emoji picker
by focusing the input field automatically. Also fix keyboard interaction with
subdocuments using the Enter key.

## Proposal

Automatically place focus on the search input when the emoji picker opens.
Additionally, ensure that pressing Enter correctly selects subdocuments,
improving keyboard usability.

- [x] Focus emoji picker input on open
- [x] Fix Enter key handling on subdocuments