### PR TITLE
🐛 (backend) prevent privileged users from requesting access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to
 - ♿️(frontend) add focus on open to modals #1948
 
 ### Fixed
-
+- 🐛 (backend) prevent privileged users from requesting access #1898
 - 🐛(frontend) fix broadcast store sync #1846
 - 🐛(helm) use celery resources instead of backend resources #1887
 - 🐛(helm) reverse liveness and readiness for backend deployment #1887

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -2523,6 +2523,12 @@ class DocumentAskForAccessViewSet(
         """Create a document ask for access resource."""
         document = self.get_document_or_404()
 
+        if document.get_role(request.user) in models.PRIVILEGED_ROLES:
+            return drf.response.Response(
+                {"detail": "You already have privileged access to this document."},
+                status=drf.status.HTTP_400_BAD_REQUEST,
+            )
+
         serializer = serializers.DocumentAskForAccessCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 


### PR DESCRIPTION
## Purpose
Prevent privileged users (owners and admins) of a document from submitting an access request on a document they already control.

Without this guardrail, two problems arise:

- Queue pollution — privileged users could inadvertently inflate the access request queue with redundant entries.
- Silent privilege downgrade — more critically, if an owner submits an access request on their own document, another admin could accept it and grant them a lower role (e.g. reader), which would silently strip them of their ownership.

**Example:**
We have a document shared between 2 users:
- John Doe (owner)
- Amine BOUKERFA (admin)
<img width="809" height="327" alt="Screenshot 2026-02-19 at 13 32 28" src="https://github.com/user-attachments/assets/d856d336-0c28-4488-9937-5743fdf719a1" />

If Amine approves John’s request for read-only access, John will lose ownership of the document. If that happens, neither of them will be able to delete it.

## Proposal
 - Add a validation check in DocumentAskForAccessViewSet.create() that returns a 400 Bad Request if the requesting user already holds a privileged role (OWNER or ADMIN) on the document.
 - Add parametrized tests covering both 

