### PR TITLE
♿️(frontend) make doc search result labels uniquely identifiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,15 @@ and this project adheres to
 
 ### Changed
 
- - ♿️(frontend) structure correctly 5xx error alerts #2128
+- ♿️(frontend) structure correctly 5xx error alerts #2128
+- ♿️(frontend) make doc search result labels uniquely identifiable #2212
 
 ## [v4.8.6] - 2026-04-08
 
 ### Added
 
-- 🚸(frontend) allow opening "@page" links with 
-ctrl/command/middle-mouse click #2170
+- 🚸(frontend) allow opening "@page" links with
+  ctrl/command/middle-mouse click #2170
 - ✅ E2E - Any instance friendly #2142
 
 ### Changed

--- a/src/frontend/apps/impress/src/features/docs/doc-management/components/SimpleDocItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/components/SimpleDocItem.tsx
@@ -38,7 +38,15 @@ export const SimpleDocItem = ({
   const { isDesktop } = useResponsiveStore();
   const { untitledDocument } = useTrans();
   const { isChild } = useDocUtils(doc);
-  const { relativeDate } = useDate();
+  const { relativeDate, formatDate } = useDate();
+  const docTitle = doc.title || untitledDocument;
+  const docRelativeUpdate = relativeDate(doc.updated_at);
+  const itemAriaLabel = `${t('Open document {{title}}', { title: docTitle })}. ${t(
+    'Last update: {{update}}',
+    {
+      update: formatDate(doc.updated_at),
+    },
+  )}`;
 
   return (
     <Box
@@ -47,8 +55,7 @@ export const SimpleDocItem = ({
       $overflow="auto"
       $width="100%"
       className="--docs--simple-doc-item"
-      role="presentation"
-      aria-label={`${t('Open document {{title}}', { title: doc.title || untitledDocument })}`}
+      aria-label={itemAriaLabel}
     >
       <Box
         $direction="row"
@@ -90,7 +97,7 @@ export const SimpleDocItem = ({
           $css={ItemTextCss}
           data-testid="doc-title"
         >
-          {doc.title || untitledDocument}
+          {docTitle}
         </Text>
         {(!isDesktop || showAccesses) && (
           <Box
@@ -101,7 +108,7 @@ export const SimpleDocItem = ({
             aria-hidden="true"
           >
             <Text $size="xs" $variation="tertiary">
-              {relativeDate(doc.updated_at)}
+              {docRelativeUpdate}
             </Text>
           </Box>
         )}


### PR DESCRIPTION
## Purpose

Fix an accessibility issue in document search results where multiple items with the same title were announced with identical labels by screen readers.

## Proposal

- [x] Include each document's relative last-update date in `SimpleDocItem` accessible label.
