### PR TITLE
✅(e2e) fix e2e test for other browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- ✅(e2e) fix e2e test for other browsers #1799
+
 ## [4.4.0] - 2026-01-13
 
 ### Added

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-comments.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-comments.spec.ts
@@ -58,7 +58,7 @@ test.describe('Doc Comments', () => {
     await page.getByRole('button', { name: '👍' }).click();
 
     await expect(
-      thread.getByRole('img', { name: 'E2E Chromium' }).first(),
+      thread.getByRole('img', { name: `E2E ${browserName}` }).first(),
     ).toBeVisible();
     await expect(thread.getByText('This is a comment').first()).toBeVisible();
     await expect(thread.getByText(`E2E ${browserName}`).first()).toBeVisible();

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-inherited-share.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-inherited-share.spec.ts
@@ -21,7 +21,7 @@ test.describe('Inherited share accesses', () => {
       `doc-share-member-row-user.test@${browserName}.test`,
     );
     await expect(user).toBeVisible();
-    await expect(user.getByText('E2E Chromium')).toBeVisible();
+    await expect(user.getByText(`E2E ${browserName}`)).toBeVisible();
     await expect(user.getByText('Owner')).toBeVisible();
 
     await page

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-common.ts
@@ -224,7 +224,9 @@ export const updateDocTitle = async (page: Page, title: string) => {
   await expect(input).toHaveText('');
   await expect(input).toBeVisible();
   await input.click();
-  await input.fill(title);
+  await input.fill(title, {
+    force: true,
+  });
   await input.click();
   await input.blur();
   await verifyDocName(page, title);


### PR DESCRIPTION
In this test the comment is made using the "current" browser which can be Chromium but can also be Firefox or Webkit.
This is why the test failed with other browsers.

There is one other occurence in this issue in src/frontend/apps/e2e/__tests__/app-impress/doc-inherited-share.spec.ts, but the test always fails on my locahost for whatever reason so I did not make the change

## Purpose

Make the test pass in the CI.


## Proposal

- [x] Maybe src/frontend/apps/e2e/__tests__/app-impress/doc-inherited-share.spec.ts should also be fixed in the same way

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)