### PR TITLE
[helm] Allow mounting secrets via extraVolumes (not just configMaps etc.)

### DIFF
--- a/src/helm/impress/templates/backend_deployment.yaml
+++ b/src/helm/impress/templates/backend_deployment.yaml
@@ -135,6 +135,9 @@ spec:
           {{- if .existingClaim }}
           persistentVolumeClaim:
             claimName: {{ .existingClaim }}
+          {{- else if .secret }}
+          secret:
+            {{ toYaml .secret | nindent 12 }}
           {{- else if .hostPath }}
           hostPath:
             {{ toYaml .hostPath | nindent 12 }}

--- a/src/helm/impress/templates/celery_worker_deployment.yaml
+++ b/src/helm/impress/templates/celery_worker_deployment.yaml
@@ -135,6 +135,9 @@ spec:
           {{- if .existingClaim }}
           persistentVolumeClaim:
             claimName: {{ .existingClaim }}
+          {{- else if .secret }}
+          secret:
+            {{ toYaml .secret | nindent 12 }}
           {{- else if .hostPath }}
           hostPath:
             {{ toYaml .hostPath | nindent 12 }}

--- a/src/helm/impress/templates/frontend_deployment.yaml
+++ b/src/helm/impress/templates/frontend_deployment.yaml
@@ -125,6 +125,9 @@ spec:
           {{- if .existingClaim }}
           persistentVolumeClaim:
             claimName: {{ .existingClaim }}
+          {{- else if .secret }}
+          secret:
+            {{ toYaml .secret | nindent 12 }}
           {{- else if .hostPath }}
           hostPath:
             {{ toYaml .hostPath | nindent 12 }}

--- a/src/helm/impress/templates/yprovider_deployment.yaml
+++ b/src/helm/impress/templates/yprovider_deployment.yaml
@@ -125,6 +125,9 @@ spec:
           {{- if .existingClaim }}
           persistentVolumeClaim:
             claimName: {{ .existingClaim }}
+          {{- else if .secret }}
+          secret:
+            {{ toYaml .secret | nindent 12 }}
           {{- else if .hostPath }}
           hostPath:
             {{ toYaml .hostPath | nindent 12 }}


### PR DESCRIPTION
## Purpose

Allow mounting secrets via extraVolumes.

Fixes #1866

## Proposal

Adds another if-condition for mounting secrets to the already implemented functionality to mount configMaps etc.

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [X] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [X] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [X] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [X] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)