### PR TITLE
📝(docs) Update documentation for keycloak in compose setup

### DIFF
--- a/docs/examples/compose/keycloak/README.md
+++ b/docs/examples/compose/keycloak/README.md
@@ -8,7 +8,7 @@
 ### Step 1: Prepare your working environment:
 
 ```bash
-mkdir keycloak
+mkdir -p keycloak/env.d
 curl -o keycloak/compose.yaml https://raw.githubusercontent.com/suitenumerique/docs/refs/heads/main/docs/examples/compose/keycloak/compose.yaml
 curl -o keycloak/env.d/kc_postgresql https://raw.githubusercontent.com/suitenumerique/docs/refs/heads/main/env.d/production.dist/kc_postgresql
 curl -o keycloak/env.d/keycloak https://raw.githubusercontent.com/suitenumerique/docs/refs/heads/main/env.d/production.dist/keycloak
@@ -58,10 +58,10 @@ services:
 ### Step 4: Start the service
 
 ```bash
-`docker compose up -d`
+docker compose up -d
 ```
 
-Your keycloak instance is now available on https://doc.yourdomain.tld
+Your keycloak instance is now available on https://id.yourdomain.tld
 
 ## Creating an OIDC Client for Docs Application
 

--- a/docs/examples/compose/keycloak/compose.yaml
+++ b/docs/examples/compose/keycloak/compose.yaml
@@ -1,6 +1,6 @@
 services:
   kc_postgresql:
-    image: postgres:16
+    image: postgres:18
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 1s
@@ -12,7 +12,7 @@ services:
       - ./data/keycloak:/var/lib/postgresql/data/pgdata
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.1.3
+    image: quay.io/keycloak/keycloak:26.5
     command: ["start"]
     env_file:
       - env.d/kc_postgresql

--- a/docs/installation/compose.md
+++ b/docs/installation/compose.md
@@ -93,13 +93,13 @@ If you are using an external service, you need to set `REDIS_URL` environment va
 
 The Y provider service enables collaboration through websockets.
 
-Generates a secure key for `Y_PROVIDER_API_KEY` and `COLLABORATION_SERVER_SECRET` in ``env.d/yprovider``. 
+Generate a secure key for `Y_PROVIDER_API_KEY` and `COLLABORATION_SERVER_SECRET` in ``env.d/yprovider``. 
 
 ### Docs
 
 The Docs backend is built on the Django Framework.
 
-Generates a secure key for `DJANGO_SECRET_KEY` in `env.d/backend`. 
+Generate a secure key for `DJANGO_SECRET_KEY` in `env.d/backend`. 
 
 ### Logging
 
@@ -222,10 +222,10 @@ You can also check the [Changelog](../../CHANGELOG.md) for brief summary of the 
 docker compose pull
 ```
 
-### Step 3: Restart your containers
+### Step 3: Restart/Reconfigure your containers
 
 ```bash
-docker compose restart
+docker compose up -d
 ```
 
 ### Step 4: Run the database migration

--- a/env.d/development/kc_postgresql
+++ b/env.d/development/kc_postgresql
@@ -4,8 +4,8 @@ POSTGRES_USER=impress
 POSTGRES_PASSWORD=pass
 
 # App database configuration
-DB_HOST=kc_postgresql
-DB_NAME=keycloak
-DB_USER=impress
-DB_PASSWORD=pass
-DB_PORT=5433
+KC_DB_URL_HOST=kc_postgresql
+KC_DB_URL_DATABASE=keycloak
+KC_DB_USERNAME=impress
+KC_DB_PASSWORD=pass
+KC_DB_URL_PORT=5433

--- a/env.d/production.dist/kc_postgresql
+++ b/env.d/production.dist/kc_postgresql
@@ -7,7 +7,7 @@ PGDATA=/var/lib/postgresql/data/pgdata
 # Keycloak postgresql configuration
 KC_DB=postgres
 KC_DB_SCHEMA=public
-KC_DB_HOST=postgresql
-KC_DB_NAME=${POSTGRES_DB}
-KC_DB_USER=${POSTGRES_USER}
+KC_DB_URL_HOST=kc_postgresql
+KC_DB_URL_DATABASE=${POSTGRES_DB}
+KC_DB_USERNAME=${POSTGRES_USER}
 KC_DB_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
Recent versions of keycloak changed the ENV var names.
(see https://www.keycloak.org/server/db#_relevant_options)

The templates for the env files were updated accordingly.
A few small typos were also fixed in the compose documentation.

The official supported Version of PostgreSQL for keycloak is 18, as stated in https://www.keycloak.org/server/db.
So the compose examples were updated accordingly. 
