### PR TITLE
✨(backend) add limit on distinct reactions per comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(backend) add limit on distinct reactions per comment #1978
 - ✨(frontend) leave a document #2410
 - ✨(frontend) add top parent on sub docs search #1952
 - ✨(frontend) unauthenticated users can search #2407

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -3234,9 +3234,11 @@ class CommentViewSet(
     permission_classes = [permissions.CommentPermission]
     pagination_class = Pagination
     serializer_class = serializers.CommentSerializer
-    queryset = models.Comment.objects.select_related("user").prefetch_related(
-        "reactions__users"
-    ).all()
+    queryset = (
+        models.Comment.objects.select_related("user")
+        .prefetch_related("reactions__users")
+        .all()
+    )
 
     def get_queryset(self):
         """Override to filter on related resource."""

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -3088,6 +3088,7 @@ class ConfigView(drf.views.APIView):
             "POSTHOG_HOST",
             "LANGUAGES",
             "LANGUAGE_CODE",
+            "REACTIONS_MAX_PER_COMMENT",
             "SENTRY_DSN",
             "TRASHBIN_CUTOFF_DAYS",
         ]
@@ -3233,7 +3234,9 @@ class CommentViewSet(
     permission_classes = [permissions.CommentPermission]
     pagination_class = Pagination
     serializer_class = serializers.CommentSerializer
-    queryset = models.Comment.objects.select_related("user").all()
+    queryset = models.Comment.objects.select_related("user").prefetch_related(
+        "reactions__users"
+    ).all()
 
     def get_queryset(self):
         """Override to filter on related resource."""
@@ -3279,9 +3282,29 @@ class CommentViewSet(
         serializer.is_valid(raise_exception=True)
 
         if request.method == "POST":
+            emoji = serializer.validated_data["emoji"]
+
+            if (
+                not models.Reaction.objects.filter(
+                    comment=comment, emoji=emoji
+                ).exists()
+                and comment.reactions.count() >= settings.REACTIONS_MAX_PER_COMMENT
+            ):
+                return drf.response.Response(
+                    {
+                        "emoji": [
+                            _(
+                                "A comment can have a maximum of %(max)d distinct reactions."
+                            )
+                            % {"max": settings.REACTIONS_MAX_PER_COMMENT}
+                        ]
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
             reaction, created = models.Reaction.objects.get_or_create(
                 comment=comment,
-                emoji=serializer.validated_data["emoji"],
+                emoji=emoji,
             )
             if not created and reaction.users.filter(id=request.user.id).exists():
                 return drf.response.Response(

--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -227,6 +227,11 @@ class ReactionFactory(factory.django.DjangoModelFactory):
     comment = factory.SubFactory(CommentFactory)
     emoji = factory.Faker("emoji")
 
+    @classmethod
+    def generate_emojis(cls, n=10):
+        """Generate a list of n unique emojis."""
+        return [fake.unique.emoji() for _ in range(n)]
+
     @factory.post_generation
     def users(self, create, extracted, **kwargs):
         """Add users to reaction from a given list of users or create one if not provided."""

--- a/src/backend/core/tests/documents/test_api_documents_comments.py
+++ b/src/backend/core/tests/documents/test_api_documents_comments.py
@@ -957,3 +957,56 @@ def test_delete_reaction_owned_by_the_current_user():
 
     reaction.refresh_from_db()
     assert reaction.users.exists()
+
+
+def test_create_reaction_exceeds_maximum(settings):
+    """
+    Users should not be able to add more than REACTIONS_MAX_PER_COMMENT
+    (here we set it to 10) distinct emoji reactions to a comment.
+    They should, however, be able to add themselves to an existing reaction.
+    """
+    user1 = factories.UserFactory()
+    user2 = factories.UserFactory()
+    document = factories.DocumentFactory(
+        link_reach="restricted",
+        users=[(user1, models.RoleChoices.ADMIN), (user2, models.RoleChoices.ADMIN)],
+    )
+    thread = factories.ThreadFactory(document=document)
+    comment = factories.CommentFactory(thread=thread)
+
+    client = APIClient()
+    client.force_login(user1)
+
+    # Add max distinct reactions
+    max_reactions = settings.REACTIONS_MAX_PER_COMMENT
+    emojis = factories.ReactionFactory.generate_emojis(max_reactions + 1)
+    for emoji in emojis[:max_reactions]:
+        response = client.post(
+            f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
+            f"comments/{comment.id!s}/reactions/",
+            {"emoji": emoji},
+        )
+        assert response.status_code == 201
+
+    # Attempt to add another distinct reaction
+    response = client.post(
+        f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
+        f"comments/{comment.id!s}/reactions/",
+        {"emoji": emojis[max_reactions]},
+    )
+    assert response.status_code == 400
+    expected_message = (
+        f"A comment can have a maximum of {max_reactions} distinct reactions."
+    )
+    assert response.json() == {"emoji": [expected_message]}
+
+    # Attempt to add user2 to one of the existing reactions (should succeed)
+    client.force_login(user2)
+    response = client.post(
+        f"/api/v1.0/documents/{document.id!s}/threads/{thread.id!s}/"
+        f"comments/{comment.id!s}/reactions/",
+        {"emoji": emojis[0]},
+    )
+    assert response.status_code == 201
+    reaction = models.Reaction.objects.get(comment=comment, emoji=emojis[0])
+    assert reaction.users.count() == 2

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -80,6 +80,7 @@ def test_api_config(is_authenticated):
         "MEDIA_BASE_URL": "http://testserver/",
         "POSTHOG_KEY": "132456",
         "POSTHOG_HOST": "https://eu.i.posthog-test.com",
+        "REACTIONS_MAX_PER_COMMENT": 15,
         "RELEASE_VERSION": "1.0.0",
         "SENTRY_DSN": "https://sentry.test/123",
         "TRASHBIN_CUTOFF_DAYS": 30,

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -197,6 +197,12 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    REACTIONS_MAX_PER_COMMENT = values.IntegerValue(
+        15,
+        environ_name="REACTIONS_MAX_PER_COMMENT",
+        environ_prefix=None,
+    )
+
     DOCUMENT_UNSAFE_MIME_TYPES = [
         # Executable Files
         "application/x-msdownload",

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-common.ts
@@ -42,6 +42,7 @@ export const CONFIG = {
   LANGUAGE_CODE: 'en-us',
   POSTHOG_HOST: 'https://eu.i.posthog.com',
   POSTHOG_KEY: null,
+  REACTIONS_MAX_PER_COMMENT: 15,
   RELEASE_VERSION: packageJsonVersion,
   SENTRY_DSN: null,
   TRASHBIN_CUTOFF_DAYS: 30,

--- a/src/frontend/apps/impress/src/core/config/api/useConfig.tsx
+++ b/src/frontend/apps/impress/src/core/config/api/useConfig.tsx
@@ -60,6 +60,7 @@ export interface ConfigResponse {
   POSTHOG_HOST?: PostHogConf['host'];
   RELEASE_VERSION: string;
   SENTRY_DSN?: string;
+  REACTIONS_MAX_PER_COMMENT: number;
   TRASHBIN_CUTOFF_DAYS?: number;
   theme_customization?: ThemeCustomization;
 }

--- a/src/frontend/apps/impress/src/features/docs/doc-comments/api/DocsThreadStoreAuth.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-comments/api/DocsThreadStoreAuth.tsx
@@ -6,6 +6,7 @@ export class DocsThreadStoreAuth extends ThreadStoreAuth {
   constructor(
     private readonly userId: string,
     public canSee: boolean,
+    private readonly maxReactions: number,
   ) {
     super();
   }
@@ -67,13 +68,27 @@ export class DocsThreadStoreAuth extends ThreadStoreAuth {
     }
 
     if (!emoji) {
-      return true;
+      return comment.reactions.length < this.maxReactions;
     }
 
-    return !comment.reactions.some(
+    const hasReactedWithEmoji = comment.reactions.some(
       (reaction) =>
         reaction.emoji === emoji && reaction.userIds.includes(this.userId),
     );
+
+    if (hasReactedWithEmoji) {
+      return false;
+    }
+
+    const reactionExists = comment.reactions.some(
+      (reaction) => reaction.emoji === emoji,
+    );
+
+    if (reactionExists) {
+      return true;
+    }
+
+    return comment.reactions.length < this.maxReactions;
   }
 
   canDeleteReaction(comment: ClientCommentData, emoji?: string): boolean {

--- a/src/frontend/apps/impress/src/features/docs/doc-comments/hooks/useComments.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-comments/hooks/useComments.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useConfig } from '@/core';
 import { useCunninghamTheme } from '@/cunningham';
 import { User, avatarUrlFromName } from '@/features/auth';
 import { Doc, useProviderStore } from '@/features/docs/doc-management';
@@ -18,6 +19,7 @@ export function useComments(
   const { t } = useTranslation();
   const { themeTokens } = useCunninghamTheme();
   const { setThreadStore } = useThreadStore();
+  const { data: config } = useConfig();
 
   const threadStore = useMemo(() => {
     return new DocsThreadStore(
@@ -26,6 +28,7 @@ export function useComments(
       new DocsThreadStoreAuth(
         encodeURIComponent(user?.full_name || ''),
         canComment,
+        config?.REACTIONS_MAX_PER_COMMENT ?? 0,
       ),
       provider?.document,
     );
@@ -35,6 +38,7 @@ export function useComments(
     provider?.awareness,
     provider?.document,
     user?.full_name,
+    config?.REACTIONS_MAX_PER_COMMENT,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Purpose

The current implementation allows users to add an unlimited number of reactions per comment.
Because the `/threads` endpoint is called on document load, having multiple comments with
thousands of reactions each could significantly impact page load performance.

<img width="576" height="618" alt="Screenshot 2026-03-11 at 00 16 56" src="https://github.com/user-attachments/assets/5e0b613e-64bc-4b7f-9b19-b5ebcfb6852d" />

## Proposal

Implement a configurable limit (default: 15) on the number of distinct emoji reactions per comment.

- Backend validation ensures the limit cannot be exceeded via API
- Frontend disables reaction buttons when limit is reached

https://github.com/user-attachments/assets/321f2ed4-a2b9-44aa-b129-fcf71a182b2b

