### PR TITLE
⬇️(backend) downgrade langfuse to version 3.11.2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,12 @@
       "allowedVersions": "<1.59.0"
     },
     {
+      "groupName": "allowed langfuse versions",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["langfuse"],
+      "allowedVersions": "<3.12.0"
+    },
+    {
       "enabled": false,
       "groupName": "ignored js dependencies",
       "matchManagers": ["npm"],

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "factory_boy==3.3.3",
     "gunicorn==25.1.0",
     "jsonschema==4.26.0",
-    "langfuse==3.14.5",
+    "langfuse==3.11.2",
     "lxml==6.0.2",
     "markdown==3.10.2",
     "mozilla-django-oidc==5.0.2",


### PR DESCRIPTION
## Purpose

We to keep in sync the version of the sdk client and the version of the langfuse server. For now we can't upgrade langfuse See https://github.com/langfuse/langfuse/issues/11564


## Proposal

- [x] ⬇️(backend) downgrade langfuse to version 3.11.2