### PR TITLE
🐛(backend) update restore ability for inherited deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
 - 🐛(backend) prevent owner from leaving a soft-deleted document
 - 🐛(frontend) fix removed item in the tree #2420
 - 🐛(frontend) fix service worker causing reload on tab focus #2454
+- 🐛(backend) update restore ability for inherited deletion #2148
 
 ## [v5.3.0] - 2026-06-19
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1404,7 +1404,7 @@ class Document(MP_Node, BaseModel):
             "leave": can_leave,
             "move": is_owner_or_admin and not is_deleted,
             "partial_update": can_update,
-            "restore": is_owner,
+            "restore": is_owner and bool(self.deleted_at),
             "retrieve": retrieve,
             "media_auth": can_get,
             "link_select_options": link_select_options,

--- a/src/backend/core/tests/documents/test_api_documents_restore.py
+++ b/src/backend/core/tests/documents/test_api_documents_restore.py
@@ -137,8 +137,10 @@ def test_api_documents_restore_authenticated_owner_not_deleted():
 
     response = client.post(f"/api/v1.0/documents/{document.id!s}/restore/")
 
-    assert response.status_code == 400
-    assert response.json() == {"detail": "This document is not deleted."}
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "You do not have permission to perform this action."
+    }
 
     document.refresh_from_db()
     assert document.deleted_at is None

--- a/src/backend/core/tests/documents/test_api_documents_retrieve.py
+++ b/src/backend/core/tests/documents/test_api_documents_retrieve.py
@@ -536,7 +536,7 @@ def test_api_documents_retrieve_authenticated_related_parent():
             "media_check": True,
             "move": access.role in ["administrator", "owner"],
             "partial_update": access.role not in ["reader", "commenter"],
-            "restore": access.role == "owner",
+            "restore": False,
             "retrieve": True,
             "search": True,
             "tree": True,

--- a/src/backend/core/tests/test_models_documents.py
+++ b/src/backend/core/tests/test_models_documents.py
@@ -458,7 +458,7 @@ def test_models_documents_get_abilities_owner(django_assert_num_queries):
         "media_check": True,
         "move": True,
         "partial_update": True,
-        "restore": True,
+        "restore": False,
         "retrieve": True,
         "tree": True,
         "update": True,
@@ -905,6 +905,22 @@ def test_models_documents_get_abilities_children_destroy(  # noqa: PLR0913
 
     abilities = document.get_abilities(user)
     assert abilities["destroy"] is can_destroy
+
+
+@pytest.mark.parametrize("parent_deleted", [False, True])
+def test_models_documents_get_abilities_owner_ancestor_deleted(parent_deleted):
+    """Test restore a child should not be enabled when a parent is deleted."""
+    user = factories.UserFactory()
+    parent = factories.DocumentFactory(users=[(user, "owner")])
+    document = factories.DocumentFactory(parent=parent)
+
+    if parent_deleted:
+        parent.soft_delete()
+        document.refresh_from_db()
+
+    abilities = document.get_abilities(user)
+
+    assert abilities["restore"] is False
 
 
 @override_settings(AI_ALLOW_REACH_FROM="public")

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertRestore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertRestore.tsx
@@ -72,26 +72,28 @@ export const AlertRestore = ({ doc }: { doc: Doc }) => {
         />
         {t('Document deleted')}
       </Box>
-      <Button
-        onClick={() =>
-          restoreDoc({
-            docId: doc.id,
-          })
-        }
-        color="error"
-        variant="tertiary"
-        size="nano"
-        icon={
-          <Icon
-            iconName="undo"
-            $withThemeInherited
-            $size="18px"
-            variant="symbols-outlined"
-          />
-        }
-      >
-        Restore
-      </Button>
+      {doc.abilities.restore && (
+        <Button
+          onClick={() =>
+            restoreDoc({
+              docId: doc.id,
+            })
+          }
+          color="error"
+          variant="tertiary"
+          size="nano"
+          icon={
+            <Icon
+              iconName="undo"
+              $withThemeInherited
+              $size="18px"
+              variant="symbols-outlined"
+            />
+          }
+        >
+          Restore
+        </Button>
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
## Purpose

Updated the restore ability so that only directly deleted documents can be restored. This prevents the restore action from being exposed for child documents whose parent is deleted. This PR addresses #2127.

## Proposal

- Hid restore button for child doc with soft-deleted parent doc.

## Attachments

Restore button before:
<img width="1912" height="999" alt="restore-button-before" src="https://github.com/user-attachments/assets/052c7a6b-06c1-4639-940e-9b732d3c3f7d" />

After: 
<img width="1918" height="1001" alt="restore-button-after" src="https://github.com/user-attachments/assets/9f9c0afe-e19e-46bb-a5d6-3b5ec18b2d07" />


Please ensure the following items are checked before submitting your pull request:
- [X] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [X] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [X] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [X] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [X] My commit messages follow the required format: `<gitmoji>(type) title description`
- [X] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [X] I have added corresponding tests for new features or bug fixes (if applicable)