### PR TITLE
🚸(frontend) remove blocking modal on save in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,19 +14,20 @@ and this project adheres to
 - 🔒(helm) Set default security context #1750
 - ✨(backend) use langfuse to monitor AI actions
 
-### Fixed 
-
-- ✅(backend) reduce flakiness on backend test #1769
-- 🐛(backend) fix TRASHBIN_CUTOFF_DAYS type error #1778
-
-### Security
-
-- 🔒️(backend) validate more strictly url used by cors-proxy endpoint #1768
-
 ### Changed
 
 - ♿(frontend) improve accessibility:
   - ♿(frontend) make html export accessible to screen reader users #1743
+
+### Fixed 
+
+- ✅(backend) reduce flakiness on backend test #1769
+- 🐛(backend) fix TRASHBIN_CUTOFF_DAYS type error #1778
+- 🚸(frontend) remove blocking modal on save in Firefox #1787
+
+### Security
+
+- 🔒️(backend) validate more strictly url used by cors-proxy endpoint #1768
 
 ## [4.3.0] - 2026-01-05
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useSaveDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useSaveDoc.tsx
@@ -4,7 +4,6 @@ import * as Y from 'yjs';
 
 import { useUpdateDoc } from '@/docs/doc-management/';
 import { KEY_LIST_DOC_VERSIONS } from '@/docs/doc-versioning';
-import { isFirefox } from '@/utils/userAgent';
 
 import { toBase64 } from '../utils';
 
@@ -62,24 +61,8 @@ export const useSaveDoc = (
   const router = useRouter();
 
   useEffect(() => {
-    const onSave = (e?: Event) => {
-      const isSaving = saveDoc();
-
-      /**
-       * Firefox does not trigger the request every time the user leaves the page.
-       * Plus the request is not intercepted by the service worker.
-       * So we prevent the default behavior to have the popup asking the user
-       * if he wants to leave the page, by adding the popup, we let the time to the
-       * request to be sent, and intercepted by the service worker (for the offline part).
-       */
-      if (
-        isSaving &&
-        typeof e !== 'undefined' &&
-        e.preventDefault &&
-        isFirefox()
-      ) {
-        e.preventDefault();
-      }
+    const onSave = () => {
+      saveDoc();
     };
 
     // Save every minute

--- a/src/frontend/apps/impress/src/features/docs/doc-management/api/useUpdateDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/api/useUpdateDoc.tsx
@@ -24,6 +24,7 @@ export const updateDoc = async ({
     body: JSON.stringify({
       ...params,
     }),
+    keepalive: true,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Purpose

In Firefox the request to save documents did not complete when the user where closing is tab or browser. To let the save request complete we added a blocking modal, but it was not user friendly.
Now we removed the blocking modal and add "keepalive" option to the fetch request to let the request complete in background when the user close the tab or browser.

