### PR TITLE
🐛(frontend) fix clickable main content regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to
 
 - 🐛(frontend) fix tables deletion #1739
 - 🐛(frontend) fix children not display when first resize #1753
-
+- 🐛(frontend) fix clickable main content regression #1773
 
 ## [4.2.0] - 2025-12-17
 

--- a/src/frontend/apps/impress/src/layouts/MainLayout.tsx
+++ b/src/frontend/apps/impress/src/layouts/MainLayout.tsx
@@ -120,7 +120,7 @@ const MainContent = ({
       $css={css`
         overflow-y: auto;
         overflow-x: clip;
-        &:focus {
+        &:focus-visible {
           outline: 3px solid ${colorsTokens['brand-400']};
           outline-offset: -3px;
         }


### PR DESCRIPTION
## Purpose

Fix regression where the main content became unintentionally clickable after introducing the skip-to-content feature.

issue [https://github.com/suitenumerique/docs/issues/1772](1772)

## Proposal

- [x] Remove unintended clickable area on main content  
- [x] Replace `:focus` with `:focus-visible` to improve focus handling
