### PR TITLE
✨(backend) Order pinned documents by last updated at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to
 
 ### Fixed
 
-🐛(frontend) abort check media status unmount #2194
+- 🐛(frontend) abort check media status unmount #2194
+- ✨(backend) order pinned documents by last updated at #2028
 
 ## [v4.8.6] - 2026-04-08
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -834,6 +834,7 @@ class DocumentViewSet(
         queryset = self.queryset.filter(path_list)
         queryset = queryset.filter(id__in=favorite_documents_ids)
         queryset = queryset.filter(ancestors_deleted_at__isnull=True)
+        queryset = queryset.order_by("-updated_at")
         queryset = queryset.annotate_user_roles(user)
         queryset = queryset.annotate(
             is_favorite=db.Value(True, output_field=db.BooleanField())

--- a/src/backend/core/tests/documents/test_api_documents_favorite_list.py
+++ b/src/backend/core/tests/documents/test_api_documents_favorite_list.py
@@ -1,5 +1,9 @@
 """Test for the document favorite_list endpoint."""
 
+from datetime import timedelta
+
+from django.utils import timezone
+
 import pytest
 from rest_framework.test import APIClient
 
@@ -111,8 +115,50 @@ def test_api_document_favorite_list_with_favorite_children():
 
     content = response.json()["results"]
 
-    assert content[0]["id"] == str(children[0].id)
+    assert content[0]["id"] == str(access.document.id)
     assert content[1]["id"] == str(children[1].id)
+    assert content[2]["id"] == str(children[0].id)
+
+
+def test_api_document_favorite_list_sorted_by_updated_at():
+    """
+    Authenticated users should receive their favorite documents including children
+    sorted by last updated_at timestamp.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    root = factories.DocumentFactory(creator=user, users=[user])
+    children = factories.DocumentFactory.create_batch(
+        2, parent=root, favorited_by=[user]
+    )
+
+    access = factories.UserDocumentAccessFactory(
+        user=user, role=models.RoleChoices.READER, document__favorited_by=[user]
+    )
+
+    other_root = factories.DocumentFactory(creator=user, users=[user])
+    factories.DocumentFactory.create_batch(2, parent=other_root)
+
+    now = timezone.now()
+
+    models.Document.objects.filter(pk=children[0].pk).update(
+        updated_at=now + timedelta(seconds=2)
+    )
+    models.Document.objects.filter(pk=children[1].pk).update(
+        updated_at=now + timedelta(seconds=3)
+    )
+
+    response = client.get("/api/v1.0/documents/favorite_list/")
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 3
+
+    content = response.json()["results"]
+
+    assert content[0]["id"] == str(children[1].id)
+    assert content[1]["id"] == str(children[0].id)
     assert content[2]["id"] == str(access.document.id)
 
 


### PR DESCRIPTION
## Purpose

- Closes https://github.com/suitenumerique/docs/issues/1962

https://github.com/user-attachments/assets/305633ee-db37-490f-bcf6-2cc64374238b

## Proposal

- [ ] Use queryset to sort favorite documents by last updated_at date.


## External contributions

Thank you for your contribution! 🎉  


Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)