### PR TITLE
♿(frontend) localize LaGaufre label fallback in Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to
 
 ### Added
 
-- ✨(backend) add a is_first_connection flag to the User model#1938
+- ✨(backend) add a is_first_connection flag to the User model #1938
+### Changed
+
+- ♿(frontend) localize LaGaufre label fallback in Docs #1979
 
 ## [v4.7.0] - 2026-03-09
 

--- a/src/frontend/apps/impress/src/features/header/components/Waffle.tsx
+++ b/src/frontend/apps/impress/src/features/header/components/Waffle.tsx
@@ -1,5 +1,6 @@
 import { LaGaufreV2, LaGaufreV2Props } from '@gouvfr-lasuite/ui-kit';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
 import { Box } from '@/components';
@@ -27,6 +28,7 @@ const LaGaufreV2Fixed = LaGaufreV2 as React.ComponentType<WaffleType>;
 
 export const Waffle = () => {
   const { data: conf } = useConfig();
+  const { t } = useTranslation();
 
   const waffleConfig = conf?.theme_customization?.waffle;
 
@@ -42,7 +44,10 @@ export const Waffle = () => {
         }
       `}
     >
-      <LaGaufreV2Fixed {...waffleConfig} />
+      <LaGaufreV2Fixed
+        {...waffleConfig}
+        label={waffleConfig.label ?? t('Digital LaSuite services')}
+      />
     </Box>
   );
 };

--- a/src/frontend/apps/impress/src/i18n/translations.json
+++ b/src/frontend/apps/impress/src/i18n/translations.json
@@ -267,6 +267,7 @@
       "Approve": "Freigeben",
       "As this is a sub-document, please request access to the parent document to enable these features.": "Dies ist ein untergeordnetes Dokument, fordern Sie bitte den Zugriff auf das übergeordnete Dokument an, um diese Funktionen zu ermöglichen.",
       "Available soon": "Bald verfügbar",
+      "Digital LaSuite services": "Digitale Dienste von LaSuite",
       "Back to homepage": "Zurück zur Startseite",
       "Banner image": "Bannerbild",
       "Beautify": "Verschönern",
@@ -517,6 +518,7 @@
   "en": {
     "translation": {
       "Contains {{count}} sub-documents_one": "Contains {{count}} sub-document",
+      "Digital LaSuite services": "Digital LaSuite services",
       "Share with {{count}} users_one": "Share with {{count}} user",
       "Shared with {{count}} users_many": "Shared with {{count}} users",
       "Shared with {{count}} users_one": "Shared with {{count}} user",
@@ -548,6 +550,7 @@
       "Anyone with the link can see the document": "Cualquiera con el enlace puede ver el documento",
       "Anyone with the link can view the document if they are logged in": "Cualquiera con el enlace puede ver el documento si ha iniciado sesión",
       "Available soon": "Próximamente disponible",
+      "Digital LaSuite services": "Servicios digitales de LaSuite",
       "Banner image": "Imagen de portada",
       "Beautify": "Embellecer",
       "Callout": "Destacado",
@@ -733,6 +736,7 @@
       "Ask anything...": "Posez n'importe quelle question...",
       "Available soon": "Disponible prochainement",
       "Back to homepage": "Retour à la page d'accueil",
+      "Digital LaSuite services": "Services LaSuite Numérique",
       "Banner image": "Image de la bannière",
       "Beautify": "Embellir",
       "By moving this document to <strong>{{targetDocumentTitle}}</strong>, it will lose its current access rights and inherit the permissions of that document. <strong>This access change cannot be undone.</strong>": "En déplaçant ce document vers <strong>{{targetDocumentTitle}}</strong>, il perdra ses droits d'accès actuels et héritera les permissions de ce document. <strong>Ce changement d'accès ne peut pas être annulé.</strong>",


### PR DESCRIPTION
## Purpose

Fix LaGaufre (waffle) label localization in Docs. The label stayed in English regardless of the selected language because Docs uses `CunninghamProvider` instead of the ui-kit provider, so `LaGaufreV2` internal translations were not applied. We now pass an explicit, translated label from Docs i18n.

[1973](https://github.com/suitenumerique/docs/issues/1973)

## Proposal

- [x] Pass `label={t('LaSuite digital services')}` in `Waffle.tsx` when `waffleConfig.label` is not provided
- [x] Add translations for "LaSuite digital services" in `translations.json` (en, fr, de, es)
