### PR TITLE
🐛(frontend) fix skeleton blocked on main page

### DIFF
--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -157,11 +157,16 @@ const DocPage = ({ id }: DocProps) => {
     setCurrentDoc(docQuery);
   }, [docQuery, setCurrentDoc, isFetching]);
 
+  /**
+   * Reset state when unmounting the component to avoid
+   * showing stale data when navigating to another document
+   */
   useEffect(() => {
     return () => {
       setCurrentDoc(undefined);
+      setIsSkeletonVisible(false);
     };
-  }, [setCurrentDoc]);
+  }, [setCurrentDoc, setIsSkeletonVisible]);
 
   /**
    * We add a broadcast task to reset the query cache


### PR DESCRIPTION
## Purpose

If navigating quickly between documents, the skeleton of the document page can be blocked on the main page.
This commit fixes this issue by resetting the skeleton state when unmounting the document page.


## Demo problem


https://github.com/user-attachments/assets/80979a79-9399-4680-9298-a2873756eec3

