### PR TITLE
🐛(y-provider) fix loop when no cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 - 🐛(backend) allow using search endpoint without refresh token enabled #2097
 - 🐛(frontend) fix close panel when click on subdoc #2094
 - 🐛(frontend) fix leftpanel button in doc version #9238
+- 🐛(y-provider) fix loop when no cookies #2101
 
 ## [v4.8.2] - 2026-03-19
 

--- a/src/frontend/apps/impress/src/features/docs/doc-management/stores/useProviderStore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/stores/useProviderStore.tsx
@@ -48,6 +48,18 @@ export const useProviderStore = create<UseCollaborationStore>((set, get) => ({
       onDisconnect(data) {
         // Attempt to reconnect if the disconnection was clean (initiated by the client or server)
         if ((data.event as ExtendedCloseEvent).wasClean) {
+          if (data.event.reason === 'No cookies' && data.event.code === 4001) {
+            console.error(
+              'Disconnection due to missing cookies. Not attempting to reconnect.',
+            );
+            void provider.disconnect();
+            set({
+              isReady: true,
+              isConnected: false,
+            });
+            return;
+          }
+
           void provider.connect();
         }
       },


### PR DESCRIPTION
## Purpose

We observed a huge amount of logs sometimes in the y-provider server logs, all related to the same error: "No cookies".
When this happens, the client keeps trying to reconnect, and the server keeps logging the error, creating a loop.
We stop the loop by checking if the error is a "No cookies" error, and if so, we don't try to reconnect.

