### PR TITLE
⬇️(backend) downgrade django-treebeard to version < 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [v4.8.0] - 2026-03-13
 
+### Changed
+
+- ⬇️(backend) downgrade django-treebeard to version < 5.0.0
+
 ### Added
 
 - ✨(backend) add a is_first_connection flag to the User model #1938

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,12 @@
       "allowedVersions": "<3.12.0"
     },
     {
+      "groupName": "allowed django-treebeard versions",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["django-treebeard"],
+      "allowedVersions": "<5.0.0"
+    },
+    {
       "enabled": false,
       "groupName": "ignored js dependencies",
       "matchManagers": ["npm"],

--- a/src/backend/core/migrations/0015_set_path_on_existing_documents.py
+++ b/src/backend/core/migrations/0015_set_path_on_existing_documents.py
@@ -22,7 +22,7 @@ def set_path_on_existing_documents(apps, schema_editor):
 
     # Iterate over all existing documents and make them root nodes
     documents = Document.objects.order_by("created_at").values_list("id", flat=True)
-    numconv = NumConv(ALPHABET)
+    numconv = NumConv(len(ALPHABET), ALPHABET)
 
     updates = []
     for i, pk in enumerate(documents):

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "django-storages[s3]==1.14.6",
     "django-timezone-field>=5.1",
     "django<6.0.0",
-    "django-treebeard==5.0.5",
+    "django-treebeard<5.0.0",
     "djangorestframework==3.16.1",
     "drf_spectacular==0.29.0",
     "dockerflow==2026.1.26",


### PR DESCRIPTION
## Purpose

Since we upgraded to django-treebeard version 5 we have anormal behavior and a high error rate on the document.path property. We must downgrade it and avoid future upgrade from renovate.


## Proposal

- [x] ⬇️(backend) downgrade django-treebeard to version < 5.0.0