### PR TITLE
🐛(frontend) fix close panel when click on subdoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,8 @@ and this project adheres to
 
 ### Changed
 
-- 💫(frontend) fix the help button to the bottom in tree #2073
 - ♿️(frontend) improve version history list accessibility #2033
-- ♿️(frontend) fix more options menu feedback for screen readers #2071
 - ♿(frontend) focus skip link on headings and skip grid dropzone #1983
-- ♿️(frontend) fix search modal accessibility issues #2054
 - ♿️(frontend) add sr-only format to export download button #2088
 - ♿️(frontend) announce formatting shortcuts for screen readers #2070
 - ✨(frontend) add markdown copy icon for Copy as Markdown option #2096
@@ -20,9 +17,12 @@ and this project adheres to
 
 ### Fixed
 
+- ♿️(frontend) fix more options menu feedback for screen readers #2071
+- ♿️(frontend) fix more options menu feedback for screen readers #2071
+- 💫(frontend) fix the help button to the bottom in tree #2073
 - ♿️(frontend) fix aria-labels for table of contents #2065
 - 🐛(backend) allow using search endpoint without refresh token enabled #2097
-
+- 🐛(frontend) fix close panel when click on subdoc
 
 ## [v4.8.2] - 2026-03-19
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/left-panel.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/left-panel.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { createDoc, goToGridDoc, verifyDocName } from './utils-common';
+import { createRootSubPage } from './utils-sub-pages';
 
 test.describe('Left panel desktop', () => {
   test.beforeEach(async ({ page }) => {
@@ -119,6 +120,47 @@ test.describe('Left panel mobile', () => {
     await expect(newDocButton).toBeInViewport();
     await expect(languageButton).toBeInViewport();
     await expect(logoutButton).toBeInViewport();
+  });
+
+  test('checks panel closes when clicking on a subdoc', async ({
+    page,
+    browserName,
+  }) => {
+    const [docTitle] = await createDoc(
+      page,
+      'mobile-doc-test',
+      browserName,
+      1,
+      true,
+    );
+
+    const { name: docChild } = await createRootSubPage(
+      page,
+      browserName,
+      'mobile-doc-test-child',
+      true,
+    );
+
+    const { name: docChild2 } = await createRootSubPage(
+      page,
+      browserName,
+      'mobile-doc-test-child-2',
+      true,
+    );
+
+    const header = page.locator('header').first();
+    await header.getByLabel('Open the header menu').click();
+
+    await expect(page.getByTestId('left-panel-mobile')).toBeInViewport();
+
+    const docTree = page.getByTestId('doc-tree');
+    await expect(docTree.getByText(docTitle)).toBeVisible();
+    await expect(docTree.getByText(docChild)).toBeVisible();
+    await expect(docTree.getByText(docChild2)).toBeVisible();
+
+    await docTree.getByText(docChild).click();
+    await verifyDocName(page, docChild);
+    await expect(page.getByTestId('left-panel-mobile')).not.toBeInViewport();
   });
 
   test('checks resize handle is not present on mobile', async ({ page }) => {

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
@@ -1,3 +1,5 @@
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { createGlobalStyle, css } from 'styled-components';
 
@@ -23,11 +25,15 @@ const MobileLeftPanelStyle = createGlobalStyle`
 
 export const LeftPanel = () => {
   const { isDesktop } = useResponsiveStore();
-  const { t } = useTranslation();
+  if (isDesktop) {
+    return <LeftPanelDesktop />;
+  }
 
-  const { spacingsTokens } = useCunninghamTheme();
-  const { isPanelOpen, isPanelOpenMobile } = useLeftPanelStore();
-  const isPanelOpenState = isDesktop ? isPanelOpen : isPanelOpenMobile;
+  return <LeftPanelMobile />;
+};
+
+export const LeftPanelDesktop = () => {
+  const { t } = useTranslation();
   const { data: config } = useConfig();
   /**
    * The onboarding can be disable, so we need to check if it's enabled before displaying the help menu.
@@ -36,42 +42,51 @@ export const LeftPanel = () => {
    */
   const showHelpMenu = config?.theme_customization?.onboarding?.enabled;
 
-  if (isDesktop) {
-    return (
+  return (
+    <Box
+      data-testid="left-panel-desktop"
+      $css={css`
+        height: calc(100vh - ${HEADER_HEIGHT}px);
+        width: 100%;
+        overflow: hidden;
+        background-color: var(--c--contextuals--background--surface--primary);
+      `}
+      className="--docs--left-panel-desktop"
+      as="nav"
+      aria-label={t('Document sections')}
+    >
       <Box
-        data-testid="left-panel-desktop"
         $css={css`
-          height: calc(100vh - ${HEADER_HEIGHT}px);
-          width: 100%;
-          overflow: hidden;
-          background-color: var(--c--contextuals--background--surface--primary);
+          flex: 0 0 auto;
         `}
-        className="--docs--left-panel-desktop"
-        as="nav"
-        aria-label={t('Document sections')}
       >
-        <Box
-          $css={css`
-            flex: 0 0 auto;
-          `}
-        >
-          <LeftPanelHeader />
-        </Box>
-        <LeftPanelContent />
-        {showHelpMenu && (
-          <SeparatedSection showSeparator={false}>
-            <Box $padding={{ horizontal: 'sm' }} $justify="flex-start">
-              <HelpMenu />
-            </Box>
-          </SeparatedSection>
-        )}
+        <LeftPanelHeader />
       </Box>
-    );
-  }
+      <LeftPanelContent />
+      {showHelpMenu && (
+        <SeparatedSection showSeparator={false}>
+          <Box $padding={{ horizontal: 'sm' }} $justify="flex-start">
+            <HelpMenu />
+          </Box>
+        </SeparatedSection>
+      )}
+    </Box>
+  );
+};
+
+const LeftPanelMobile = () => {
+  const { t } = useTranslation();
+  const { spacingsTokens } = useCunninghamTheme();
+  const { closePanel, isPanelOpenMobile } = useLeftPanelStore();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    closePanel({ type: 'mobile' });
+  }, [pathname, closePanel]);
 
   return (
     <>
-      {isPanelOpenState && <MobileLeftPanelStyle />}
+      {isPanelOpenMobile && <MobileLeftPanelStyle />}
       <Box
         $hasTransition
         $height="100vh"
@@ -81,7 +96,7 @@ export const LeftPanel = () => {
           height: calc(100dvh - 52px);
           border-right: 1px solid var(--c--globals--colors--gray-200);
           position: fixed;
-          transform: translateX(${isPanelOpenState ? '0' : '-100dvw'});
+          transform: translateX(${isPanelOpenMobile ? '0' : '-100dvw'});
           background-color: var(--c--contextuals--background--surface--primary);
           overflow-y: auto;
           overflow-x: hidden;


### PR DESCRIPTION
## Purpose

Recent refacto of left panel components caused the close panel function to stop working when clicking on a subdoc when mobile.
This commit fixes that issue by ensuring that the close panel function is properly called when a subdoc is clicked.

## Demo bug

https://github.com/user-attachments/assets/ce7c3ed2-c432-4e2c-a649-324c13bd9896



