### PR TITLE
🥚(e2e) fix e2e easter egg

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
@@ -179,7 +179,8 @@ test.describe('Doc Header', () => {
     await optionMenu.click();
     await expect(removeEmojiMenuItem).toBeHidden();
     await addEmojiMenuItem.click();
-    await expect(emojiPicker).toHaveText('📄');
+    // The 1 April the emoji is a fish
+    await expect(emojiPicker).toHaveText(/📄|🐟/);
 
     // Change emoji
     await emojiPicker.click({


### PR DESCRIPTION
## Purpose

The test e2e were not working on April 1st because of the easter egg that changes the document emoji to a fish.

