### PR TITLE
⬆️(docker) upgrade nginx image to last version

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -60,7 +60,7 @@ COPY --from=impress-builder /home/frontend/apps/impress/out /app
 FROM ${FRONTEND_IMAGE} AS frontend-source
 
 # ---- Front-end image ----
-FROM nginxinc/nginx-unprivileged:alpine3.22 AS frontend-production
+FROM nginxinc/nginx-unprivileged:alpine3.23 AS frontend-production
 
 # Upgrade system packages to install security updates
 USER root


### PR DESCRIPTION
## Purpose

We want to upgrade the frontend image using the last nginx version available in order to remove some fixed in version 1.29.7

## Proposal

* [x] ⬆️(docker) upgrade nginx image to last version