### PR TITLE
♿(frontend) use aria-haspopup menu on DropButton triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♿(frontend) use aria-haspopup menu on DropButton triggers #2126
+
 ## [v4.8.4] - 2026-03-25
 
 ### Added

--- a/src/frontend/apps/impress/src/components/DropButton.tsx
+++ b/src/frontend/apps/impress/src/components/DropButton.tsx
@@ -93,7 +93,7 @@ export const DropButton = ({
           onOpenChangeHandler(true);
         }}
         aria-label={label}
-        aria-haspopup="true"
+        aria-haspopup="menu"
         aria-expanded={isLocalOpen}
         data-testid={testId}
         $css={css`

--- a/src/frontend/apps/impress/src/components/dropdown-menu/__tests__/DropdownMenu.spec.tsx
+++ b/src/frontend/apps/impress/src/components/dropdown-menu/__tests__/DropdownMenu.spec.tsx
@@ -94,7 +94,7 @@ describe('<DropdownMenu />', () => {
     );
 
     const trigger = screen.getByRole('button', { name: 'Select language' });
-    expect(trigger).toHaveAttribute('aria-haspopup', 'true');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
 
     await userEvent.click(trigger);


### PR DESCRIPTION
## Purpose

Fix incorrect VoiceOver announcements on menu triggers that use `DropButton` (document actions, language selector, and other dropdowns). The deprecated boolean `aria-haspopup="true"` led VoiceOver to read **“rejected”** instead of the expanded/collapsed menu state

## Proposal

- [x] Set `aria-haspopup="menu"` on the `DropButton` trigger (matches the `role="menu"` content).
- [x] Update `DropdownMenu` unit test expectations for `aria-haspopup`.
