### PR TITLE
🔖(patch) release 4.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v4.8.2] - 2026-03-19
+
 ### Changed
 
 - ♿️(frontend) ensure doc title is h1 for accessibility #2006
@@ -20,8 +22,8 @@ and this project adheres to
 - ♿️(frontend) fix modal aria-label and name #2014
 - ♿️(frontend) fix language dropdown ARIA for screen readers #2020
 - ♿️(frontend) fix waffle aria-label spacing for new-window links #2030
-- 🐛(backend) stop using add_sibling method to create sandbox document
-- 🐛(backend) duplicate a document as last-sibling
+- 🐛(backend) stop using add_sibling method to create sandbox document #2084
+- 🐛(backend) duplicate a document as last-sibling #2084
 
 ## [v4.8.1] - 2026-03-17
 
@@ -1139,7 +1141,8 @@ and this project adheres to
 - ✨(frontend) Coming Soon page (#67)
 - 🚀 Impress, project to manage your documents easily and collaboratively.
 
-[unreleased]: https://github.com/suitenumerique/docs/compare/v4.8.1...main
+[unreleased]: https://github.com/suitenumerique/docs/compare/v4.8.2...main
+[v4.8.2]: https://github.com/suitenumerique/docs/releases/v4.8.2
 [v4.8.1]: https://github.com/suitenumerique/docs/releases/v4.8.1
 [v4.8.0]: https://github.com/suitenumerique/docs/releases/v4.8.0
 [v4.7.0]: https://github.com/suitenumerique/docs/releases/v4.7.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impress"
-version = "4.8.1"
+version = "4.8.2"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-impress",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "private": true,
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",

--- a/src/frontend/packages/eslint-plugin-docs/package.json
+++ b/src/frontend/packages/eslint-plugin-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-docs",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/servers/y-provider/package.json
+++ b/src/frontend/servers/y-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-y-provider",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "Y.js provider for docs",
   "repository": "https://github.com/suitenumerique/docs",
   "license": "MIT",

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -1,10 +1,10 @@
 environments:
   dev:
     values:
-      - version: 4.8.0
+      - version: 4.8.2
   feature:
     values:
-      - version: 4.8.0
+      - version: 4.8.2
         feature: ci
         domain: example.com
         imageTag: demo

--- a/src/helm/impress/Chart.yaml
+++ b/src/helm/impress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: docs
-version: 4.8.1
+version: 4.8.2
 appVersion: latest

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Added

- ✨(backend) add resource server api #1923
- ✨(frontend) activate Find search #1834
- ✨ handle searching on subdocuments #1834
- ✨(backend) add search feature flags #1897

### Changed

- ♿️(frontend) ensure doc title is h1 for accessibility #2006
- ♿️(frontend) add nb accesses in share button aria-label #2017
- ✨(backend) improve fallback logic on search endpoint #1834

### Fixed

- 🐛(frontend) fix image resizing when caption #2045
- 🙈(docker) add \*\*/.next to .dockerignore #2034
- ♿️(frontend) fix share modal heading hierarchy #2007
- ♿️(frontend) fix Copy link toast accessibility for screen readers #2029
- ♿️(frontend) fix modal aria-label and name #2014
- ♿️(frontend) fix language dropdown ARIA for screen readers #2020
- ♿️(frontend) fix waffle aria-label spacing for new-window links #2030
- 🐛(backend) stop using add_sibling method to create sandbox document #2084
- 🐛(backend) duplicate a document as last-sibling #2084

### Removed

- 🔥(api) remove `documents/<document_id>/descendants/` endpoint #1834
- 🔥(api) remove pagination on `documents/search/` endpoint #1834
