### PR TITLE
Improve test coverage on the Document update API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,13 @@ and this project adheres to
 - ♿️(frontend) add sr-only format to export download button #2088
 - ♿️(frontend) announce formatting shortcuts for screen readers #2070
 - ✨(frontend) add markdown copy icon for Copy as Markdown option #2096
+- ♻️(backend) skip saving in database a document when payload is empty #2062
 
 ### Fixed
 
 - ♿️(frontend) fix aria-labels for table of contents #2065
-
-### Fixed
-
 - 🐛(backend) allow using search endpoint without refresh token enabled #2097
+
 
 ## [v4.8.2] - 2026-03-19
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -300,6 +300,15 @@ class DocumentSerializer(ListDocumentSerializer):
 
         return file
 
+    def update(self, instance, validated_data):
+        """
+        When no data is sent on the update, skip making the update in the database and return
+        directly the instance unchanged.
+        """
+        if not validated_data:
+            return instance  # No data provided, skip the update
+        return super().update(instance, validated_data)
+
     def save(self, **kwargs):
         """
         Process the content field to extract attachment keys and update the document's

--- a/src/backend/core/tests/documents/test_api_documents_update.py
+++ b/src/backend/core/tests/documents/test_api_documents_update.py
@@ -4,6 +4,7 @@ Tests for Documents API endpoint in impress's core app: update
 # pylint: disable=too-many-lines
 
 import random
+from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
@@ -1429,3 +1430,47 @@ def test_api_documents_patch_invalid_content():
     )
     assert response.status_code == 400
     assert response.json() == {"content": ["Invalid base64 content."]}
+
+
+@responses.activate
+def test_api_documents_patch_empty_body(settings):
+    """
+    Test when data is empty the document should not be updated.
+    The `updated_at` property should not change asserting that no update in the database is made.
+    """
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+    session_key = client.session.session_key
+
+    document = factories.DocumentFactory(users=[(user, "owner")], creator=user)
+    document_updated_at = document.updated_at
+
+    settings.COLLABORATION_API_URL = "http://example.com/"
+    settings.COLLABORATION_SERVER_SECRET = "secret-token"
+    settings.COLLABORATION_WS_NOT_CONNECTED_READY_ONLY = True
+    endpoint_url = (
+        f"{settings.COLLABORATION_API_URL}get-connections/"
+        f"?room={document.id}&sessionKey={session_key}"
+    )
+    ws_resp = responses.get(endpoint_url, json={"count": 3, "exists": True})
+
+    assert cache.get(f"docs:no-websocket:{document.id}") is None
+
+    old_document_values = serializers.DocumentSerializer(instance=document).data
+
+    with patch("core.models.Document.save") as mock_document_save:
+        response = client.patch(
+            f"/api/v1.0/documents/{document.id!s}/",
+            content_type="application/json",
+        )
+    mock_document_save.assert_not_called()
+    assert response.status_code == 200
+
+    document = models.Document.objects.get(id=document.id)
+    new_document_values = serializers.DocumentSerializer(instance=document).data
+    assert new_document_values == old_document_values
+    assert document_updated_at == document.updated_at
+    assert cache.get(f"docs:no-websocket:{document.id}") is None
+    assert ws_resp.call_count == 1


### PR DESCRIPTION
## Purpose

There was no test using the PATCH method to update a Document and it is the method mostly used by the frontend application. This PR add all the missing test with the PATCH method.

Also, the frontend application make PATCH request with no body. In that case, an UPDATE method is used but nothing is changed. We can skip this UPDATE by returning earlier the Document instance in the update method in the serializer.


## Proposal

- [x] ✅(backend) assert document path can not change during API update
- [x] ✅(backend) add missing update api test using the PATCH method
- [x] ♻️(backend) skip saving in database a document when payload is empty  