### PR TITLE
♻️(frontend) Update base role for access request

### DIFF
--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareAccessRequest.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareAccessRequest.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components';
 import { QuickSearchData, QuickSearchGroup } from '@/components/quick-search';
 import { useCunninghamTheme } from '@/cunningham';
-import { AccessRequest, Doc } from '@/docs/doc-management/';
+import { AccessRequest, Doc, Role } from '@/docs/doc-management/';
 import { useAuth } from '@/features/auth';
 
 import {
@@ -220,7 +220,7 @@ export const ButtonAccessRequest = ({
   return (
     <Button
       onClick={(e) => {
-        createRequest({ docId });
+        createRequest({ docId, role: Role.EDITOR });
         onClick?.(e);
       }}
       disabled={hasRequested}


### PR DESCRIPTION
## Purpose

The base role for access request is now "editor" instead of "viewer".


## ProposalDemo

<img width="1102" height="846" alt="image" src="https://github.com/user-attachments/assets/9018ef45-1aff-46ed-9f0b-6d088639b05e" />
