### PR TITLE
🐛(backend) fix race condition in reconciliation requests CSV import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ ctrl/command/middle-mouse click #2170
 - ⚡️(frontend) add jitter to WS reconnection #2162
 - 🐛(frontend) fix tree pagination #2145
 - 🐛(nginx) add page reconciliation on nginx #2154
-
+- 🐛(backend) fix race condition in reconciliation requests CSV import #2153
 
 ## [v4.8.4] - 2026-03-25
 

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -1,7 +1,10 @@
 """Admin classes and registrations for core app."""
 
+from functools import partial
+
 from django.contrib import admin, messages
 from django.contrib.auth import admin as auth_admin
+from django.db import transaction
 from django.shortcuts import redirect
 from django.utils.translation import gettext_lazy as _
 
@@ -108,7 +111,9 @@ class UserReconciliationCsvImportAdmin(admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
         if not change:
-            user_reconciliation_csv_import_job.delay(obj.pk)
+            transaction.on_commit(
+                partial(user_reconciliation_csv_import_job.delay, obj.pk)
+            )
             messages.success(request, _("Import job created and queued."))
         return redirect("..")
 

--- a/src/backend/core/tasks/user_reconciliation.py
+++ b/src/backend/core/tasks/user_reconciliation.py
@@ -1,6 +1,7 @@
 """Processing tasks for user reconciliation CSV imports."""
 
 import csv
+import logging
 import traceback
 import uuid
 
@@ -13,6 +14,8 @@ from botocore.exceptions import ClientError
 from core.models import UserReconciliation, UserReconciliationCsvImport
 
 from impress.celery_app import app
+
+logger = logging.getLogger(__name__)
 
 
 def _process_row(row, job, counters):
@@ -89,8 +92,12 @@ def user_reconciliation_csv_import_job(job_id):
     Rows with errors are logged in the job logs and skipped, but do not cause
     the entire job to fail or prevent the next rows from being processed.
     """
-    # Imports the CSV file, breaks it into UserReconciliation items
-    job = UserReconciliationCsvImport.objects.get(id=job_id)
+    try:
+        job = UserReconciliationCsvImport.objects.get(id=job_id)
+    except UserReconciliationCsvImport.DoesNotExist:
+        logger.warning("CSV import job %s no longer exists; skipping.", job_id)
+        return
+
     job.status = "running"
     job.save()
 


### PR DESCRIPTION
## Purpose
The call to the background task is now wrapped in a on_commit to ensure that it isn't called before the save is finished, in order to avoid race condition issues.

## Proposal
- [x] Wrapped the call to `user_reconciliation_csv_import_job` in a `transaction.on_commit` on `UserReconciliationCsvImportAdmin.save_model()`

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)