### PR TITLE
💄(frontend) fix icon position in callout block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - ✅(backend) reduce flakiness on backend test #1769
 - 🐛(frontend) fix clickable main content regression #1773
 - 🐛(backend) fix TRASHBIN_CUTOFF_DAYS type error #1778
+- 💄(frontend) fix icon position in callout block #1779
 
 ### Security
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/CalloutBlock.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/CalloutBlock.tsx
@@ -97,7 +97,12 @@ const CalloutComponent = ({
       `}
     >
       <CalloutBlockStyle />
-      <Box $position="relative">
+      <Box
+        $position="relative"
+        $css={css`
+          align-self: start;
+        `}
+      >
         <BoxButton
           contentEditable={false}
           onClick={toggleEmojiPicker}


### PR DESCRIPTION
Make sure the icon in the callout block is aligned to the top instead of centered when we have multi-line content.

## Purpose

Make sure the icon / emoji picker stays at the top of the block. Fixes #1608


Before

<img width="1108" height="306" alt="image" src="https://github.com/user-attachments/assets/4ee0f0ff-9ad3-407c-a7f7-1c3dcbc5edeb" />


After

<img width="893" height="343" alt="image" src="https://github.com/user-attachments/assets/a64f0cb3-5da5-43a0-8111-37383f0e6f78" />



## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)