### PR TITLE
🚸(frontend) allow opening "@page" links with ctrl/command/middle-mouse click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- 🚸(frontend) allow opening "@page" links with ctrl/command/middle-mouse click
+
 ## [v4.8.5] - 2026-04-03
 
 ### Added

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/InterlinkingLinkInlineContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/InterlinkingLinkInlineContent.tsx
@@ -124,10 +124,27 @@ export const LinkSelected = ({
 
   const { emoji, titleWithoutEmoji } = getEmojiAndTitle(title);
   const router = useRouter();
+  const href = `/docs/${docId}/`;
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
-    void router.push(`/docs/${docId}/`);
+
+    // If ctrl or command is pressed, it opens a new tab. If shift is pressed, it opens a new window
+    if (e.metaKey || e.ctrlKey || e.shiftKey) {
+      window.open(href, '_blank');
+      return;
+    }
+    void router.push(href);
+  };
+
+  // This triggers on middle-mouse click
+  const handleAuxClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.button !== 1) {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    window.open(href, '_blank');
   };
 
   return (
@@ -135,6 +152,7 @@ export const LinkSelected = ({
       as="span"
       className="--docs--interlinking-link-inline-content"
       onClick={handleClick}
+      onAuxClick={handleAuxClick}
       draggable="false"
       $css={css`
         display: inline;


### PR DESCRIPTION
Hey there Docs team :wave: 

## Purpose

Make "interlinking" elements (links to other pages, made through the `@` shortcut) usable with ctrl/command/shift+click and mousewheel click to open the link in a new tab or new window.

## Proposal

Just add additional event listeners on the existing homemade `span`. An obviously better solution would have been to find a way to make actual `<a>` work, but I have to confess I didn't have the motivation to dig deeper. These small changes already make for a better UX I'd say.

Things to know:

- :warning: I didn't manually test this on macOS right now, I have a little trouble setting up necessary stuff on my mac. I tested on Windows Edge/Windows+Linux Chrome/Windows+Linux Firefox/Android Chrome. If someone's willing to verify my mistakes on macOS/iOS for a few minutes just to be sure, it's greatly appreciated :innocent:
- I didn't add any tests as I didn't find any existing ones for the interlinking component. But I'm not familiar with the codebase. Let me know if tests are necessary.

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)