### PR TITLE
👷(CI) add GHCR workflow for forked repo testing

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,157 @@
+name: Build and Push to GHCR
+run-name: Build and Push to GHCR
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+
+env:
+  DOCKER_USER: 1001:127
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push-backend:
+    runs-on: ubuntu-latest
+    if: github.event.repository.fork == true
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/backend
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: backend-production
+          build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Cleanup Docker after build
+        if: always()
+        run: |
+          docker system prune -af
+          docker volume prune -f
+
+  build-and-push-frontend:
+    runs-on: ubuntu-latest
+    if: github.event.repository.fork == true
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/frontend
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/frontend/Dockerfile
+          target: frontend-production
+          build-args: |
+            DOCKER_USER=${{ env.DOCKER_USER }}:-1000
+            PUBLISH_AS_MIT=false
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Cleanup Docker after build
+        if: always()
+        run: |
+          docker system prune -af
+          docker volume prune -f
+
+  build-and-push-y-provider:
+    runs-on: ubuntu-latest
+    if: github.event.repository.fork == true
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/y-provider
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/frontend/servers/y-provider/Dockerfile
+          target: y-provider
+          build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Cleanup Docker after build
+        if: always()
+        run: |
+          docker system prune -af
+          docker volume prune -f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 - ✨(frontend) Can print a doc #1832
 - ✨(backend) manage reconciliation requests for user accounts #1878
+- 👷(CI) add GHCR workflow for forked repo testing #1851
 
 ### Changed
 


### PR DESCRIPTION
## Purpose

When I fork the project to make improvements, I want to be able to deploy it to my VPS for testing. I want an image built in a reproducible way. However, the current [`docker-hub.yml`](https://github.com/suitenumerique/docs/blob/main/.github/workflows/docker-hub.yml) is hardcoded to push to Docker Hub under `lasuite` registry.

This PR adds a GitHub Actions workflow that builds and pushes Docker images to GitHub Container Registry (GHCR) trigger. This enables forked repositories to build their own images for testing without requiring Docker Hub credentials or having to configure any credentials at all.

I created this workflow while fixing #1788 (submitted as PR #1850). To verify it works, I ran the workflow on my fork:

<img width="709" height="506" alt="image" src="https://github.com/user-attachments/assets/c299927f-7dcb-4dd5-8bcb-6cadf96a563f" />

This generates the images in my account:

<img width="296" height="171" alt="image" src="https://github.com/user-attachments/assets/60b0baea-d34c-4361-a5af-85ff55e1980c" />

Now I can test it on my VPS by pointing my Docker Compose to my built image:

<img width="717" height="158" alt="image" src="https://github.com/user-attachments/assets/b4380fa9-c392-4503-b5a9-7665e84b0f27" />

## Proposal

- [x] Create `.github/workflows/ghcr.yml` with `workflow_dispatch` trigger, based on existing `docker-hub.yml`
- [x] **Only runs on forked repos.** It will not run on the source `suitenumerique/docs` repo.
- [x] Build backend, frontend, and y-provider images
- [x] Push to `ghcr.io/{owner}/{repo}/{service}`
- [x] Support both manual triggers and pushes to main/tags
- [x] Include proper metadata tagging (branch, semver, SHA)

Notes:

- This workflow is independent of the existing Docker Hub workflow
- Both workflows can coexist and serve different purposes
- GHCR is free for public repositories

## External contributions

Thank you for your contribution! 🎉

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable) - N/A for CI workflow
