### PR TITLE
✨(tracking) add UTM parameters to shared document links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(tracking) add UTM parameters to shared document links
 - ✨(frontend) Can print a doc #1832
 - ✨(backend) manage reconciliation requests for user accounts #1878
 - 👷(CI) add GHCR workflow for forked repo testing #1851

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1260,7 +1260,7 @@ class Document(MP_Node, BaseModel):
                 "brandname": settings.EMAIL_BRAND_NAME,
                 "document": self,
                 "domain": domain,
-                "link": f"{domain}/docs/{self.id}/",
+                "link": f"{domain}/docs/{self.id}/?utm_source=docssharelink&utm_campaign={self.id}",
                 "link_label": self.title or str(_("Untitled Document")),
                 "button_label": _("Open"),
                 "logo_img": settings.EMAIL_LOGO_IMG,

--- a/src/backend/core/tests/test_models_documents.py
+++ b/src/backend/core/tests/test_models_documents.py
@@ -1021,7 +1021,10 @@ def test_models_documents__email_invitation__success():
         f"Test Sender (sender@example.com) invited you with the role &quot;editor&quot; "
         f"on the following document: {document.title}" in email_content
     )
-    assert f"docs/{document.id}/" in email_content
+    assert (
+        f"docs/{document.id}/?utm_source=docssharelink&amp;utm_campaign={document.id}"
+        in email_content
+    )
 
 
 @pytest.mark.parametrize(
@@ -1051,10 +1054,18 @@ def test_models_documents__email_invitation__url_app_param(email_url_app):
 
         # Determine expected domain
         if email_url_app:
-            assert f"https://test-example.com/docs/{document.id}/" in email_content
+            expected_url = (
+                f"https://test-example.com/docs/{document.id}/"
+                f"?utm_source=docssharelink&amp;utm_campaign={document.id}"
+            )
+            assert expected_url in email_content
         else:
             # Default Site domain is example.com
-            assert f"example.com/docs/{document.id}/" in email_content
+            expected_url = (
+                f"example.com/docs/{document.id}/"
+                f"?utm_source=docssharelink&amp;utm_campaign={document.id}"
+            )
+            assert expected_url in email_content
 
 
 def test_models_documents__email_invitation__success_empty_title():
@@ -1085,7 +1096,10 @@ def test_models_documents__email_invitation__success_empty_title():
         "Test Sender (sender@example.com) invited you with the role &quot;editor&quot; "
         "on the following document: Untitled Document" in email_content
     )
-    assert f"docs/{document.id}/" in email_content
+    assert (
+        f"docs/{document.id}/?utm_source=docssharelink&amp;utm_campaign={document.id}"
+        in email_content
+    )
 
 
 def test_models_documents__email_invitation__success_fr():
@@ -1120,7 +1134,10 @@ def test_models_documents__email_invitation__success_fr():
         f"Test Sender2 (sender2@example.com) vous a invité avec le rôle &quot;propriétaire&quot; "
         f"sur le document suivant : {document.title}" in email_content
     )
-    assert f"docs/{document.id}/" in email_content
+    assert (
+        f"docs/{document.id}/?utm_source=docssharelink&amp;utm_campaign={document.id}"
+        in email_content
+    )
 
 
 @mock.patch(

--- a/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useCopyDocLink.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/hooks/useCopyDocLink.tsx
@@ -11,7 +11,7 @@ export const useCopyDocLink = (docId: Doc['id']) => {
 
   return useCallback(() => {
     copyToClipboard(
-      `${window.location.origin}/docs/${docId}/`,
+      `${window.location.origin}/docs/${docId}/?utm_source=docssharelink&utm_campaign=${docId}`,
       t('Link Copied !'),
       t('Failed to copy link'),
     );


### PR DESCRIPTION
ation emails).

## Purpose

Add UTM tracking parameters to shared document links to enable referral tracking. When a document is shared (via copy link or email invitation), the generated URL now includes ?utm_source=docssharelink&utm_campaign={docId}.



## Proposal

- [x]  Append UTM params to the copied share link in useCopyDocLink.tsx
- [x]  Append UTM params to the email link in Document.send_email() (models.py)
- [x]   Update backend tests to match the new URL format
- [x]  Add changelog entry

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)