### PR TITLE
🔖(patch) release 4.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v4.8.3] - 2026-03-23
+
 ### Changed
 
 - ♿️(frontend) improve version history list accessibility #2033
@@ -1171,7 +1173,8 @@ and this project adheres to
 - ✨(frontend) Coming Soon page (#67)
 - 🚀 Impress, project to manage your documents easily and collaboratively.
 
-[unreleased]: https://github.com/suitenumerique/docs/compare/v4.8.2...main
+[unreleased]: https://github.com/suitenumerique/docs/compare/v4.8.3...main
+[v4.8.3]: https://github.com/suitenumerique/docs/releases/v4.8.3
 [v4.8.2]: https://github.com/suitenumerique/docs/releases/v4.8.2
 [v4.8.1]: https://github.com/suitenumerique/docs/releases/v4.8.1
 [v4.8.0]: https://github.com/suitenumerique/docs/releases/v4.8.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impress"
-version = "4.8.2"
+version = "4.8.3"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-impress",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "private": true,
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",

--- a/src/frontend/packages/eslint-plugin-docs/package.json
+++ b/src/frontend/packages/eslint-plugin-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-docs",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -1,10 +1,10 @@
 environments:
   dev:
     values:
-      - version: 4.8.2
+      - version: 4.8.3
   feature:
     values:
-      - version: 4.8.2
+      - version: 4.8.3
         feature: ci
         domain: example.com
         imageTag: demo

--- a/src/helm/impress/Chart.yaml
+++ b/src/helm/impress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: docs
-version: 4.8.2
+version: 4.8.3
 appVersion: latest

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Changed

- ♿️(frontend) improve version history list accessibility #2033
- ♿(frontend) focus skip link on headings and skip grid dropzone #1983
- ♿️(frontend) add sr-only format to export download button #2088
- ♿️(frontend) announce formatting shortcuts for screen readers #2070
- ✨(frontend) add markdown copy icon for Copy as Markdown option #2096
- ♻️(backend) skip saving in database a document when payload is empty #2062
- ♻️(frontend) refacto Version modal to fit with the design system #2091

### Fixed

- ♿️(frontend) fix more options menu feedback for screen readers #2071
- ♿️(frontend) fix more options menu feedback for screen readers #2071
- 💫(frontend) fix the help button to the bottom in tree #2073
- ♿️(frontend) fix aria-labels for table of contents #2065
- 🐛(backend) allow using search endpoint without refresh token enabled #2097
- 🐛(frontend) fix close panel when click on subdoc #2094
- 🐛(frontend) fix leftpanel button in doc version #9238
- 🐛(y-provider) fix loop when no cookies #2101
