### PR TITLE
 ♻️(frontend) centralize allowed conversion formats in ContentTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ and this project adheres to
 - 🔥(backend) remove deprecated descendants endpoint #2243
 - 🔥(backend) remove content in document responses #2171
 
+### Changed
+
+- ♻️(frontend) centralize allowed conversion formats in ContentTypes #2215
+
 ## [v4.8.6] - 2026-04-08
 
 ### Added

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/api/useImportDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/api/useImportDoc.tsx
@@ -33,7 +33,7 @@ export const ContentTypes: {
   },
   Markdown: {
     mime: 'text/markdown',
-    extensions: ['.md', '.markdown'],
+    extensions: ['.md'],
   },
   OctetStream: {
     mime: 'application/octet-stream',

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/api/useImportDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/api/useImportDoc.tsx
@@ -17,11 +17,29 @@ import {
 } from '@/api';
 import { Doc, DocsResponse, KEY_LIST_DOC } from '@/docs/doc-management';
 
-export enum ContentTypes {
-  Docx = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  Markdown = 'text/markdown',
-  OctetStream = 'application/octet-stream',
+interface ContentType {
+  mime: string;
+  extensions: string[];
 }
+
+export const ContentTypes: {
+  Docx: ContentType;
+  Markdown: ContentType;
+  OctetStream: ContentType;
+} = {
+  Docx: {
+    mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    extensions: ['.docx'],
+  },
+  Markdown: {
+    mime: 'text/markdown',
+    extensions: ['.md', '.markdown'],
+  },
+  OctetStream: {
+    mime: 'application/octet-stream',
+    extensions: [],
+  },
+};
 
 export const importDoc = async ([file, mimeType]: [
   File,

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/hooks/useImport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/hooks/useImport.tsx
@@ -3,7 +3,7 @@ import {
   useToastProvider,
 } from '@gouvfr-lasuite/cunningham-react';
 import { t } from 'i18next';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useDropzone } from 'react-dropzone';
 
 import { useConfig } from '@/core';
@@ -61,12 +61,37 @@ export const useImport = ({ onDragOver }: UseImportProps) => {
     );
   }, [config?.CONVERSION_FILE_EXTENSIONS_ALLOWED]);
 
+  const toastInvalidFileType = useCallback(
+    (fileName: string) => {
+      const allowedExtensions = Object.values(ACCEPT).flat().join(', ');
+      toast(
+        t(
+          allowedExtensions
+            ? `The document "{{documentName}}" import has failed (only {{allowedExtensions}} files are allowed)`
+            : `The document "{{documentName}}" import has failed`,
+          {
+            documentName: fileName,
+            allowedExtensions,
+          },
+        ),
+        VariantType.ERROR,
+      );
+    },
+    [ACCEPT, toast],
+  );
+
   const { getRootProps, getInputProps, open } = useDropzone({
     accept: ACCEPT,
     maxSize: MAX_FILE_SIZE.bytes,
     onDrop(acceptedFiles) {
       onDragOver(false);
+      const allowedExtensions = Object.values(ACCEPT).flat();
       for (const file of acceptedFiles) {
+        const ext = `.${file.name.split('.').pop()?.toLowerCase()}`;
+        if (!allowedExtensions.includes(ext)) {
+          toastInvalidFileType(file.name);
+          continue;
+        }
         importDoc([file, file.type]);
       }
     },
@@ -94,20 +119,7 @@ export const useImport = ({ onDragOver }: UseImportProps) => {
             VariantType.ERROR,
           );
         } else {
-          const allowedExtensions = Object.values(ACCEPT).flat().join(', ');
-
-          toast(
-            t(
-              allowedExtensions
-                ? `The document "{{documentName}}" import has failed (only {{allowedExtensions}} files are allowed)`
-                : `The document "{{documentName}}" import has failed`,
-              {
-                documentName: rejection.file.name,
-                allowedExtensions,
-              },
-            ),
-            VariantType.ERROR,
-          );
+          toastInvalidFileType(rejection.file.name);
         }
       });
     },

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/hooks/useImport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/hooks/useImport.tsx
@@ -14,6 +14,10 @@ interface UseImportProps {
   onDragOver: (isDragOver: boolean) => void;
 }
 
+interface AcceptedMap {
+  [mime: string]: string[];
+}
+
 export const useImport = ({ onDragOver }: UseImportProps) => {
   const { toast } = useToastProvider();
   const { data: config } = useConfig();
@@ -36,31 +40,25 @@ export const useImport = ({ onDragOver }: UseImportProps) => {
     };
   }, [config?.CONVERSION_FILE_MAX_SIZE]);
 
-  const ACCEPT = useMemo(() => {
-    const extensions = config?.CONVERSION_FILE_EXTENSIONS_ALLOWED;
-    const accept: { [key: string]: string[] } = {};
+  const ACCEPT = useMemo((): AcceptedMap => {
+    const allowedExtensions = config?.CONVERSION_FILE_EXTENSIONS_ALLOWED?.map(
+      (ext: string) => ext.toLowerCase(),
+    ) ?? ['.docx', '.md'];
 
-    if (extensions && extensions.length > 0) {
-      extensions.forEach((ext) => {
-        switch (ext.toLowerCase()) {
-          case '.docx':
-            accept[ContentTypes.Docx] = ['.docx'];
-            break;
-          case '.md':
-          case '.markdown':
-            accept[ContentTypes.Markdown] = ['.md'];
-            break;
-          default:
-            break;
+    return Object.values(ContentTypes).reduce(
+      (acc: AcceptedMap, contentType) => {
+        const matchedExtensions = contentType.extensions.filter((ext: string) =>
+          allowedExtensions.includes(ext),
+        );
+
+        if (matchedExtensions.length > 0) {
+          acc[contentType.mime] = matchedExtensions;
         }
-      });
-    } else {
-      // Default to docx and md if no configuration is provided
-      accept[ContentTypes.Docx] = ['.docx'];
-      accept[ContentTypes.Markdown] = ['.md'];
-    }
 
-    return accept;
+        return acc;
+      },
+      {},
+    );
   }, [config?.CONVERSION_FILE_EXTENSIONS_ALLOWED]);
 
   const { getRootProps, getInputProps, open } = useDropzone({
@@ -96,11 +94,16 @@ export const useImport = ({ onDragOver }: UseImportProps) => {
             VariantType.ERROR,
           );
         } else {
+          const allowedExtensions = Object.values(ACCEPT).flat().join(', ');
+
           toast(
             t(
-              `The document "{{documentName}}" import has failed (only .docx and .md files are allowed)`,
+              allowedExtensions
+                ? `The document "{{documentName}}" import has failed (only {{allowedExtensions}} files are allowed)`
+                : `The document "{{documentName}}" import has failed`,
               {
                 documentName: rejection.file.name,
+                allowedExtensions,
               },
             ),
             VariantType.ERROR,


### PR DESCRIPTION
## Purpose / Proposal

To centralize configuration surrounding acceptable formats to be converted and imported into La Suite Docs. This PR will be followed up by others to further centralize configuration.

## External contributions

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added corresponding tests for new features or bug fixes (if applicable)

### CI requirements

* [x] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

I have used AI only for the description of this pull request and the commit message of my commit(s) and applying PR feedback.

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer