### PR TITLE
♿️(frontend) fix aria-labels for table of contents 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to
 - ♿️(frontend) add sr-only format to export download button #2088
 - ♿️(frontend) announce formatting shortcuts for screen readers #2070
 
+### Fixed
+
+- ♿️(frontend) fix aria-labels for table of contents #2065
+
 ## [v4.8.2] - 2026-03-19
 
 ### Added

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-table-content.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-table-content.spec.ts
@@ -19,7 +19,9 @@ test.describe('Doc Table Content', () => {
 
     await page.locator('.ProseMirror').click();
 
-    await expect(page.getByRole('button', { name: 'Summary' })).toBeHidden();
+    await expect(
+      page.getByRole('button', { name: 'Show the table of contents' }),
+    ).toBeHidden();
 
     await page.keyboard.type('# Level 1\n## Level 2\n### Level 3');
 

--- a/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContent.tsx
@@ -91,7 +91,7 @@ export const TableContent = () => {
             $height="100%"
             $justify="center"
             $align="center"
-            aria-label={t('Summary')}
+            aria-label={t('Show the table of contents')}
             aria-expanded={isOpen}
             aria-controls="toc-list"
             $css={css`
@@ -218,8 +218,8 @@ const TableContentOpened = ({
           onClick={onClose}
           $justify="center"
           $align="center"
-          aria-label={t('Summary')}
-          aria-expanded="true"
+          aria-label={t('Hide the table of contents')}
+          aria-expanded={true}
           aria-controls="toc-list"
           $css={css`
             transition: none !important;


### PR DESCRIPTION
## Purpose

Use distinct aria-labels for the table of contents region (nav) and the toggle buttons.

## Proposal

- [x] Keep "Summary" on the `<nav>`
- [x] Use "Show/Hide the table of contents" on the buttons
- [x] Update the e2e test