### PR TITLE
♿️(frontend) fix waffle aria-label spacing for new-window links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - ♿️(frontend) fix Copy link toast accessibility for screen readers #2029
 - ♿️(frontend) fix modal aria-label and name #2014
 - ♿️(frontend) fix language dropdown ARIA for screen readers #2020
+- ♿️(frontend) fix waffle aria-label spacing for new-window links #2030
 
 ## [v4.8.1] - 2026-03-17
 

--- a/src/frontend/apps/impress/src/features/header/components/Waffle.tsx
+++ b/src/frontend/apps/impress/src/features/header/components/Waffle.tsx
@@ -47,7 +47,7 @@ export const Waffle = () => {
       <LaGaufreV2Fixed
         {...waffleConfig}
         label={waffleConfig.label ?? t('Digital LaSuite services')}
-        newWindowLabelSuffix={t('new window')}
+        newWindowLabelSuffix={` (${t('new window')})`}
       />
     </Box>
   );


### PR DESCRIPTION
## Purpose

Fix the aria-label for waffle links that open in a new window. Screen readers previously announced "Visionouvelle fenêtre" instead of "Visio (nouvelle fenêtre)".

## Proposal

- [x] Include the space and parentheses in the key