### PR TITLE
🔧(docker) run django app with uvicorn in dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,15 @@ ENV DB_HOST=postgresql \
   DB_PORT=5432
 
 # Run django development server
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD [\
+  "uvicorn",\
+  "--app-dir=/app",\
+  "--host=0.0.0.0",\
+  "--lifespan=off",\
+  "--reload",\
+  "--reload-dir=/app",\
+  "impress.asgi:application"\
+  ]
 
 # ---- Production image ----
 FROM core AS backend-production

--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -100,10 +100,9 @@ backend:
     - uvicorn
     - --app-dir=/app
     - --host=0.0.0.0
-    - --timeout-graceful-shutdown=300
-    - --limit-max-requests=20000
     - --lifespan=off
     - --reload
+    - --reload-dir=/app
     - "impress.asgi:application"
 
   createsuperuser:


### PR DESCRIPTION
## Purpose

The django application is running in ASGI in production, to have the same behavior we run the development container with uvicorn too with options more appropriated for a development evironment.

## Proposal

* [x] 🔧(docker) run django app with uvicorn in dev environment

