### PR TITLE
🙈(docker) add **/.next to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,4 +34,4 @@ db.sqlite3
 
 # Frontend
 node_modules
-.next
+**/.next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🙈(docker) add **/.next to .dockerignore #2034
+
+
 ## [v4.8.1] - 2026-03-17
 
 ### Added


### PR DESCRIPTION
## Purpose

The container "frontend-development" was failing since the upgrade of Next.
Seems to be because all the ".next" files generated by the build process should not be included in the Docker context.


