### PR TITLE
🔧(y-provider) increase Node.js memory limit

### DIFF
--- a/src/frontend/servers/y-provider/Dockerfile
+++ b/src/frontend/servers/y-provider/Dockerfile
@@ -51,6 +51,8 @@ RUN NODE_ENV=production yarn install --frozen-lockfile
 # Remove npm, contains CVE related to cross-spawn and we don't use it.
 RUN rm -rf /usr/local/bin/npm /usr/local/lib/node_modules/npm
 
+ENV NODE_OPTIONS="--max-old-space-size=2048"
+
 # Un-privileged user running the application
 ARG DOCKER_USER
 USER ${DOCKER_USER}

--- a/src/helm/env.d/feature/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/feature/values.impress.yaml.gotmpl
@@ -145,6 +145,7 @@ yProvider:
     COLLABORATION_SERVER_ORIGIN: https://{{ .Values.feature }}-docs.{{ .Values.domain }}
     COLLABORATION_SERVER_SECRET: my-secret
     Y_PROVIDER_API_KEY: my-secret
+    NODE_OPTIONS: "--max-old-space-size=1024"
 
 docSpec:
   enabled: true


### PR DESCRIPTION


## Purpose

By default, Node.js has a memory limit of
around 512MB, which can lead to out-of-memory
errors when processing large documents.
This commit increases the memory limit to
2GB for the y-provider server, allowing
it to handle larger documents without crashing.


