### PR TITLE
🔖(major) release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v5.0.0] - 2026-04-08
+
 ### Added
 
 - ✨(backend) create a dedicated endpoint to update document content 
@@ -1270,7 +1272,8 @@ and this project adheres to
 - ✨(frontend) Coming Soon page (#67)
 - 🚀 Impress, project to manage your documents easily and collaboratively.
 
-[unreleased]: https://github.com/suitenumerique/docs/compare/v4.8.6...main
+[unreleased]: https://github.com/suitenumerique/docs/compare/v5.0.0...main
+[v5.0.0]: https://github.com/suitenumerique/docs/releases/v5.0.0
 [v4.8.6]: https://github.com/suitenumerique/docs/releases/v4.8.6
 [v4.8.5]: https://github.com/suitenumerique/docs/releases/v4.8.5
 [v4.8.4]: https://github.com/suitenumerique/docs/releases/v4.8.4

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,8 @@ the following command inside your docker container:
 
 ## [Unreleased]
 
+### [5.0.0] - 2026-04-30
+
 We made several changes around document content management leading to several breaking changes in the API.
 
 - The endpoint `/api/v1.0/documents/{document_id}/content/` has been renamed in `/api/v1.0/documents/{document_id}/formatted-content/`

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impress"
-version = "4.8.6"
+version = "5.0.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "4.8.6",
+  "version": "5.0.0",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-impress",
-  "version": "4.8.6",
+  "version": "5.0.0",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "4.8.6",
+  "version": "5.0.0",
   "private": true,
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",

--- a/src/frontend/packages/eslint-plugin-docs/package.json
+++ b/src/frontend/packages/eslint-plugin-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-docs",
-  "version": "4.8.6",
+  "version": "5.0.0",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "4.8.6",
+  "version": "5.0.0",
   "repository": "https://github.com/suitenumerique/docs",
   "author": "DINUM",
   "license": "MIT",

--- a/src/frontend/servers/y-provider/package.json
+++ b/src/frontend/servers/y-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-y-provider",
-  "version": "4.8.6",
+  "version": "5.0.0",
   "description": "Y.js provider for docs",
   "repository": "https://github.com/suitenumerique/docs",
   "license": "MIT",

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -1,10 +1,10 @@
 environments:
   dev:
     values:
-      - version: 4.8.6
+      - version: 5.0.0
   feature:
     values:
-      - version: 4.8.6
+      - version: 5.0.0
         feature: ci
         domain: example.com
         imageTag: demo

--- a/src/helm/impress/Chart.yaml
+++ b/src/helm/impress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: docs
-version: 4.8.6
+version: 5.0.0
 appVersion: latest

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "4.8.6",
+  "version": "5.0.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Added

- ✨(backend) create a dedicated endpoint to update document content
- ⚡️(backend) stream s3 file content with a dedicated endpoint
- ✨(backend) allow to use new ai feature using mistral sdk

### Changed

- ♻️(backend) rename documents content endpoint in `formatted-content` (BC)
- 🚸(frontend) show Crisp from the help menu #2222
- ♿️(frontend) structure correctly 5xx error alerts #2128
- ♿️(frontend) make doc search result labels uniquely identifiable #2212
- ⬆️(backend) upgrade docspec to v3.0.x and adapt converter API #2220
- ✨(backend) make forward auth request uri header configurable #2241
- ♿️(frontend) fix sidebar resize handle for screen readers #2122

### Fixed

- 🚸(frontend) redirect on current url tab after 401 #2197
- 🐛(frontend) abort check media status unmount #2194
- ✨(backend) order pinned documents by last updated at #2028
- 🐛(frontend) fix app shallow reload #2231
- 🐛(frontend) fix interlinking modal clipping #2213
- 🛂(frontend) fix cannot manage member on small screen #2226
- 🐛(backend) load jwks url when OIDC_RS_PRIVATE_KEY_STR is set
- 🐛(backend) Prevent moving document to its own descendant or self #2208
- 🐛(backend) return 400 when restoring a non-deleted document #2225