### PR TITLE
🐛(backend) properly encode attachment upload content-disposition header

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -27,6 +27,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
+from django.utils.http import content_disposition_header
 from django.utils.text import capfirst, slugify
 from django.utils.translation import gettext_lazy as _
 
@@ -1661,11 +1662,19 @@ class DocumentViewSet(
             or serializer.validated_data["is_unsafe"]
         ):
             extra_args.update(
-                {"ContentDisposition": f'attachment; filename="{file_name:s}"'}
+                {
+                    "ContentDisposition": content_disposition_header(
+                        as_attachment=True, filename=file_name
+                    )
+                }
             )
         else:
             extra_args.update(
-                {"ContentDisposition": f'inline; filename="{file_name:s}"'}
+                {
+                    "ContentDisposition": content_disposition_header(
+                        as_attachment=False, filename=file_name
+                    )
+                }
             )
 
         file = serializer.validated_data["file"]


### PR DESCRIPTION
## Purpose

This pull request changes the Content-Disposition header set on S3 PutObject requests when uploading attachments to be encoded using a Django helper, properly encoding UTF-8 in filenames.

This fixes compatibility for uploading attachments with non ASCII file names to Garage, since the HTTP library used by Garage validates that HTTP Headers are ASCII only.

## Proposal

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)