### PR TITLE
📝 Fix documentation and comment typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,7 +304,7 @@ and this project adheres to
 - ♻️(frontend) Refactor Auth component for improved redirection logic #1461
 - ♻️(frontend) replace Arial font-family with token font #1411
 - ♿(frontend) improve accessibility:
-  - ♿(frontend) enable enter key to open documentss #1354
+  - ♿(frontend) enable enter key to open documents #1354
   - ♿(frontend) improve modal a11y: structure, labels, title #1349
   - ♿improve NVDA navigation in DocShareModal #1396
   - ♿ improve accessibility by adding landmark roles to layout #1394
@@ -512,10 +512,10 @@ and this project adheres to
 
 - ✨(backend) add endpoint checking media status #984
 - ✨(backend) allow setting session cookie age via env var #977
-- ✨(backend) allow theme customnization using a configuration file #948
+- ✨(backend) allow theme customization using a configuration file #948
 - ✨(frontend) Add a custom callout block to the editor #892
 - 🚩(frontend) version MIT only #911
-- ✨(backend) integrate maleware_detection from django-lasuite #936
+- ✨(backend) integrate malware_detection from django-lasuite #936
 - 🏗️(frontend) Footer configurable #959
 - 🩺(CI) add lint spell mistakes #954
 - ✨(frontend) create generic theme #792

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,8 @@ Thank you for your contributions! 👍
 
 ## Contribute to BlockNote
 We use [BlockNote](https://www.blocknotejs.org/) for the text editing features of Docs. 
-If you find and issue with the editor you can [report it](https://github.com/TypeCellOS/BlockNote/issues) directly on their repository.
+If you find an issue with the editor you can [report it](https://github.com/TypeCellOS/BlockNote/issues) directly on their repository.
 
 Please consider contributing to BlockNotejs, as a library, it's useful to many projects not just Docs.
 
-The project is licended with Mozilla Public License Version 2.0 but be aware that [XL packages](https://github.com/TypeCellOS/BlockNote/blob/main/packages/xl-docx-exporter/LICENSE) are dual licenced with GNU AFFERO GENERAL PUBLIC LICENCE Version 3 and proprietary licence if you are [sponsor](https://www.blocknotejs.org/pricing).
+The project is licensed with Mozilla Public License Version 2.0 but be aware that [XL packages](https://github.com/TypeCellOS/BlockNote/blob/main/packages/xl-docx-exporter/LICENSE) are dual licensed with GNU AFFERO GENERAL PUBLIC LICENSE Version 3 and proprietary license if you are a [sponsor](https://www.blocknotejs.org/pricing).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Docs is an open-source alternative to tools like Notion or Google Docs, focused 
 - Slash commands & block system
 - Beautiful formatting
 - Offline editing
-- Optional AI writing helpers (rewirite, summarize, translate, fix typos)
+- Optional AI writing helpers (rewrite, summarize, translate, fix typos)
 
 ### Collaboration
 
@@ -120,7 +120,7 @@ docker -v
 docker compose version
 ```
 
-> If you encounounter permission errors, you may need to use `sudo`, or add your user to the `docker` group.
+> If you encounter permission errors, you may need to use `sudo`, or add your user to the `docker` group.
 
 ### Bootstrap the project
 
@@ -130,9 +130,9 @@ The easiest way to start is using GNU Make:
 make bootstrap FLUSH_ARGS='--no-input'
 ```
 
-This builds the `app-dev` and `fronted-dev` containers, installs dependencies, runs database migrations, and compiles translations.
+This builds the `app-dev` and `frontend-dev` containers, installs dependencies, runs database migrations, and compiles translations.
 
-It is recommend to run this command after pulling new code.
+It is recommended to run this command after pulling new code.
 
 Start services:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -68,5 +68,5 @@ service.
 
 - AI features are now limited to users who are authenticated. Before this release, even anonymous
   users who gained editor access on a document with link reach used to get AI feature.
-  IF you want anonymous users to keep access on AI features, you must now define the
+  If you want anonymous users to keep access on AI features, you must now define the
   `AI_ALLOW_REACH_FROM` setting to "public".

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -13,7 +13,7 @@ Please follow the instructions [here](/docs/installation/compose.md).
 ⚠️ Please keep in mind that we do not use it ourselves in production. Let us know in the issues if you run into troubles, we'll try to help.
 
 ## Other ways to install Docs
-Community members have contributed several other ways to install Docs. While we owe them a big thanks 🙏, please keep in mind we (Docs maintainers) can't provide support on these installation methods as we don't use them ourselves and there are two many options out there for us to keep track of. Of course you can contact the contributors and the broader community for assistance.
+Community members have contributed several other ways to install Docs. While we owe them a big thanks 🙏, please keep in mind we (Docs maintainers) can't provide support on these installation methods as we don't use them ourselves and there are too many options out there for us to keep track of. Of course you can contact the contributors and the broader community for assistance.
 
 Here is the list of other methods in alphabetical order:
 - Coop-Cloud: [code](https://git.coopcloud.tech/coop-cloud/lasuite-docs)

--- a/docs/installation/compose.md
+++ b/docs/installation/compose.md
@@ -134,7 +134,7 @@ DJANGO_EMAIL_URL_APP=<url used in email templates to go to the app> # e.g. "http
 
 Built-in AI actions let users generate, summarize, translate, and correct content.
 
-AI is disabled by default. To enable it, the following environment variables must be set in in `env.d/backend`:
+AI is disabled by default. To enable it, the following environment variables must be set in `env.d/backend`:
 
 ```env
 AI_FEATURE_ENABLED=true # is false by default
@@ -152,7 +152,7 @@ You can [customize your Docs instance](../theming.md) with your own theme and cu
 The following environment variables must be set in `env.d/backend`:
 
 ```env
-FRONTEND_THEME=default # name of your theme built with cuningham
+FRONTEND_THEME=default # name of your theme built with Cunningham
 FRONTEND_CSS_URL=https://storage.yourdomain.tld/themes/custom.css # custom css
 ```
 
@@ -206,7 +206,7 @@ Replace `<admin email>` with the email of your admin user and generate a secure 
 
 Your docs instance is now available on the domain you defined, https://docs.yourdomain.tld.
 
-THe admin interface is available on https://docs.yourdomain.tld/admin with the admin user you just created.
+The admin interface is available on https://docs.yourdomain.tld/admin with the admin user you just created.
 
 ## How to upgrade your Docs application
 

--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -250,4 +250,4 @@ minio-dev-backend-minio-api       <none>   docs-minio.127.0.0.1.nip.io          
 minio-dev-backend-minio-console   <none>   docs-minio-console.127.0.0.1.nip.io   localhost   80, 443   8m48s
 ```
 
-You can use Docs at https://docs.127.0.0.1.nip.io. The provisionning user in keycloak is docs/docs.
+You can use Docs at https://docs.127.0.0.1.nip.io. The provisioning user in keycloak is docs/docs.

--- a/src/helm/impress/values.yaml
+++ b/src/helm/impress/values.yaml
@@ -37,7 +37,7 @@ ingress:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingress.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingress.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingress.tls.secretName Secret name for TLS config
   ## @skip ingress.tls.additional
   ## @extra ingress.tls.additional[].secretName Secret name for additional TLS config
@@ -62,7 +62,7 @@ ingressCollaborationWS:
   ## @param ingressCollaborationWS.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressCollaborationWS.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressCollaborationWS.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressCollaborationWS.tls.secretName Secret name for TLS config
   ## @skip ingressCollaborationWS.tls.additional
   ## @extra ingressCollaborationWS.tls.additional[].secretName Secret name for additional TLS config
@@ -92,7 +92,7 @@ ingressRedirects:
   enabled: false
   className: null
   host: impress.example.com
-  ## @param ingressRedirects.tls.enabled Weather to enable TLS for the Ingress Redirects
+  ## @param ingressRedirects.tls.enabled Whether to enable TLS for the Ingress Redirects
   ## @param ingressRedirects.tls.secretName Secret name for TLS config
   ## @skip ingressRedirects.tls.additional
   ## @extra ingressRedirects.tls.additional[].secretName Secret name for additional TLS config
@@ -116,7 +116,7 @@ ingressCollaborationApi:
   ## @param ingressCollaborationApi.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressCollaborationApi.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressCollaborationApi.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressCollaborationApi.tls.secretName Secret name for TLS config
   ## @skip ingressCollaborationApi.tls.additional
   ## @extra ingressCollaborationApi.tls.additional[].secretName Secret name for additional TLS config
@@ -145,7 +145,7 @@ ingressAdmin:
   ## @param ingressAdmin.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressAdmin.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressAdmin.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressAdmin.tls.secretName Secret name for TLS config
   ## @skip ingressAdmin.tls.additional
   ## @extra ingressAdmin.tls.additional[].secretName Secret name for additional TLS config
@@ -167,7 +167,7 @@ ingressMedia:
   ## @param ingressMedia.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressMedia.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressMedia.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressMedia.tls.secretName Secret name for TLS config
   ## @skip ingressMedia.tls.additional
   ## @extra ingressMedia.tls.additional[].secretName Secret name for additional TLS config
@@ -453,7 +453,7 @@ frontend:
   ## @param frontend.replicas Amount of frontend replicas
   replicas: 3
 
-  ## @param frontend.shareProcessNamespace Enable share process namefrontend between containers
+  ## @param frontend.shareProcessNamespace Enable share process namespace between containers
   shareProcessNamespace: false
 
   ## @param frontend.sidecars Add sidecars containers to frontend deployment


### PR DESCRIPTION
## Summary
- Fix typos in documentation and code comments
- Corrections: regulair → regular, licences → licenses, dont → don't

## Details
Fixed 4 typos identified across the codebase:
- `docs/env.md`: regulair → regular, licences → licenses (2x)
- `src/frontend/apps/impress/src/features/auth/utils.ts`: dont → don't

## Test plan
- [ ] Verify changes are correct
- [ ] CI passes