### PR TITLE
frontend: fix TypeError in document editor

### DIFF
--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -52,7 +52,7 @@ import {
 const AIMenu = BlockNoteAI?.AIMenu;
 const AIMenuController = BlockNoteAI?.AIMenuController;
 const useAI = BlockNoteAI?.useAI;
-const localesBNAI = BlockNoteAI?.localesAI;
+const localesBNAI = BlockNoteAI?.localesAI || {};
 import {
   InterlinkingLinkInlineContent,
   InterlinkingSearchInlineContent,


### PR DESCRIPTION

## Purpose

I get

> TypeError: Cannot use 'in' operator to search for 'de' in undefined

when building MIT-only since `localesBNAI` is undefined then.

This is fixed by making `localesBNAI` an empty object if undefined.

## Proposal

- [ ] item 1...
- [ ] item 2...

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)