### PR TITLE
🔧(compose) replace minio by rustfs

### DIFF
--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Configure Rustfs
         run: |
-          docker exec rustfs sh -c \
+          docker run --rm -it minio/mc sh -c \
             "mc alias set impress http://localhost:9000 impress password && \
             mc alias ls && \
             mc mb impress/impress-media-storage && \

--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -189,11 +189,12 @@ jobs:
 
       - name: Configure Rustfs
         run: |
-          docker run --rm minio/mc sh -c \
-            "mc alias set impress http://localhost:9000 impress password && \
-            mc alias ls && \
-            mc mb impress/impress-media-storage && \
-            mc version enable impress/impress-media-storage"
+          curl --progress-bar -L https://dl.min.io/aistor/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          /tmp/mc alias set impress http://localhost:9000 impress password
+          /tmp/mc alias ls
+          /tmp/mc mb impress/impress-media-storage
+          /tmp/mc version enable impress/impress-media-storage
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Configure Rustfs
         run: |
-          docker run --rm -it minio/mc sh -c \
+          docker run --rm minio/mc sh -c \
             "mc alias set impress http://localhost:9000 impress password && \
             mc alias ls && \
             mc mb impress/impress-media-storage && \

--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -164,29 +164,31 @@ jobs:
           key: mail-templates-${{ hashFiles('src/mail/mjml') }}
           fail-on-cache-miss: true
 
-      - name: Start MinIO
+      - name: Start Rustfs
         run: |
-          docker pull minio/minio
-          docker run -d --name minio \
+          docker pull rustfs/rustfs:latest
+          docker run -d --name rustfs \
             -p 9000:9000 \
-            -e "MINIO_ACCESS_KEY=impress" \
-            -e "MINIO_SECRET_KEY=password" \
+            -e "RUSTFS_ACCESS_KEY=impress" \
+            -e "RUSTFS_SECRET_KEY=password" \
+            -e "RUSTFS_ADDRESS=0.0.0.0:9000" \
+            -e "RUSTFS_CORS_ALLOWED_ORIGINS=*" \
+            -e "RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS=*" \
             -v /data/media:/data \
-            minio/minio server --console-address :9001 /data
+            rustfs/rustfs /data
 
       # Tool to wait for a service to be ready
       - name: Install Dockerize
         run: |
           curl -sSL https://github.com/jwilder/dockerize/releases/download/v0.8.0/dockerize-linux-amd64-v0.8.0.tar.gz | sudo tar -C /usr/local/bin -xzv
 
-      - name: Wait for MinIO to be ready
+      - name: Wait for Rustfs to be ready
         run: |
           dockerize -wait tcp://localhost:9000 -timeout 10s
 
-      - name: Configure MinIO
+      - name: Configure Rustfs
         run: |
-          MINIO=$(docker ps | grep minio/minio | sed -E 's/.*\s+([a-zA-Z0-9_-]+)$/\1/')
-          docker exec ${MINIO} sh -c \
+          docker exec rustfs sh -c \
             "mc alias set impress http://localhost:9000 impress password && \
             mc alias ls && \
             mc mb impress/impress-media-storage && \

--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Start Rustfs
         run: |
           docker pull rustfs/rustfs:latest
-          docker run -d --name rustfs \
+          docker run --name rustfs \
             -p 9000:9000 \
             -e "RUSTFS_ACCESS_KEY=impress" \
             -e "RUSTFS_SECRET_KEY=password" \

--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Start Rustfs
         run: |
-          docker pull rustfs/rustfs:latest
+          docker pull rustfs/rustfs:1.0.0-alpha.83
           docker run -d --name rustfs \
             -p 9000:9000 \
             -e "RUSTFS_ACCESS_KEY=impress" \
@@ -189,7 +189,7 @@ jobs:
 
       - name: Configure Rustfs
         run: |
-          curl --progress-bar -L https://dl.min.io/aistor/mc/release/linux-amd64/mc -o /tmp/mc
+          curl -L https://dl.min.io/aistor/mc/release/linux-amd64/mc -o /tmp/mc
           chmod +x /tmp/mc
           /tmp/mc alias set impress http://localhost:9000 impress password
           /tmp/mc alias ls

--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Start Rustfs
         run: |
           docker pull rustfs/rustfs:latest
-          docker run --name rustfs \
+          docker run -d --name rustfs \
             -p 9000:9000 \
             -e "RUSTFS_ACCESS_KEY=impress" \
             -e "RUSTFS_SECRET_KEY=password" \

