### PR TITLE
Mark mosa.cloud demo instance as unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We hope to see many more, here is an incomplete list of public Docs instances. F
 | [notes.demo.opendesk.eu](https://notes.demo.opendesk.eu)    | ZenDiS    | Demo instance of OpenDesk. Request access to get credentials |
 | [notes.liiib.re](https://notes.liiib.re/)    | lasuite.coop    | Free and open demo to all. Content and accounts are reset after one month |
 | [docs.federated.nexus](https://docs.federated.nexus/)    | federated.nexus    | Public instance, but you have to [sign up for a Federated Nexus account](https://federated.nexus/register/). |
-| [docs.demo.mosacloud.eu](https://docs.demo.mosacloud.eu/)    | mosa.cloud    | Demo instance of mosa.cloud, a dutch company providing services around La Suite apps. |
+| [docs.demo.mosacloud.eu](https://docs.demo.mosacloud.eu/)    | mosa.cloud    | [⚠️ Unavailable as of 19/01/26] Demo instance of mosa.cloud, a dutch company providing services around La Suite apps. |
 
 #### ⚠️ Advanced features
 For some advanced features (ex: Export as PDF) Docs relies on XL packages from BlockNote. These are licenced under GPL and are not MIT compatible. You can perfectly use Docs without these packages by setting the environment variable `PUBLISH_AS_MIT` to true. That way you'll build an image of the application without the features that are not MIT compatible. Read the [environment variables documentation](/docs/env.md) for more information.


### PR DESCRIPTION
Updated the status of the mosa.cloud demo instance to indicate it is unavailable.

## Purpose

Describe the purpose of this pull request. 
