### PR TITLE
📱(frontend) toolbar to the bottom when mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - 🥅(frontend) intercept 401 error on GET threads #1754
 - 🦺(frontend) check content type pdf on PdfBlock #1756
 - ✈️(frontend) pause Posthog when offline #1755
+- 📱(frontend) toolbar to the bottom when mobile #1774
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/core/AppProvider.tsx
+++ b/src/frontend/apps/impress/src/core/AppProvider.tsx
@@ -52,13 +52,16 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const { theme } = useCunninghamTheme();
   const { replace } = useRouter();
 
-  const initializeResizeListener = useResponsiveStore(
-    (state) => state.initializeResizeListener,
-  );
+  const { initializeResizeListener, initializeInputDetection } =
+    useResponsiveStore();
 
   useEffect(() => {
     return initializeResizeListener();
   }, [initializeResizeListener]);
+
+  useEffect(() => {
+    return initializeInputDetection();
+  }, [initializeInputDetection]);
 
   /**
    * Update the global router replace function

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/BlockNoteToolbar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/BlockNoteToolbar.tsx
@@ -35,7 +35,7 @@ export const BlockNoteToolbar = () => {
   const [onConfirm, setOnConfirm] = useState<() => void | Promise<void>>();
   const { t } = useTranslation();
   const { data: conf } = useConfig();
-  const { isMobile, isTablet } = useResponsiveStore();
+  const { isTablet, isInputTouch } = useResponsiveStore();
 
   const toolbarItems = useMemo(() => {
     let toolbarItems = getFormattingToolbarItems([
@@ -96,7 +96,7 @@ export const BlockNoteToolbar = () => {
 
   return (
     <>
-      {isMobile || isTablet ? (
+      {isInputTouch && isTablet ? (
         <MobileFormattingToolbarController
           formattingToolbar={formattingToolbar}
         />
@@ -133,7 +133,6 @@ const MobileFormattingToolbarController = ({
 
   return (
     <Box
-      $margin="auto"
       $position="absolute"
       $css={`
         & > div {

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/BlockNoteToolbar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/BlockNoteToolbar.tsx
@@ -1,15 +1,26 @@
+import { FormattingToolbarExtension } from '@blocknote/core/extensions';
 import {
+  ExperimentalMobileFormattingToolbarController,
   FormattingToolbar,
   FormattingToolbarController,
   blockTypeSelectItems,
   getFormattingToolbarItems,
+  useBlockNoteEditor,
   useDictionary,
+  useExtensionState,
 } from '@blocknote/react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { Box } from '@/components';
 import { useConfig } from '@/core/config/api';
+import { useResponsiveStore } from '@/stores';
 
+import {
+  DocsBlockSchema,
+  DocsInlineContentSchema,
+  DocsStyleSchema,
+} from '../../types';
 import { CommentToolbarButton } from '../comments/CommentToolbarButton';
 import { getCalloutFormattingToolbarItems } from '../custom-blocks';
 
@@ -24,6 +35,7 @@ export const BlockNoteToolbar = () => {
   const [onConfirm, setOnConfirm] = useState<() => void | Promise<void>>();
   const { t } = useTranslation();
   const { data: conf } = useConfig();
+  const { isMobile, isTablet } = useResponsiveStore();
 
   const toolbarItems = useMemo(() => {
     let toolbarItems = getFormattingToolbarItems([
@@ -84,7 +96,13 @@ export const BlockNoteToolbar = () => {
 
   return (
     <>
-      <FormattingToolbarController formattingToolbar={formattingToolbar} />
+      {isMobile || isTablet ? (
+        <MobileFormattingToolbarController
+          formattingToolbar={formattingToolbar}
+        />
+      ) : (
+        <FormattingToolbarController formattingToolbar={formattingToolbar} />
+      )}
       {confirmOpen && (
         <ModalConfirmDownloadUnsafe
           onClose={() => setIsConfirmOpen(false)}
@@ -92,5 +110,41 @@ export const BlockNoteToolbar = () => {
         />
       )}
     </>
+  );
+};
+
+const MobileFormattingToolbarController = ({
+  formattingToolbar,
+}: {
+  formattingToolbar: () => React.ReactNode;
+}) => {
+  const editor = useBlockNoteEditor<
+    DocsBlockSchema,
+    DocsInlineContentSchema,
+    DocsStyleSchema
+  >();
+  const show = useExtensionState(FormattingToolbarExtension, {
+    editor,
+  });
+
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <Box
+      $margin="auto"
+      $position="absolute"
+      $css={`
+        & > div {
+        left: 50%;
+        transform: translate(0px, 0px) scale(1) translateX(-50%)!important;
+      }
+    `}
+    >
+      <ExperimentalMobileFormattingToolbarController
+        formattingToolbar={formattingToolbar}
+      />
+    </Box>
   );
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/MarkdownButton.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteToolBar/MarkdownButton.tsx
@@ -74,7 +74,9 @@ export function MarkdownButton() {
   };
 
   const show = useMemo(() => {
-    return !!selectedBlocks.find((block) => block.content !== undefined);
+    return (
+      selectedBlocks.filter((block) => block.content !== undefined).length !== 0
+    );
   }, [selectedBlocks]);
 
   if (!show || !editor.isEditable || !Components) {

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/PdfBlock.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/PdfBlock.tsx
@@ -59,11 +59,7 @@ interface PdfBlockComponentProps {
   >;
 }
 
-const PdfBlockComponent = ({
-  editor,
-  block,
-  contentRef,
-}: PdfBlockComponentProps) => {
+const PdfBlockComponent = ({ editor, block }: PdfBlockComponentProps) => {
   const pdfUrl = block.props.url;
   const { i18n, t } = useTranslation();
   const lang = i18n.resolvedLanguage;
@@ -114,27 +110,34 @@ const PdfBlockComponent = ({
     void validatePDFContent();
   }, [pdfUrl]);
 
+  if (isPDFContentLoading) {
+    return <Loading />;
+  }
+
+  if (!isPDFContentLoading && isPDFContent !== null && !isPDFContent) {
+    return (
+      <Box
+        $align="center"
+        $justify="center"
+        $color="#666"
+        $background="#f5f5f5"
+        $border="1px solid #ddd"
+        $height="300px"
+        $css={css`
+          text-align: center;
+        `}
+        $width="100%"
+        contentEditable={false}
+        onClick={() => editor.setTextCursorPosition(block)}
+      >
+        {t('Invalid or missing PDF file.')}
+      </Box>
+    );
+  }
+
   return (
-    <Box ref={contentRef} className="bn-file-block-content-wrapper">
+    <>
       <PDFBlockStyle />
-      {isPDFContentLoading && <Loading />}
-      {!isPDFContentLoading && isPDFContent !== null && !isPDFContent && (
-        <Box
-          $align="center"
-          $justify="center"
-          $color="#666"
-          $background="#f5f5f5"
-          $border="1px solid #ddd"
-          $height="300px"
-          $css={css`
-            text-align: center;
-          `}
-          contentEditable={false}
-          onClick={() => editor.setTextCursorPosition(block)}
-        >
-          {t('Invalid or missing PDF file.')}
-        </Box>
-      )}
       <ResizableFileBlockWrapper
         buttonIcon={
           <Icon iconName="upload" $size="24px" $css="line-height: normal;" />
@@ -158,7 +161,7 @@ const PdfBlockComponent = ({
           />
         )}
       </ResizableFileBlockWrapper>
-    </Box>
+    </>
   );
 };
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -180,6 +180,9 @@ export const cssEditor = css`
     & .bn-editor {
       padding-right: 36px;
     }
+    & .bn-toolbar {
+      max-width: 100vw;
+    }
   }
 
   @media screen and (width <= 560px) {

--- a/src/frontend/apps/impress/src/layouts/MainLayout.tsx
+++ b/src/frontend/apps/impress/src/layouts/MainLayout.tsx
@@ -120,7 +120,7 @@ const MainContent = ({
       $css={css`
         overflow-y: auto;
         overflow-x: clip;
-        &:focus {
+        &:focus-visible {
           outline: 3px solid ${colorsTokens['brand-400']};
           outline-offset: -3px;
         }


### PR DESCRIPTION
## Purpose

On mobile devices, the mobile toolbar is often positioned above the Blocknote toolbar, making it hard to access.
This commit adjusts the toolbar position to the bottom of the screen for better accessibility when using mobile devices.


## Demo

https://github.com/user-attachments/assets/2383e9b6-e07c-4276-aab7-d0bfa299522f