--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -154,7 +154,8 @@ jobs:
       - name: Create writable /data
         run: |
           sudo mkdir -p /data/media && \
-          sudo mkdir -p /data/static
+          sudo mkdir -p /data/static && \
+          sudo chown -R 10001:10001 /data/media
 
       - name: Restore the mail templates
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/compose.yml
+++ b/compose.yml
@@ -26,7 +26,7 @@ services:
 
   rustfs:
     user: ${DOCKER_USER:-1000}
-    image: rustfs/rustfs:latest
+    image: rustfs/rustfs:1.0.0-alpha.83
     environment:
       - RUSTFS_ACCESS_KEY=rustfsadmin
       - RUSTFS_SECRET_KEY=rustfsadmin

--- a/compose.yml
+++ b/compose.yml
@@ -24,34 +24,44 @@ services:
     ports:
       - "1081:1080"
 
-  minio:
+  rustfs:
     user: ${DOCKER_USER:-1000}
-    image: minio/minio
+    image: rustfs/rustfs:latest
     environment:
-      - MINIO_ROOT_USER=impress
-      - MINIO_ROOT_PASSWORD=password
+      - RUSTFS_ACCESS_KEY=rustfsadmin
+      - RUSTFS_SECRET_KEY=rustfsadmin
+      - RUSTFS_CONSOLE_ENABLE=true
+      - RUSTFS_ADDRESS=0.0.0.0:9000
+      - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9001
+      - RUSTFS_CORS_ALLOWED_ORIGINS=*
+      - RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS=*
     ports:
       - "9000:9000"
       - "9001:9001"
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
-      interval: 1s
-      timeout: 20s
-      retries: 300
-    entrypoint: ""
-    command: minio server --console-address :9001 /data
+      test:
+        [
+          "CMD",
+          "sh",
+          "-c",
+          "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/rustfs/console/health",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     volumes:
       - ./data/media:/data
 
   createbuckets:
     image: minio/mc
     depends_on:
-      minio:
+      rustfs:
         condition: service_healthy
         restart: true
     entrypoint: >
       sh -c "
-      /usr/bin/mc alias set impress http://minio:9000 impress password && \
+      /usr/bin/mc alias set impress http://rustfs:9000 rustfsadmin rustfsadmin && \
       /usr/bin/mc mb impress/impress-media-storage && \
       /usr/bin/mc version enable impress/impress-media-storage && \
       exit 0;"

--- a/docker/files/etc/nginx/conf.d/default.conf
+++ b/docker/files/etc/nginx/conf.d/default.conf
@@ -17,9 +17,9 @@ server {
         proxy_set_header X-Amz-Date $authDate;
         proxy_set_header X-Amz-Content-SHA256 $authContentSha256;
 
-        # Get resource from Minio
-        proxy_pass http://minio:9000/impress-media-storage/;
-        proxy_set_header Host minio:9000;
+        # Get resource from rustfs
+        proxy_pass http://rustfs:9000/impress-media-storage/;
+        proxy_set_header Host rustfs:9000;
 
         add_header Content-Security-Policy "default-src 'none'" always;
     }
@@ -30,7 +30,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Original-URL $request_uri;
-        
+
         # Prevent the body from being passed
         proxy_pass_request_body off;
         proxy_set_header Content-Length "";

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -27,9 +27,9 @@ IMPRESS_BASE_URL="http://localhost:8072"
 
 # Media
 STORAGES_STATICFILES_BACKEND=django.contrib.staticfiles.storage.StaticFilesStorage
-AWS_S3_ENDPOINT_URL=http://minio:9000
-AWS_S3_ACCESS_KEY_ID=impress
-AWS_S3_SECRET_ACCESS_KEY=password
+AWS_S3_ENDPOINT_URL=http://rustfs:9000
+AWS_S3_ACCESS_KEY_ID=rustfsadmin
+AWS_S3_SECRET_ACCESS_KEY=rustfsadmin
 MEDIA_BASE_URL=http://localhost:8083
 
 # OIDC


### PR DESCRIPTION
## Purpose

Minio is no longer maintained, its git repository is archived. We need to replace it. We decided to choose rustfs
https://github.com/minio/minio/commit/7aac2a2c5b7c882e68c1ce017d8256be2feea27f
https://github.com/rustfs/rustfs


## Proposal

- [x] 🔧(compose) replace minio by rustfs
- [ ] replace minio in github actions
- [ ] replace minio in the helm run in dev mode