### PR TITLE
✨(backend) allow the duplication of subpages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - ✨(frontend) Can print a doc #1832
 - ✨(backend) manage reconciliation requests for user accounts #1878
 - 👷(CI) add GHCR workflow for forked repo testing #1851
+- ✨(backend) allow the duplication of subpages #1893
 
 ### Changed
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -591,10 +591,13 @@ class LinkDocumentSerializer(serializers.ModelSerializer):
 class DocumentDuplicationSerializer(serializers.Serializer):
     """
     Serializer for duplicating a document.
-    Allows specifying whether to keep access permissions.
+    Allows specifying whether to keep access permissions,
+    and whether to duplicate descendant documents as well
+    (deep copy) or not (shallow copy).
     """
 
     with_accesses = serializers.BooleanField(default=False)
+    with_descendants = serializers.BooleanField(default=False)
 
     def create(self, validated_data):
         """


### PR DESCRIPTION
## Purpose
When a doc is duplicated, the frontend can now ask the backend to duplicate its sub-documents, if any.

Adds a new with_descendants parameter to the doc duplication API. The logic of the duplicate() method has been moved to a new internal _duplicate_document() method to allow for recursion. Adds unit tests for the new feature.

Solves #1327 on the back-en

## Proposal
- [x] Added a new `with_descendants` parameter to the `DocumentDuplicationSerializer`
- [x] In the `DocumentViewSet`, the logic of the `duplicate()` method has been moved to a new internal `_duplicate_document()` method to allow for recursion
- [x] Added unit tests for the new features.

Note: I locally added some logging and duplicated a normal doc with two subpages, along with a huge document with many subpages ("LaSuite - Équipe Docs"):
```
app-dev-1  | 2026-02-18 14:07:33,600 core.api.viewsets INFO Document a4111eff-ee5f-425f-a8ac-f5fdc859cc81 duplicated (took 0.055s)
[...]
app-dev-1  | 2026-02-18 14:40:07,030 core.api.viewsets INFO Document b890f38a-d4ec-4dbc-950f-77878fc679a8 duplicated (took 2.138s)
```