### PR TITLE
🐛(backend) Fix unreachable exception handler for URLValidator

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -2135,7 +2135,7 @@ class DocumentViewSet(
         url_validator = URLValidator(schemes=["http", "https"])
         try:
             url_validator(url)
-        except drf.exceptions.ValidationError as e:
+        except ValidationError as e:
             return drf.response.Response(
                 {"detail": str(e)},
                 status=drf.status.HTTP_400_BAD_REQUEST,

--- a/src/backend/core/tests/documents/test_api_documents_cors_proxy.py
+++ b/src/backend/core/tests/documents/test_api_documents_cors_proxy.py
@@ -255,7 +255,7 @@ def test_api_docs_cors_proxy_invalid_url(url_to_fetch):
         f"/api/v1.0/documents/{document.id!s}/cors-proxy/?url={url_to_fetch}"
     )
     assert response.status_code == 400
-    assert response.json() == ["Enter a valid URL."]
+    assert response.json() == {"detail": "['Enter a valid URL.']"}
 
 
 @unittest.mock.patch("core.api.viewsets.socket.getaddrinfo")


### PR DESCRIPTION

## Purpose

The exception block was never being executed because URLValidator raises django.core.exceptions.ValidationError, not drf.exceptions.ValidationError, so the except block was dead code.

## Proposal
Replace the `drf.exceptions.ValidationError` with Django 'ValidationError'