### PR TITLE
♿️(frontend) fix aria-label and improper landmark on document banner state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to
 ⬆️(frontend) upgrade Next.js to v16 #1980
 
 
+### Changed
+
+- ♿️(frontend) fix aria-label and landmark on document banner state #1986
+
 ## [v4.7.0] - 2026-03-09
 
 ### Added
@@ -46,7 +50,6 @@ and this project adheres to
 - 🐛(frontend) fix zIndex table of content #1949
 - 🐛(frontend) fix bug when language not supported by BN #1957
 - 🐛 (backend) prevent privileged users from requesting access #1898
-
 
 ## [v4.6.0] - 2026-03-03
 

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertPublic.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertPublic.tsx
@@ -9,7 +9,7 @@ export const AlertPublic = ({ isPublicDoc }: { isPublicDoc: boolean }) => {
 
   return (
     <Card
-      aria-label={t('Public document')}
+      role="presentation"
       $radius={spacingsTokens['3xs']}
       $direction="row"
       $padding="xs"


### PR DESCRIPTION
## Purpose

Fix improper use of landmark on the public document alert banner.

Remove the redundant `aria-label` and `role="region"` on `AlertPublic` to avoid duplicate screen reader announcements and align with RGAA 12.6.

Screen readers will now announce the visible text only, for example: "Document accessible à toute personne connectée".

## Proposal

- [x] Remove `aria-label` from `AlertPublic` (redundant with visible text)
- [x] Override default `role="region"` with `role="presentation"` (not a main content landmark)