### PR TITLE
♿️(i18n) add "new window" translation key for waffle aria-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,20 +14,14 @@ and this project adheres to
 
 - ♿(frontend) localize LaGaufre label fallback in Docs #1979
 - ✨(backend) add a migration cleaning on-boarding document accesses
+- ⬆️(frontend) upgrade Next.js to v16 #1980
+- ♿️(frontend) fix aria-label and landmark on document banner state #1986
+- 🌐(i18n) add "new window" translation key for waffle aria-label #1984
 
 ### Fixed
 
 - 🐛(backend) create a link_trace record for on-boarding documents
 - 🐛(backend) manage race condition when creating sandbox document
-
-### Changed
-
-⬆️(frontend) upgrade Next.js to v16 #1980
-
-
-### Changed
-
-- ♿️(frontend) fix aria-label and landmark on document banner state #1986
 
 ## [v4.7.0] - 2026-03-09
 

--- a/src/frontend/apps/impress/src/features/header/components/Waffle.tsx
+++ b/src/frontend/apps/impress/src/features/header/components/Waffle.tsx
@@ -27,8 +27,8 @@ export type WaffleType = Omit<
 const LaGaufreV2Fixed = LaGaufreV2 as React.ComponentType<WaffleType>;
 
 export const Waffle = () => {
-  const { data: conf } = useConfig();
   const { t } = useTranslation();
+  const { data: conf } = useConfig();
 
   const waffleConfig = conf?.theme_customization?.waffle;
 
@@ -47,6 +47,7 @@ export const Waffle = () => {
       <LaGaufreV2Fixed
         {...waffleConfig}
         label={waffleConfig.label ?? t('Digital LaSuite services')}
+        newWindowLabelSuffix={t('new window')}
       />
     </Box>
   );


### PR DESCRIPTION
## Purpose

Add the "new window" translation key for waffle external links aria-label.

## Proposal

- [x] Add the "new window" key in translations.json (all languages)
- [x] Pass newWindowLabelSuffix={t('new window')} to LaGaufreV2 in Waffle.tsx to localize aria-labels of links opening in a new window (e.g. "Visio (nouvelle fenêtre)" in French)