### PR TITLE
🐛(backend) Forbid restoring a non-deleted document 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to
 - 🛂(frontend) fix cannot manage member on small screen #2226
 - 🐛(backend) load jwks url when OIDC_RS_PRIVATE_KEY_STR is set
 - 🐛(backend) Prevent moving document to its own descendant or self #2208
+- 🐛(backend) return 400 when restoring a non-deleted document #2225
 
 ### Removed
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -996,7 +996,10 @@ class DocumentViewSet(
         Restore a soft-deleted document if it was deleted less than x days ago.
         """
         document = self.get_object()
-        document.restore()
+        try:
+            document.restore()
+        except RuntimeError as err:
+            raise drf.exceptions.ValidationError({"detail": str(err)}) from err
 
         return drf_response.Response(
             {"detail": "Document has been successfully restored."},

--- a/src/backend/core/tests/documents/test_api_documents_restore.py
+++ b/src/backend/core/tests/documents/test_api_documents_restore.py
@@ -124,3 +124,22 @@ def test_api_documents_restore_authenticated_owner_expired():
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Not found."}
+
+
+def test_api_documents_restore_authenticated_owner_not_deleted():
+    """Restoring a document that is not deleted should return a 400 error."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    document = factories.DocumentFactory()
+    factories.UserDocumentAccessFactory(document=document, user=user, role="owner")
+
+    response = client.post(f"/api/v1.0/documents/{document.id!s}/restore/")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "This document is not deleted."}
+
+    document.refresh_from_db()
+    assert document.deleted_at is None
+    assert document.ancestors_deleted_at is None


### PR DESCRIPTION
## Purpose
When attempting to restore a non-deleted document, the server would crash with a 500 Internal Server Error.

## Proposal
Handling the exception and returning a 400 Bad Request instead of a 500 Internal Server Error.
### Before
<img width="1095" height="354" alt="Screenshot 2026-04-16 at 23 51 26" src="https://github.com/user-attachments/assets/d00c6195-7135-4e4b-85f5-ea959406db28" />
### After
<img width="1053" height="491" alt="Screenshot 2026-04-16 at 23 48 13" src="https://github.com/user-attachments/assets/f0767c58-4114-4e59-835c-1e0706053dca" />
