### PR TITLE
⏪️(actions) enable trivy scan on backend image

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -36,12 +36,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      # -
-      #   name: Run trivy scan
-      #   uses: numerique-gouv/action-trivy-cache@main
-      #   with:
-      #     docker-build-args: '--target backend-production -f Dockerfile'
-      #     docker-image-name: 'docker.io/lasuite/impress-backend:${{ github.sha }}'
+      -
+        name: Run trivy scan
+        uses: numerique-gouv/action-trivy-cache@main
+        with:
+          docker-build-args: '--target backend-production -f Dockerfile'
+          docker-image-name: 'docker.io/lasuite/impress-backend:${{ github.sha }}'
       -
         name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Purpose

The trivy was disabled because protobuf library was blocking the release process. We can now enable it again, a new release of protobuf is available.

## Proposal

- [x] ⏪️(actions) enable trivy scan on backend image