### PR TITLE
♿️(frontend) fix share modal heading hierarchy and title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to
 
 ### Fixed
 
-- 🙈(docker) add **/.next to .dockerignore #2034
+- 🙈(docker) add \*\*/.next to .dockerignore #2034
 
 ### Changed
 
 - ♿️(frontend) ensure doc title is h1 for accessibility #2006
+- ♿️(frontend) fix share modal heading hierarchy #2007
 
 ## [v4.8.1] - 2026-03-17
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
@@ -285,7 +285,7 @@ test.describe('Doc Header', () => {
     await page.getByRole('button', { name: 'Share' }).click();
 
     const shareModal = page.getByRole('dialog', {
-      name: 'Share modal content',
+      name: 'Share the document',
     });
     await expect(shareModal).toBeVisible();
     await expect(page.getByText('Share the document')).toBeVisible();
@@ -364,7 +364,7 @@ test.describe('Doc Header', () => {
     await page.getByRole('button', { name: 'Share' }).click();
 
     const shareModal = page.getByRole('dialog', {
-      name: 'Share modal content',
+      name: 'Share the document',
     });
     await expect(shareModal).toBeVisible();
     await expect(page.getByText('Share the document')).toBeVisible();
@@ -435,7 +435,9 @@ test.describe('Doc Header', () => {
 
     await page.getByRole('button', { name: 'Share' }).click();
 
-    const shareModal = page.getByLabel('Share modal');
+    const shareModal = page.getByRole('dialog', {
+      name: 'Share the document',
+    });
     await expect(page.getByText('Share the document')).toBeVisible();
 
     await expect(page.getByPlaceholder('Type a name or email')).toBeHidden();
@@ -705,10 +707,12 @@ test.describe('Documents Header mobile', () => {
     await page.getByRole('menuitem', { name: 'Share' }).click();
 
     const shareModal = page.getByRole('dialog', {
-      name: 'Share modal content',
+      name: 'Share the document',
     });
     await expect(shareModal).toBeVisible();
     await page.getByRole('button', { name: 'close' }).click();
-    await expect(page.getByLabel('Share modal')).toBeHidden();
+    await expect(
+      page.getByRole('dialog', { name: 'Share the document' }),
+    ).toBeHidden();
   });
 });

--- a/src/frontend/apps/impress/src/components/quick-search/QuickSearchGroup.tsx
+++ b/src/frontend/apps/impress/src/components/quick-search/QuickSearchGroup.tsx
@@ -19,9 +19,11 @@ export const QuickSearchGroup = <T,>({
 }: Props<T>) => {
   return (
     <Box>
+      <Text as="h2" $weight="700" $size="sm" $margin="none">
+        {group.groupName}
+      </Text>
       <Command.Group
         key={group.groupName}
-        heading={group.groupName}
         forceMount={false}
         contentEditable={false}
       >

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
@@ -183,7 +183,7 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
         isOpen
         closeOnClickOutside
         data-testid="doc-share-modal"
-        aria-labelledby="doc-share-modal-title"
+        aria-label={t('Share the document')}
         size={isDesktop ? ModalSize.LARGE : ModalSize.FULL}
         aria-modal="true"
         onClose={onClose}
@@ -223,8 +223,6 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
           $overflow="hidden"
           className="--docs--doc-share-modal noPadding "
           $justify="space-between"
-          role="dialog"
-          aria-label={t('Share modal content')}
         >
           <Box
             $flex={1}

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocVisibility.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocVisibility.tsx
@@ -137,7 +137,7 @@ export const DocVisibility = ({ doc }: DocVisibilityProps) => {
       $gap={spacingsTokens['base']}
       className="--docs--doc-visibility"
     >
-      <Text $weight="700" $size="sm">
+      <Text as="h2" $weight="700" $size="sm" $margin="none">
         {t('Link settings')}
       </Text>
       {isDesynchronized && <DocDesynchronized doc={doc} />}


### PR DESCRIPTION
## Purpose

Fix two accessibility issues in the share modal:
1. The modal's accessible name was `[object Object]` and there was a duplicate `role="dialog"` causing confusion for screen readers.
2. The heading hierarchy was inconsistent: group names and "Link settings" were not structured as h2 under the h1 "Share the document", and some were hidden from assistive technologies via `aria-hidden`.

<img width="1455" height="766" alt="hierarchy" src="https://github.com/user-attachments/assets/caaa925d-03af-456f-b598-91527a6f6665" />

<img width="992" height="162" alt="sharemodalname" src="https://github.com/user-attachments/assets/41e8c6e3-886e-4018-bed4-e482d484f01f" />

## Proposal

- [x] Fix modal `aria-label` being `[object Object]` by passing an explicit string instead of relying on `title.toString()` on a ReactNode
- [x] Remove duplicate `role="dialog"` and  `aria-label` from the inner presentational container
- [x] Replace the `heading` prop of `Command.Group` (which rendered a div with `aria-hidden="true"`) with an explicit `<Text as="h2">` for group names (e.g. Shared with X users, Document owner, Pending invitations)
- [x] Render "Link settings" as h2 in `DocVisibility`
- [x] Ensure consistent h1 → h2 heading hierarchy in the share modal