### PR TITLE
🐛(frontend) fix callout block spacing for old browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to
 - 🐛(helm) use celery resources instead of backend resources
 - 🐛(helm) reverse liveness and readiness for backend deployment
 - 🐛(y-provider) use CONVERSION_FILE_MAX_SIZE settings #1913
+- 🐛(frontend) fix callout block spacing for old browsers #1914
 
 ## [v4.5.0] - 2026-01-28
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/CalloutBlock.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-blocks/CalloutBlock.tsx
@@ -21,6 +21,9 @@ const CalloutBlockStyle = createGlobalStyle`
     padding: var(--c--globals--spacings--3xs) var(--c--globals--spacings--3xs);
     border-radius: var(--c--globals--spacings--3xs);
   }
+  .bn-block-content[data-content-type="callout"] .inline-content {
+    white-space: pre-wrap;
+  }
 `;
 
 type CreateCalloutBlockConfig = BlockConfig<


### PR DESCRIPTION
## Purpose

On the old Firefox versions, the spacing of the callout block was not applied correctly.
We changed the "white-space" property to "pre-wrap" to ensure that the spacing is applied correctly on all browsers.

## Demo

https://github.com/user-attachments/assets/34b6e800-fe90-4911-bbd9-54fecdb20103

