### PR TITLE
🐛(backend) load jwks url when OIDC_RS_PRIVATE_KEY_STR is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 - 🐛(frontend) abort check media status unmount #2194
 - ✨(backend) order pinned documents by last updated at #2028
 - 🛂(frontend) fix cannot manage member on small screen #2226
+- 🐛(backend) load jwks url when OIDC_RS_PRIVATE_KEY_STR is set
 
 ## [v4.8.6] - 2026-04-08
 

--- a/src/backend/core/urls.py
+++ b/src/backend/core/urls.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.urls import include, path, re_path
 
 from lasuite.oidc_login.urls import urlpatterns as oidc_urls
+from lasuite.oidc_resource_server.urls import urlpatterns as oidc_resource_server_urls
 from rest_framework.routers import DefaultRouter
 
 from core.api import viewsets
@@ -117,3 +118,11 @@ if settings.OIDC_RESOURCE_SERVER_ENABLED:
             ),
         )
     )
+
+    if settings.OIDC_RS_PRIVATE_KEY_STR:
+        urlpatterns.append(
+            path(
+                f"api/{settings.API_VERSION}/",
+                include([*oidc_resource_server_urls]),
+            )
+        )


### PR DESCRIPTION
## Purpose

When the resource server is enabled and the backend used is JWTResourceServerBackend, then the API should expose a JWKS endpoint to share the RSA public key to the OIDC provider. Everything is made in the Django LaSuite library, but the URL is not included in the Docs URLs. This commit adds it when the setting OIDC_RS_PRIVATE_KEY_STR is set.


## Proposal

* [x] 🐛(backend) load jwks url when OIDC_RS_PRIVATE_KEY_STR is set
