### PR TITLE
🐛(backend) enforce emoji validation for reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) enforce emoji validation for reactions #1965
 - 🐛(frontend) analytic feature flags problem #1953
 - 🐛(frontend) fix home collapsing panel #1954
 - 🐛(frontend) fix disabled color on icon Dropdown #1950

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -13,6 +13,7 @@ from django.utils.functional import lazy
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
+import emoji
 import magic
 from rest_framework import serializers
 
@@ -874,6 +875,12 @@ class ReactionSerializer(serializers.ModelSerializer):
             "users",
         ]
         read_only_fields = ["id", "created_at", "users"]
+
+    def validate_emoji(self, value):
+        """Ensure the reaction is a single emoji."""
+        if not emoji.is_emoji(value):
+            raise serializers.ValidationError("Reaction must be a single valid emoji.")
+        return value
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -231,9 +231,10 @@ class ReactionFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = models.Reaction
+        skip_postgeneration_save = True
 
     comment = factory.SubFactory(CommentFactory)
-    emoji = "test"
+    emoji = factory.Faker("emoji")
 
     @factory.post_generation
     def users(self, create, extracted, **kwargs):

--- a/src/backend/core/tests/documents/test_api_documents_comments.py
+++ b/src/backend/core/tests/documents/test_api_documents_comments.py
@@ -644,11 +644,13 @@ def test_create_reaction_anonymous_user_public_document(link_role):
     document = factories.DocumentFactory(link_reach="public", link_role=link_role)
     thread = factories.ThreadFactory(document=document)
     comment = factories.CommentFactory(thread=thread)
+    reaction = factories.ReactionFactory(comment=comment)
+
     client = APIClient()
     response = client.post(
         f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
         f"comments/{comment.id!s}/reactions/",
-        {"emoji": "test"},
+        {"emoji": reaction.emoji},
     )
     assert response.status_code == 401
 
@@ -664,12 +666,14 @@ def test_create_reaction_authenticated_user_public_document():
     )
     thread = factories.ThreadFactory(document=document)
     comment = factories.CommentFactory(thread=thread)
+    reaction = factories.ReactionFactory(comment=comment)
+
     client = APIClient()
     client.force_login(user)
     response = client.post(
         f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
         f"comments/{comment.id!s}/reactions/",
-        {"emoji": "test"},
+        {"emoji": reaction.emoji},
     )
     assert response.status_code == 403
 
@@ -684,17 +688,19 @@ def test_create_reaction_authenticated_user_accessible_public_document():
     )
     thread = factories.ThreadFactory(document=document)
     comment = factories.CommentFactory(thread=thread)
+    reaction = factories.ReactionFactory(comment=comment)
+
     client = APIClient()
     client.force_login(user)
     response = client.post(
         f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
         f"comments/{comment.id!s}/reactions/",
-        {"emoji": "test"},
+        {"emoji": reaction.emoji},
     )
     assert response.status_code == 201
 
     assert models.Reaction.objects.filter(
-        comment=comment, emoji="test", users__in=[user]
+        comment=comment, emoji=reaction.emoji, users__in=[user]
     ).exists()
 
 
@@ -709,12 +715,14 @@ def test_create_reaction_authenticated_user_connected_document_link_role_reader(
     )
     thread = factories.ThreadFactory(document=document)
     comment = factories.CommentFactory(thread=thread)
+    reaction = factories.ReactionFactory(comment=comment)
+
     client = APIClient()
     client.force_login(user)
     response = client.post(
         f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
         f"comments/{comment.id!s}/reactions/",
-        {"emoji": "test"},
+        {"emoji": reaction.emoji},
     )
     assert response.status_code == 403
 
@@ -737,17 +745,19 @@ def test_create_reaction_authenticated_user_connected_document(link_role):
     )
     thread = factories.ThreadFactory(document=document)
     comment = factories.CommentFactory(thread=thread)
+    reaction = factories.ReactionFactory(comment=comment)
+
     client = APIClient()
     client.force_login(user)
     response = client.post(
         f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
         f"comments/{comment.id!s}/reactions/",
-        {"emoji": "test"},
+        {"emoji": reaction.emoji},
     )
     assert response.status_code == 201
 
     assert models.Reaction.objects.filter(
-        comment=comment, emoji="test", users__in=[user]
+        comment=comment, emoji=reaction.emoji, users__in=[user]
     ).exists()
 
 
