### PR TITLE
🐛(frontend) fix children not display when first resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(frontend) fix tables deletion #1752
+- 🐛(frontend) fix children not display when first resize #1753
 
 
 ## [4.2.0] - 2025-12-17

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocSubPageItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocSubPageItem.tsx
@@ -172,7 +172,10 @@ export const DocSubPageItem = (props: TreeViewNodeProps<Doc>) => {
           emoji={emoji}
           withEmojiPicker={doc.abilities.partial_update}
           defaultIcon={
-            <SubPageIcon color="var(--c--contextuals--content--semantic--info--tertiary)" />
+            <SubPageIcon
+              color="var(--c--contextuals--content--semantic--info--tertiary)"
+              style={{ flexShrink: 0 }}
+            />
           }
           $size="sm"
           docId={doc.id}

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
@@ -63,13 +63,11 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
     });
     treeContext?.treeData.handleMove(result);
   };
+
   /**
    * This function resets the tree states.
    */
   const resetStateTree = useCallback(() => {
-    if (!treeContext?.root?.id) {
-      return;
-    }
     treeContext?.setRoot(null);
     setInitialOpenState(undefined);
   }, [treeContext]);


### PR DESCRIPTION
## Purpose

When we resize the window for the first time, then open the panel, the children were not displayed.

## Demo


https://github.com/user-attachments/assets/ef652572-1e7d-4e11-b3fe-077ff783819b



