### PR TITLE
✅(backend) fix flaky test in user search api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to
 - ✨(backend) add documents/all endpoint with descendants #1553
 - ✅(export) add PDF regression tests #1762
 
+### Fixed 
+
+- ✅(backend) reduce flakiness on backend test #1769
+
 ## [4.3.0] - 2026-01-05
 
 ### Added

--- a/src/backend/core/tests/test_api_users.py
+++ b/src/backend/core/tests/test_api_users.py
@@ -311,7 +311,7 @@ def test_api_users_list_query_short_queries():
     """
     Queries shorter than 5 characters should return an empty result set.
     """
-    user = factories.UserFactory(email="paul@example.com")
+    user = factories.UserFactory(email="paul@example.com", full_name="Paul")
     client = APIClient()
     client.force_login(user)
 


### PR DESCRIPTION
Make sure the full is never John for the first user in order to make sure we always have only 2 users (as the search is performed on both the email and the full name).

Fixes #1765

## Purpose
Fix a flaky test

## External contributions

This is my first contribution, let me know if I did something wrong :) 

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)