### PR TITLE
🐛(frontend) fix zIndex table of content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,9 @@ and this project adheres to
 ### Fixed
 
 - 🐛(frontend) analytic feature flags problem #1953
-
-### Fixed
-
 - 🐛(frontend) fix disabled color on icon Dropdown #1950
+- 🐛(frontend) fix zIndex table of content #1949
+
 
 ## [v4.6.0] - 2026-03-03
 

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/FloatingBar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/FloatingBar.tsx
@@ -31,7 +31,7 @@ export const FloatingBar = () => {
       margin-left: calc(-${base});
       margin-right: calc(-${base});
       margin-top: calc(-${base});
-      z-index: 1000;
+      z-index: 10;
       display: flex;
       align-items: flex-start;
       justify-content: flex-start;

--- a/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
@@ -61,7 +61,7 @@ export const TableContent = () => {
         $width={!isOpen ? '40px' : '200px'}
         $height={!isOpen ? '40px' : 'auto'}
         $maxHeight="calc(50vh - 60px)"
-        $zIndex={2000}
+        $zIndex={1000}
         $align="center"
         $padding={isOpen ? 'xs' : '0'}
         $justify="center"


### PR DESCRIPTION
## Purpose

When we open a modal, the table of content is above the modal, which is not the expected behavior. This commit fixes the zIndex of the table of content to be below the modal.


## Demo problem

<img width="1358" height="650" alt="image" src="https://github.com/user-attachments/assets/c87ecbaf-1358-4c91-bf65-581184bd9e15" />
