### PR TITLE
🐛(frontend) fix broadcast store sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+🐛(frontend) fix broadcast store sync #1846
+
 ## [v4.5.0] - 2026-01-28
 
 ### Added 

--- a/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useCollaboration.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useCollaboration.tsx
@@ -8,7 +8,7 @@ import { Base64 } from '../types';
 
 export const useCollaboration = (room?: string, initialContent?: Base64) => {
   const collaborationUrl = useCollaborationUrl(room);
-  const { setBroadcastProvider } = useBroadcastStore();
+  const { setBroadcastProvider, cleanupBroadcast } = useBroadcastStore();
   const { provider, createProvider, destroyProvider } = useProviderStore();
 
   useEffect(() => {
@@ -33,8 +33,9 @@ export const useCollaboration = (room?: string, initialContent?: Base64) => {
   useEffect(() => {
     return () => {
       if (room) {
+        cleanupBroadcast();
         destroyProvider();
       }
     };
-  }, [destroyProvider, room]);
+  }, [destroyProvider, room, cleanupBroadcast]);
 };


### PR DESCRIPTION
## Purpose

When going from one subdoc to another by example, the broadcast store could have difficulty to resync. This commit ensures that the broadcast store cleans up and resets its state when rerendering.
It will stop as well triggering the action for the current user avoiding potential unecessary requests.


## Demo


https://github.com/user-attachments/assets/552353d8-b5ee-4065-a45c-f569d543facb

