### PR TITLE
📌(backend) pin celery to version<5.6.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,13 @@
       "allowedVersions": "<6.0.0"
     },
     {
+
+      "groupName": "allowed celery versions",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["celery"],
+      "allowedVersions": "<5.6.0"
+    },
+    {
       "enabled": false,
       "groupName": "ignored js dependencies",
       "matchManagers": ["npm"],

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "beautifulsoup4==4.14.3",
     "boto3==1.42.17",
     "Brotli==1.2.0",
-    "celery[redis]==5.6.0",
+    "celery[redis]==5.5.3",
     "django-configurations==2.5.1",
     "django-cors-headers==4.9.0",
     "django-countries==8.2.0",


### PR DESCRIPTION
## Purpose

Since celery version 5.6.0 we have trouble with retrying tasks and it is impactig the malware_detection workflow. We have to use version 5.5.3 while we found the issue.

## Proposal

- [x] 📌(backend) pin celery to version<5.6.0