### PR TITLE
♿️(frontend) replace ARIA grid pattern with list in docs grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♿️(frontend) replace ARIA grid pattern with list in docs grid #2116
+
 ## [v4.8.3] - 2026-03-23
 
 ### Changed

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGrid.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGrid.tsx
@@ -140,36 +140,30 @@ export const DocsGrid = ({
             $overflow="auto"
             $padding={{ vertical: 'sm', horizontal: isDesktop ? 'md' : 'xs' }}
           >
-            <Box role="grid" aria-label={t('Documents grid')}>
-              <Box role="rowgroup">
-                <Box
-                  $direction="row"
-                  $padding={{ horizontal: 'xs' }}
-                  $gap="10px"
-                  data-testid="docs-grid-header"
-                  role="row"
-                >
-                  <Box $flex={flexLeft} $padding="3xs" role="columnheader">
-                    <Text $size="xs" $variation="secondary" $weight="500">
-                      {t('Name')}
+            <Box aria-label={t('Documents grid')}>
+              <Box
+                $direction="row"
+                $padding={{ horizontal: 'xs' }}
+                $gap="10px"
+                data-testid="docs-grid-header"
+                aria-hidden="true"
+              >
+                <Box $flex={flexLeft} $padding="3xs">
+                  <Text $size="xs" $variation="secondary" $weight="500">
+                    {t('Name')}
+                  </Text>
+                </Box>
+                {isDesktop && (
+                  <Box $flex={flexRight} $padding={{ vertical: '3xs' }}>
+                    <Text $size="xs" $weight="500" $variation="secondary">
+                      {DocDefaultFilter.TRASHBIN === target
+                        ? t('Days remaining')
+                        : t('Updated at')}
                     </Text>
                   </Box>
-                  {isDesktop && (
-                    <Box
-                      $flex={flexRight}
-                      $padding={{ vertical: '3xs' }}
-                      role="columnheader"
-                    >
-                      <Text $size="xs" $weight="500" $variation="secondary">
-                        {DocDefaultFilter.TRASHBIN === target
-                          ? t('Days remaining')
-                          : t('Updated at')}
-                      </Text>
-                    </Box>
-                  )}
-                </Box>
+                )}
               </Box>
-              <Box role="rowgroup">
+              <Box role="list">
                 <DocGridContentList docs={docs} />
               </Box>
             </Box>

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
@@ -1,6 +1,5 @@
 import { Tooltip } from '@gouvfr-lasuite/cunningham-react';
 import { useSearchParams } from 'next/navigation';
-import { KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
@@ -33,20 +32,13 @@ export const DocsGridItem = ({ doc, dragMode = false }: DocsGridItemProps) => {
   const { flexLeft, flexRight } = useResponsiveDocGrid();
   const { spacingsTokens } = useCunninghamTheme();
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      (e.target as HTMLAnchorElement).click();
-    }
-  };
-
   return (
     <>
       <Box
         $direction="row"
         $width="100%"
         $align="center"
-        role="row"
+        role="listitem"
         $gap="20px"
         $padding={{ vertical: '4xs', horizontal: isDesktop ? 'base' : 'xs' }}
         $css={css`
@@ -65,7 +57,6 @@ export const DocsGridItem = ({ doc, dragMode = false }: DocsGridItemProps) => {
       >
         <Box
           $flex={flexLeft}
-          role="gridcell"
           $css={css`
             align-items: center;
             min-width: 0;
@@ -78,7 +69,6 @@ export const DocsGridItem = ({ doc, dragMode = false }: DocsGridItemProps) => {
               min-width: 0;
             `}
             href={`/docs/${doc.id}`}
-            onKeyDown={handleKeyDown}
           >
             <DocsGridItemTitle doc={doc} withTooltip={!dragMode} />
           </StyledLink>
@@ -90,7 +80,6 @@ export const DocsGridItem = ({ doc, dragMode = false }: DocsGridItemProps) => {
           $align="center"
           $justify={isDesktop ? 'space-between' : 'flex-end'}
           $gap="32px"
-          role="gridcell"
         >
           <StyledLink href={`/docs/${doc.id}`} tabIndex={-1}>
             <DocsGridItemDate

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/Draggable.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/Draggable.tsx
@@ -19,6 +19,7 @@ export const Draggable = <T,>(props: PropsWithChildren<DraggableProps<T>>) => {
       ref={setNodeRef}
       {...listeners}
       {...attributes}
+      tabIndex={-1}
       data-testid={`draggable-doc-${props.id}`}
       className="--docs--grid-draggable"
       role="none"


### PR DESCRIPTION
## Purpose

The document grid used `role="grid"` with `role="row"`, `role="gridcell"`, `role="rowgroup"`, and `role="columnheader"`. This ARIA grid pattern requires full keyboard navigation with arrow keys which it's not implemented and demand to much complexity, . With role="grid", some screen readers switch to a mode where arrow keys are handled by the page; since the page did not implement grid navigation, that interaction did not work as expected.

## Proposal

- [x] Replace `role="grid"` / `role="row"` / `role="gridcell"` / `role="columnheader"` / `role="rowgroup"` with `role="list"` / `role="listitem"`, matching the actual semantics (a list of documents, not a data grid)
- [x] Mark visual column headers (`Name`, `Updated at`) as `aria-hidden="true"` since they are no longer part of the list semantics
- [x] Remove the custom `handleKeyDown` (Enter/Space) on document links, native `<a>` elements handle this already
- [x] Override `tabIndex` on the DnD `Draggable` wrapper to `-1` to prevent focus trapping before document links