### PR TITLE
🦺(frontend) check content type pdf on PdfBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to
 
 - 🥅(frontend) intercept 401 error on GET threads #1754
 
+## Changed
+
+- 🦺(frontend) check content type pdf on PdfBlock #1756
+
 ### Fixed
 
 - 🐛(frontend) fix tables deletion #1752

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/conf.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/conf.ts
@@ -1,0 +1,1 @@
+export const ANALYZE_URL = 'media-check';

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useUploadFile.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useUploadFile.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { backendUrl } from '@/api';
 
 import { useCreateDocAttachment } from '../api';
+import { ANALYZE_URL } from '../conf';
 import { DocsBlockNoteEditor } from '../types';
 
 export const useUploadFile = (docId: string) => {
@@ -46,7 +47,6 @@ export const useUploadFile = (docId: string) => {
  * @param editor
  */
 export const useUploadStatus = (editor: DocsBlockNoteEditor) => {
-  const ANALYZE_URL = 'media-check';
   const { t } = useTranslation();
 
   /**


### PR DESCRIPTION
## Purpose

Pdfblock was quite permissive on the content type it was accepting. 
Now it checks that the content type is exactly 'application/pdf' before rendering the PDF viewer.


