### PR TITLE
♿️(frontend) add aria-hidden to decorative icons in dropdown menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - 💄(frontend) improve comments highlights #1961
 - ♿️(frontend) improve BoxButton a11y and native button semantics #2103
 - ♿️(frontend) improve language picker accessibility #2069
+- ♿️(frontend) add aria-hidden to decorative icons in dropdown menu #2093
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/frontend/apps/impress/src/components/dropdown-menu/DropdownMenu.tsx
@@ -275,7 +275,6 @@ export const DropdownMenu = ({
                     <Box
                       $theme="neutral"
                       $variation={isDisabled ? 'tertiary' : 'primary'}
-                      aria-hidden="true"
                     >
                       {option.icon}
                     </Box>

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
@@ -118,13 +118,13 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
   const options: DropdownMenuOption[] = [
     {
       label: t('Share'),
-      icon: <GroupSVG width={24} height={24} />,
+      icon: <GroupSVG width={24} height={24} aria-hidden="true" />,
       callback: modalShare.open,
       show: isSmallMobile,
     },
     {
       label: t('Export'),
-      icon: <DownloadSVG width={24} height={24} />,
+      icon: <DownloadSVG width={24} height={24} aria-hidden="true" />,
       callback: () => {
         setIsModalExportOpen(true);
       },
@@ -133,9 +133,9 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     {
       label: doc.is_favorite ? t('Unpin') : t('Pin'),
       icon: doc.is_favorite ? (
-        <KeepOffSVG width={24} height={24} />
+        <KeepOffSVG width={24} height={24} aria-hidden="true" />
       ) : (
-        <KeepSVG width={24} height={24} />
+        <KeepSVG width={24} height={24} aria-hidden="true" />
       ),
       callback: () => {
         if (doc.is_favorite) {
@@ -148,7 +148,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     },
     {
       label: t('Version history'),
-      icon: <HistorySVG width={24} height={24} />,
+      icon: <HistorySVG width={24} height={24} aria-hidden="true" />,
       disabled: !doc.abilities.versions_list,
       callback: () => {
         selectHistoryModal.open();
@@ -158,7 +158,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     },
     {
       label: t('Remove emoji'),
-      icon: <RemoveEmojiSVG width={24} height={24} />,
+      icon: <RemoveEmojiSVG width={24} height={24} aria-hidden="true" />,
       callback: () => {
         updateDocEmoji(doc.id, doc.title ?? '', '');
       },
@@ -167,7 +167,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     },
     {
       label: t('Add emoji'),
-      icon: <AddEmojiSVG width={24} height={24} />,
+      icon: <AddEmojiSVG width={24} height={24} aria-hidden="true" />,
       callback: () => {
         updateDocEmoji(doc.id, doc.title ?? '', '📄');
       },
@@ -176,12 +176,12 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     },
     {
       label: t('Copy link'),
-      icon: <AddLinkSVG width={24} height={24} />,
+      icon: <AddLinkSVG width={24} height={24} aria-hidden="true" />,
       callback: copyDocLink,
     },
     {
       label: t('Copy as {{format}}', { format: 'Markdown' }),
-      icon: <MarkdownCopySVG width={24} height={24} />,
+      icon: <MarkdownCopySVG width={24} height={24} aria-hidden="true" />,
       callback: () => {
         void copyCurrentEditorToClipboard('markdown');
       },
@@ -189,7 +189,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     },
     {
       label: t('Duplicate'),
-      icon: <ContentCopySVG width={24} height={24} />,
+      icon: <ContentCopySVG width={24} height={24} aria-hidden="true" />,
       disabled: !doc.abilities.duplicate,
       callback: () => {
         duplicateDoc({
@@ -202,7 +202,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     },
     {
       label: isChild ? t('Delete sub-document') : t('Delete document'),
-      icon: <DeleteSVG width={24} height={24} />,
+      icon: <DeleteSVG width={24} height={24} aria-hidden="true" />,
       disabled: !doc.abilities.destroy,
       callback: () => {
         setIsModalRemoveOpen(true);

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridActions.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridActions.tsx
@@ -72,9 +72,9 @@ export const DocsGridActions = ({ doc }: DocsGridActionsProps) => {
     {
       label: doc.is_favorite ? t('Unpin') : t('Pin'),
       icon: doc.is_favorite ? (
-        <KeepOffSVG width={24} height={24} />
+        <KeepOffSVG width={24} height={24} aria-hidden="true" />
       ) : (
-        <KeepSVG width={24} height={24} />
+        <KeepSVG width={24} height={24} aria-hidden="true" />
       ),
       callback: () => {
         if (doc.is_favorite) {
@@ -88,7 +88,7 @@ export const DocsGridActions = ({ doc }: DocsGridActionsProps) => {
     },
     {
       label: t('Share'),
-      icon: <GroupSVG width={24} height={24} />,
+      icon: <GroupSVG width={24} height={24} aria-hidden="true" />,
       callback: () => {
         shareModal.open();
       },
@@ -97,7 +97,7 @@ export const DocsGridActions = ({ doc }: DocsGridActionsProps) => {
     },
     {
       label: t('Move into a doc'),
-      icon: <DocMoveInSVG width={24} height={24} />,
+      icon: <DocMoveInSVG width={24} height={24} aria-hidden="true" />,
       callback: () => {
         importModal.open();
       },
@@ -106,7 +106,7 @@ export const DocsGridActions = ({ doc }: DocsGridActionsProps) => {
     },
     {
       label: t('Duplicate'),
-      icon: <ContentCopySVG width={24} height={24} />,
+      icon: <ContentCopySVG width={24} height={24} aria-hidden="true" />,
       disabled: !doc.abilities.duplicate,
       callback: () => {
         duplicateDoc({
@@ -119,7 +119,7 @@ export const DocsGridActions = ({ doc }: DocsGridActionsProps) => {
     },
     {
       label: t('Delete'),
-      icon: <DeleteSVG width={24} height={24} />,
+      icon: <DeleteSVG width={24} height={24} aria-hidden="true" />,
       callback: () => deleteModal.open(),
       disabled: !doc.abilities.destroy,
       testId: `docs-grid-actions-remove-${doc.id}`,


### PR DESCRIPTION
## Description

Add `aria-hidden` to decorative SVG icons in the dropdown menu so they are ignored by assistive technologies. ( NVDA / VO )

## Proposal

- [x] Add `aria-hidden` and `focusable="false"` to custom SVG icons rendered in `DropdownMenu` options
- [x] Extract icon rendering logic into a `customIconElement` constant for clarity