### PR TITLE
🥅(frontend) intercept 401 error on GET threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ and this project adheres to
 - ✨(helm) redirecting system #1697
 - 📱(frontend) add comments for smaller device #1737
 
+### Changed
+
+- 🥅(frontend) intercept 401 error on GET threads #1754
+
 ### Fixed
 
 - 🐛(frontend) fix tables deletion #1752
+
 
 ## [4.2.0] - 2025-12-17
 


### PR DESCRIPTION
## Purpose

We intercept 401 errors on GET /threads to avoid spamming Sentry with authentication errors when users are not logged in.


