### PR TITLE
🔒️(trivy) fix vulnerability about jaraco.context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to
 - ♿(frontend) improve accessibility:
   - ♿️(frontend) fix subdoc opening and emoji pick focus #1745
 
+### Security
+
+- 🔒️(trivy) fix vulnerability about jaraco.context #1806
+
+
 ## [4.4.0] - 2026-01-13
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM python:3.13.3-alpine AS base
 
 # Upgrade pip to its latest release to speed up dependencies installation
-RUN python -m pip install --upgrade pip setuptools
+RUN python -m pip install --upgrade pip
 
 # Upgrade system packages to install security updates
 RUN apk update && apk upgrade --no-cache


### PR DESCRIPTION
## Purpose

We got a vulnerability report from Trivy about `jaraco.context` package. It comes from `setuptools`.
`setuptools` does not seems used by the application. We removed it.


