### PR TITLE
♿️(frontend) add nb accesses in share button aria-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to
 ### Changed
 
 - ♿️(frontend) ensure doc title is h1 for accessibility #2006
+- ♿️(frontend) add nb accesses in share button aria-label #2017
 
 ### Fixed
 
 - 🐛(frontend) fix image resizing when caption #2045
-- 🙈(docker) add **/.next to .dockerignore #2034
+- 🙈(docker) add \*\*/.next to .dockerignore #2034
 - ♿️(frontend) fix share modal heading hierarchy #2007
 - ♿️(frontend) fix Copy link toast accessibility for screen readers #2029
 - ♿️(frontend) fix modal aria-label and name #2014

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/BoutonShare.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/BoutonShare.tsx
@@ -55,7 +55,9 @@ export const BoutonShare = ({
         `}
       >
         <Button
-          aria-label={t('Share button')}
+          aria-label={t('Share button, shared with {{count}} users', {
+            count: doc.nb_accesses_direct,
+          })}
           variant="secondary"
           icon={
             <Icon


### PR DESCRIPTION
## Purpose

The share button shows the number of users with access, but screen readers don't announce it.

## Proposal

- [x] Add `nb_accesses_direct` to the share button `aria-label` when the count is visible