### PR TITLE
🐛(frontend) preserve typed text after @ on escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 - 🐛(frontend) add fallback for unsupported Blocknote languages #1810
 - 🐛(frontend) fix emojipicker closing in tree #1808
 - 🐛(frontend) display children in favorite #1782
+- 🐛(frontend) preserve typed text after @ on escape #1833
 
 ### Removed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/SearchPage.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/SearchPage.tsx
@@ -122,8 +122,8 @@ export const SearchPage = ({
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Escape') {
       e.preventDefault();
-      // Keep the trigger character ('@' or '/') in the editor when closing with Escape
-      closeSearch(trigger);
+      // Keep the trigger character and typed text in the editor when closing with Escape
+      closeSearch(`${trigger}${search}`);
     } else if (e.key === 'Backspace' && search.length === 0) {
       e.preventDefault();
       closeSearch('');


### PR DESCRIPTION
## Purpose

Fix the interlinking search behavior so pressing Escape keeps the `@` (or `/`) plus the text the user already typed.


https://github.com/user-attachments/assets/1dc675c7-17ca-4724-8706-9f8c922927ec



## Proposal

- [x] Preserve typed input when closing the inline search with Escape
- [x] Keep existing Backspace/selection behaviors unchanged