### PR TITLE
🐛(frontend) fix leftpanel button in doc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - ♿️(frontend) fix aria-labels for table of contents #2065
 - 🐛(backend) allow using search endpoint without refresh token enabled #2097
 - 🐛(frontend) fix close panel when click on subdoc
+- 🐛(frontend) fix leftpanel button in doc version #9238
 
 ## [v4.8.2] - 2026-03-19
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/DocEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/DocEditor.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 
 import { Box, Loading } from '@/components';
-import { DocHeader, FloatingBar } from '@/docs/doc-header/';
+import { DocHeader } from '@/docs/doc-header/';
 import {
   Doc,
   LinkReach,
@@ -35,7 +35,6 @@ export const DocEditorContainer = ({
 
   return (
     <>
-      {isDesktop && <FloatingBar />}
       <Box
         $maxWidth="868px"
         $width="100%"

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelCollapseButton.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelCollapseButton.tsx
@@ -18,8 +18,46 @@ export const LeftPanelCollapseButton = () => {
   const { isPanelOpen, togglePanel } = useLeftPanelStore();
   const { currentDoc } = useDocStore();
   const [isDocTitleVisible, setIsDocTitleVisible] = useState(true);
+  const [isDocTitleInDom, setIsDocTitleInDom] = useState(true);
 
+  /**
+   * CLASS_DOC_TITLE is not every time in the DOM when
+   * this component is rendered, we need to observe the DOM
+   * to know when it is added, then we can observe
+   * its visibility.
+   */
   useEffect(() => {
+    setIsDocTitleInDom(false);
+
+    const docTitleEl = document.querySelector(`.${CLASS_DOC_TITLE}`);
+    if (docTitleEl) {
+      setIsDocTitleInDom(true);
+      return;
+    }
+
+    const mutationObserver = new MutationObserver(() => {
+      if (document.querySelector(`.${CLASS_DOC_TITLE}`)) {
+        mutationObserver.disconnect();
+        setIsDocTitleInDom(true);
+      }
+    });
+
+    mutationObserver.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      mutationObserver.disconnect();
+    };
+  }, [currentDoc?.id]);
+
+  /**
+   * When the doc title is in the DOM, we observe its
+   * visibility to show or hide the collapse button accordingly
+   */
+  useEffect(() => {
+    if (!isDocTitleInDom) {
+      return;
+    }
+
     const mainContent = document.getElementById(MAIN_LAYOUT_ID);
     const docTitleEl = document.querySelector(`.${CLASS_DOC_TITLE}`);
 
@@ -43,7 +81,7 @@ export const LeftPanelCollapseButton = () => {
       observer.disconnect();
       setIsDocTitleVisible(true);
     };
-  }, [currentDoc?.id]);
+  }, [isDocTitleInDom]);
 
   const { untitledDocument } = useTrans();
 

--- a/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
+++ b/src/frontend/apps/impress/src/pages/docs/[id]/index.tsx
@@ -19,6 +19,7 @@ import {
   useTrans,
 } from '@/docs/doc-management/';
 import { KEY_AUTH, setAuthUrl, useAuth } from '@/features/auth';
+import { FloatingBar } from '@/features/docs/doc-header/components/FloatingBar';
 import { getDocChildren, subPageToTree } from '@/features/docs/doc-tree/';
 import { DocEditorSkeleton, useSkeletonStore } from '@/features/skeletons';
 import { MainLayout } from '@/layouts';
@@ -60,6 +61,7 @@ export function DocLayout() {
         }}
       >
         <MainLayout enableResizablePanel={true}>
+          <FloatingBar />
           <DocPage id={id} />
         </MainLayout>
       </TreeProvider>


### PR DESCRIPTION
## Purpose

The left panel button was shown in the doc version page. 
This commit removes the button from the doc version page by moving it to the DocLayout.
By moving it to the DocLayout, we do not have the flickering when we switch between subpages.


## Demo problem

<img width="1898" height="540" alt="image" src="https://github.com/user-attachments/assets/6247e2f2-f6e6-40f8-8c32-e8d8fed067ed" />