### PR TITLE
🐛(frontend) fix app shalow reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - 🚸(frontend) redirect on current url tab after 401 #2197
 - 🐛(frontend) abort check media status unmount #2194
 - ✨(backend) order pinned documents by last updated at #2028
+- 🐛(frontend) fix app shallow reload #2231
 - 🐛(frontend) fix interlinking modal clipping #2213
 - 🛂(frontend) fix cannot manage member on small screen #2226
 - 🐛(backend) load jwks url when OIDC_RS_PRIVATE_KEY_STR is set

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-create.spec.ts
@@ -52,7 +52,7 @@ test.describe('Doc Create', () => {
     ).toBeVisible();
   });
 
-  test('it creates a doc with link "/doc/new/', async ({
+  test('it creates a doc with link "/docs/new/"', async ({
     page,
     browserName,
   }) => {

--- a/src/frontend/apps/impress/src/features/auth/components/Auth.tsx
+++ b/src/frontend/apps/impress/src/features/auth/components/Auth.tsx
@@ -18,32 +18,30 @@ import { FirstConnection } from './FirstConnection';
 
 export const Auth = ({ children }: PropsWithChildren) => {
   const {
-    isLoading: isAuthLoading,
+    isAuthLoading,
     pathAllowed,
-    isFetchedAfterMount,
     authenticated,
-    fetchStatus,
+    hasInitiallyLoaded,
     user,
   } = useAuth();
-  const isLoading = fetchStatus !== 'idle' || isAuthLoading;
   const [isRedirecting, setIsRedirecting] = useState(false);
   const { data: config } = useConfig();
   const shouldTrySilentLogin = useMemo(
     () =>
       !authenticated &&
       !hasTrySilent() &&
-      !isLoading &&
+      !isAuthLoading &&
       !isRedirecting &&
       config?.FRONTEND_SILENT_LOGIN_ENABLED,
     [
       authenticated,
-      isLoading,
+      isAuthLoading,
       isRedirecting,
       config?.FRONTEND_SILENT_LOGIN_ENABLED,
     ],
   );
   const shouldTryLogin =
-    !authenticated && !isLoading && !isRedirecting && !pathAllowed;
+    !authenticated && !isAuthLoading && !isRedirecting && !pathAllowed;
   const { replace, pathname } = useRouter();
 
   /**
@@ -104,7 +102,7 @@ export const Auth = ({ children }: PropsWithChildren) => {
   ]);
 
   const shouldShowLoader =
-    (isLoading && !isFetchedAfterMount) ||
+    !hasInitiallyLoaded ||
     isRedirecting ||
     (!authenticated && !pathAllowed) ||
     shouldTrySilentLogin;

--- a/src/frontend/apps/impress/src/features/auth/hooks/useAuth.tsx
+++ b/src/frontend/apps/impress/src/features/auth/hooks/useAuth.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useAnalytics } from '@/libs';
 
@@ -12,6 +12,12 @@ export const useAuth = () => {
   const { pathname } = useRouter();
   const { trackEvent } = useAnalytics();
   const [hasTracked, setHasTracked] = useState(authStates.isFetched);
+  const isAuthLoading =
+    authStates.fetchStatus !== 'idle' || authStates.isLoading;
+  const hasInitiallyLoaded = useRef(false);
+  if (authStates.isFetched) {
+    hasInitiallyLoaded.current = true;
+  }
   const [pathAllowed, setPathAllowed] = useState<boolean>(
     !regexpUrlsAuth.some((regexp) => !!pathname.match(regexp)),
   );
@@ -35,6 +41,8 @@ export const useAuth = () => {
     user,
     authenticated: !!user && authStates.isSuccess,
     pathAllowed,
+    hasInitiallyLoaded: hasInitiallyLoaded.current,
+    isAuthLoading,
     ...authStates,
   };
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareAccessRequest.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareAccessRequest.tsx
@@ -11,6 +11,7 @@ import { createGlobalStyle, css } from 'styled-components';
 import {
   Box,
   BoxButton,
+  HorizontalSeparator,
   Icon,
   LoadMoreText,
   Loading,
@@ -165,19 +166,25 @@ export const QuickSearchGroupAccessRequest = ({
   }
 
   return (
-    <Box
-      aria-label={t('List request access card')}
-      className="--docs--share-access-request"
-      $padding={{ horizontal: 'base' }}
-    >
-      <QuickSearchGroupAccessRequestStyle />
-      <QuickSearchGroup
-        group={accessRequestsData}
-        renderElement={(accessRequest) => (
-          <DocShareAccessRequestItem doc={doc} accessRequest={accessRequest} />
-        )}
-      />
-    </Box>
+    <>
+      <Box
+        aria-label={t('List request access card')}
+        className="--docs--share-access-request"
+        $padding={{ horizontal: 'base' }}
+      >
+        <QuickSearchGroupAccessRequestStyle />
+        <QuickSearchGroup
+          group={accessRequestsData}
+          renderElement={(accessRequest) => (
+            <DocShareAccessRequestItem
+              doc={doc}
+              accessRequest={accessRequest}
+            />
+          )}
+        />
+      </Box>
+      <HorizontalSeparator $margin={{ vertical: 'sm' }} />
+    </>
   );
 };
 

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareInvitation.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareInvitation.tsx
@@ -6,7 +6,14 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
-import { Box, BoxButton, Icon, LoadMoreText, Text } from '@/components';
+import {
+  Box,
+  BoxButton,
+  HorizontalSeparator,
+  Icon,
+  LoadMoreText,
+  Text,
+} from '@/components';
 import { QuickSearchData, QuickSearchGroup } from '@/components/quick-search';
 import { useCunninghamTheme } from '@/cunningham';
 import { Doc, Role } from '@/docs/doc-management';
@@ -162,16 +169,19 @@ export const QuickSearchGroupInvitation = ({
   }
 
   return (
-    <Box
-      aria-label={t('List invitation card')}
-      $padding={{ horizontal: 'base' }}
-    >
-      <QuickSearchGroup
-        group={invitationsData}
-        renderElement={(invitation) => (
-          <DocShareInvitationItem doc={doc} invitation={invitation} />
-        )}
-      />
-    </Box>
+    <>
+      <Box
+        aria-label={t('List invitation card')}
+        $padding={{ horizontal: 'base' }}
+      >
+        <QuickSearchGroup
+          group={invitationsData}
+          renderElement={(invitation) => (
+            <DocShareInvitationItem doc={doc} invitation={invitation} />
+          )}
+        />
+      </Box>
+      <HorizontalSeparator $margin={{ vertical: 'sm' }} />
+    </>
   );
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
@@ -291,9 +291,7 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
                   {showMemberSection && isRootDoc && (
                     <Box $padding={{ top: 'base' }}>
                       <QuickSearchGroupAccessRequest doc={doc} />
-                      <HorizontalSeparator $margin={{ vertical: 'sm' }} />
                       <QuickSearchGroupInvitation doc={doc} />
-                      <HorizontalSeparator $margin={{ vertical: 'sm' }} />
                       <QuickSearchGroupMember doc={doc} />
                     </Box>
                   )}


### PR DESCRIPTION
## Purpose

The app was doing a shalow reload when user was coming from another tab and the user data was staled. We stop to block the app during the loading state, depend the response the app will manage correctly its states.