@@ -760,12 +770,14 @@ def test_create_reaction_authenticated_user_restricted_accessible_document():
     document = factories.DocumentFactory(link_reach="restricted")
     thread = factories.ThreadFactory(document=document)
     comment = factories.CommentFactory(thread=thread)
+    reaction = factories.ReactionFactory(comment=comment)
+
     client = APIClient()
     client.force_login(user)
     response = client.post(
         f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
         f"comments/{comment.id!s}/reactions/",
-        {"emoji": "test"},
+        {"emoji": reaction.emoji},
     )
     assert response.status_code == 403
 
@@ -781,12 +793,14 @@ def test_create_reaction_authenticated_user_restricted_accessible_document_role_
     )
     thread = factories.ThreadFactory(document=document)
     comment = factories.CommentFactory(thread=thread)
+    reaction = factories.ReactionFactory(comment=comment)
+
     client = APIClient()
     client.force_login(user)
     response = client.post(
         f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
         f"comments/{comment.id!s}/reactions/",
-        {"emoji": "test"},
+        {"emoji": reaction.emoji},
     )
     assert response.status_code == 403
 
@@ -806,18 +820,41 @@ def test_create_reaction_authenticated_user_restricted_accessible_document_role_
     document = factories.DocumentFactory(link_reach="restricted", users=[(user, role)])
     thread = factories.ThreadFactory(document=document)
     comment = factories.CommentFactory(thread=thread)
+    reaction = factories.ReactionFactory(comment=comment)
+
     client = APIClient()
     client.force_login(user)
     response = client.post(
         f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
         f"comments/{comment.id!s}/reactions/",
-        {"emoji": "test"},
+        {"emoji": reaction.emoji},
     )
     assert response.status_code == 201
 
     assert models.Reaction.objects.filter(
-        comment=comment, emoji="test", users__in=[user]
+        comment=comment, emoji=reaction.emoji, users__in=[user]
     ).exists()
+
+    response = client.post(
+        f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
+        f"comments/{comment.id!s}/reactions/",
+        {"emoji": reaction.emoji},
+    )
+    assert response.status_code == 400
+    assert response.json() == {"user_already_reacted": True}
+
+
+def test_create_reaction_invalid_emoji():
+    """Users should not be able to submit non-emojis as reactions."""
+    user = factories.UserFactory()
+    document = factories.DocumentFactory(
+        link_reach="restricted", users=[(user, models.RoleChoices.COMMENTER)]
+    )
+    thread = factories.ThreadFactory(document=document)
+    comment = factories.CommentFactory(thread=thread)
+
+    client = APIClient()
+    client.force_login(user)
 
     response = client.post(
         f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
@@ -825,7 +862,28 @@ def test_create_reaction_authenticated_user_restricted_accessible_document_role_
         {"emoji": "test"},
     )
     assert response.status_code == 400
-    assert response.json() == {"user_already_reacted": True}
+    assert "Reaction must be a single valid emoji." in str(response.json())
+
+
+def test_create_reaction_multiple_emojis():
+    """Users should not be able to submit multiple emojis as a single reaction."""
+    user = factories.UserFactory()
+    document = factories.DocumentFactory(
+        link_reach="restricted", users=[(user, models.RoleChoices.COMMENTER)]
+    )
+    thread = factories.ThreadFactory(document=document)
+    comment = factories.CommentFactory(thread=thread)
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
+        f"comments/{comment.id!s}/reactions/",
+        {"emoji": "🐛🐛"},
+    )
+    assert response.status_code == 400
+    assert "Reaction must be a single valid emoji." in str(response.json())
 
 
 # Delete reaction

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "drf_spectacular==0.29.0",
     "dockerflow==2026.1.26",
     "easy_thumbnails==2.10.1",
+    "emoji==2.15.0",
     "factory_boy==3.3.3",
     "gunicorn==25.1.0",
     "jsonschema==4.26.0",


### PR DESCRIPTION
## Purpose

This pull request enforces emoji validation in the `ReactionSerializer` to prevent invalid emoji submissions.

- Currently we can do such reactions
<img width="636" height="673" alt="Screenshot 2026-03-10 at 07 09 24" src="https://github.com/user-attachments/assets/c809a87e-1bfa-4f3f-8b41-20d43d5eb52f" />

## Proposal

- Validate emojis in `ReactionSerializer` (previously accepted any string)
- Prevents multiple emojis or text uploads in a single reaction