### PR TITLE
♿️(frontend) add sr-only format to export download button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - ♿️(frontend) fix more options menu feedback for screen readers #2071
 - ♿(frontend) focus skip link on headings and skip grid dropzone #1983
 - ♿️(frontend) fix search modal accessibility issues #2054
+- ♿️(frontend) add sr-only format to export download button #2088
 
 ## [v4.8.2] - 2026-03-19
 

--- a/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
@@ -60,6 +60,23 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
   const { untitledDocument } = useTrans();
   const mediaUrl = useMediaUrl();
 
+  const formatOptions = [
+    { label: t('PDF'), value: DocDownloadFormat.PDF },
+    { label: t('Docx'), value: DocDownloadFormat.DOCX },
+    { label: t('ODT'), value: DocDownloadFormat.ODT },
+    { label: t('HTML'), value: DocDownloadFormat.HTML },
+    { label: t('Print'), value: DocDownloadFormat.PRINT },
+  ];
+
+  const formatLabels = Object.fromEntries(
+    formatOptions.map((opt) => [opt.value, opt.label]),
+  );
+
+  const downloadButtonAriaLabel =
+    format === DocDownloadFormat.PRINT
+      ? t('Print')
+      : t('Download {{format}}', { format: formatLabels[format] });
+
   async function onSubmit() {
     if (!editor) {
       toast(t('The export failed'), VariantType.ERROR);
@@ -211,9 +228,7 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
           </Button>
           <Button
             data-testid="doc-export-download-button"
-            aria-label={
-              format === DocDownloadFormat.PRINT ? t('Print') : t('Download')
-            }
+            aria-label={downloadButtonAriaLabel}
             variant="primary"
             fullWidth
             onClick={() => void onSubmit()}
@@ -260,13 +275,7 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
           clearable={false}
           fullWidth
           label={t('Format')}
-          options={[
-            { label: t('PDF'), value: DocDownloadFormat.PDF },
-            { label: t('Docx'), value: DocDownloadFormat.DOCX },
-            { label: t('ODT'), value: DocDownloadFormat.ODT },
-            { label: t('HTML'), value: DocDownloadFormat.HTML },
-            { label: t('Print'), value: DocDownloadFormat.PRINT },
-          ]}
+          options={formatOptions}
           value={format}
           onChange={(options) =>
             setFormat(options.target.value as DocDownloadFormat)


### PR DESCRIPTION
## Purpose

Help screen reader users know which format will be exported before they click. Today they only hear "Download" and can't tell if it's PDF, DOCX, etc.

## Proposal

- [x] Add the selected format to the download button’s aria-label (e.g. "Download PDF") for screen readers
- [x] Remove the redundant aria-label that repeated the visible text
- [x] Simplify the code by using one shared list of format options