### PR TITLE
♿️ (frontend) prevent dates from being focusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to
 
 ### Changed
 
+- ♿️(frontend) prevent dates from being focusable #1855
 - ♿️(frontend) Focus main container after navigation #1854
-- 🚸(backend) sort user search results by proximity with the active user #1802 
+- 🚸(backend) sort user search results by proximity with the active user #1802
 - 🚸(oidc) ignore case when fallback on email #1880
-
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
@@ -223,7 +223,7 @@ export const DocsGridItemDate = ({
   }
 
   return (
-    <StyledLink href={`/docs/${doc.id}`}>
+    <StyledLink href={`/docs/${doc.id}`} tabIndex={-1}>
       <Text
         $size="xs"
         $layer="background"


### PR DESCRIPTION
## Purpose

Improve keyboard accessibility by preventing date links from being focusable
while keeping them clickable for mouse users.

## Proposal

- [x] Remove date links from the tab order in the docs grid.
- [x] Keep date cells clickable with the mouse for consistency.