### PR TITLE
🐛(y-provider) use CONVERSION_FILE_MAX_SIZE settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to
 - 🐛(frontend) fix broadcast store sync #1846
 - 🐛(helm) use celery resources instead of backend resources
 - 🐛(helm) reverse liveness and readiness for backend deployment
+- 🐛(y-provider) use CONVERSION_FILE_MAX_SIZE settings #1913
 
 ## [v4.5.0] - 2026-01-28
 

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -736,7 +736,7 @@ class Base(Configuration):
 
     # Imported file settings
     CONVERSION_FILE_MAX_SIZE = values.IntegerValue(
-        20 * MB,  # 10MB
+        20 * MB,
         environ_name="CONVERSION_FILE_MAX_SIZE",
         environ_prefix=None,
     )

--- a/src/frontend/servers/y-provider/__tests__/server.test.ts
+++ b/src/frontend/servers/y-provider/__tests__/server.test.ts
@@ -9,6 +9,7 @@ vi.mock('../src/env', async (importOriginal) => {
     ...(await importOriginal()),
     COLLABORATION_SERVER_ORIGIN: 'http://localhost:3000',
     Y_PROVIDER_API_KEY: 'yprovider-api-key',
+    CONVERSION_FILE_MAX_SIZE: 500 * 1024, // 500kb
   };
 });
 
@@ -54,7 +55,7 @@ describe('Server Tests', () => {
     expect(response.status).not.toBe(413);
   });
 
-  it('rejects payloads larger than 500kb for the CONVERT route', async () => {
+  it('rejects payloads larger than CONVERSION_FILE_MAX_SIZE for the CONVERT route', async () => {
     const app = initApp();
 
     const oversizedPayload = 'a'.repeat(501 * 1024); // 501kb payload

--- a/src/frontend/servers/y-provider/src/env.ts
+++ b/src/frontend/servers/y-provider/src/env.ts
@@ -8,6 +8,9 @@ export const COLLABORATION_SERVER_SECRET = process.env
   .COLLABORATION_SERVER_SECRET_FILE
   ? readFileSync(process.env.COLLABORATION_SERVER_SECRET_FILE, 'utf-8')
   : process.env.COLLABORATION_SERVER_SECRET || 'secret-api-key';
+export const CONVERSION_FILE_MAX_SIZE = process.env.CONVERSION_FILE_MAX_SIZE
+  ? Number(process.env.CONVERSION_FILE_MAX_SIZE)
+  : 20971520; // 20 MB default
 export const Y_PROVIDER_API_KEY = process.env.Y_PROVIDER_API_KEY_FILE
   ? readFileSync(process.env.Y_PROVIDER_API_KEY_FILE, 'utf-8')
   : process.env.Y_PROVIDER_API_KEY || 'yprovider-api-key';

--- a/src/frontend/servers/y-provider/src/servers/appServer.ts
+++ b/src/frontend/servers/y-provider/src/servers/appServer.ts
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/node';
 import express from 'express';
 import expressWebsockets from 'express-ws';
 
+import { CONVERSION_FILE_MAX_SIZE } from '@/env';
 import {
   collaborationResetConnectionsHandler,
   collaborationWSHandler,
@@ -55,7 +56,7 @@ export const initApp = () => {
     routes.CONVERT,
     httpSecurity,
     express.raw({
-      limit: '500kb',
+      limit: CONVERSION_FILE_MAX_SIZE,
       type: '*/*',
     }),
     convertHandler,


### PR DESCRIPTION
## Purpose

The settings `CONVERSION_FILE_MAX_SIZE` was not used in the route conversion in the `y-provider` server, which caused a `413 Payload Too Large` error when trying to convert a file larger than 500kb.
This commit updates the y-provider to use the `CONVERSION_FILE_MAX_SIZE` settings, allowing it to handle larger files without throwing an error.
`CONVERSION_FILE_MAX_SIZE` should follow the same value as the one defined in the backend settings, which is 20mb by default.


