### PR TITLE
🔒(helm) Set default security context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 - ✨(backend) add documents/all endpoint with descendants #1553
 - ✅(export) add PDF regression tests #1762
 - 📝(docs) Add language configuration documentation #1757
+- 🔒(helm) Set default security context #1750
 
 ### Fixed 
 

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -227,7 +227,14 @@ backend:
     backoffLimit: 2
 
   ## @param backend.securityContext Configure backend Pod security context
-  securityContext: null
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - "ALL"
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   ## @param backend.envVars Configure backend container environment variables
   ## @extra backend.envVars.BY_VALUE Example environment variable by setting value directly
@@ -431,7 +438,14 @@ frontend:
   sidecars: []
 
   ## @param frontend.securityContext Configure frontend Pod security context
-  securityContext: null
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - "ALL"
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   ## @param frontend.envVars Configure frontend container environment variables
   ## @extra frontend.envVars.BY_VALUE Example environment variable by setting value directly
@@ -603,7 +617,14 @@ yProvider:
   sidecars: []
 
   ## @param yProvider.securityContext Configure yProvider Pod security context
-  securityContext: null
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - "ALL"
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
   ## @param yProvider.envVars Configure yProvider container environment variables
   ## @extra yProvider.envVars.BY_VALUE Example environment variable by setting value directly


### PR DESCRIPTION
In order to be able to deploy this in a restricted k8s cluster, we set this default security context.

We set it as default because it doesn't change the way the app runs.

So it is better to be more secured by default.

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)