### PR TITLE
[release/3.8.21] Backport CVE-2026-22867 interlinking props XSS fix (#1792)

### DIFF
--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -64,6 +64,7 @@
     "react-select": "5.10.2",
     "styled-components": "6.1.19",
     "use-debounce": "10.0.6",
+    "uuid": "13.0.0",
     "y-protocols": "1.0.6",
     "yjs": "*",
     "zustand": "5.0.8"

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/InterlinkingLinkInlineContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/InterlinkingLinkInlineContent.tsx
@@ -1,8 +1,13 @@
-/* eslint-disable react-hooks/rules-of-hooks */
+import {
+  PartialCustomInlineContentFromConfig,
+  StyleSchema,
+} from '@blocknote/core';
 import { createReactInlineContentSpec } from '@blocknote/react';
+import * as Sentry from '@sentry/nextjs';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { css } from 'styled-components';
+import { validate as uuidValidate } from 'uuid';
 
 import { BoxButton, Text } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
@@ -13,9 +18,6 @@ export const InterlinkingLinkInlineContent = createReactInlineContentSpec(
   {
     type: 'interlinkingLinkInline',
     propSchema: {
-      url: {
-        default: '',
-      },
       docId: {
         default: '',
       },
@@ -26,37 +28,104 @@ export const InterlinkingLinkInlineContent = createReactInlineContentSpec(
     content: 'none',
   },
   {
-    render: ({ inlineContent, updateInlineContent }) => {
-      const { data: doc } = useDoc({ id: inlineContent.props.docId });
+    render: ({ editor, inlineContent, updateInlineContent }) => {
+      if (!inlineContent.props.docId) {
+        return null;
+      }
 
-      useEffect(() => {
-        if (doc?.title && doc.title !== inlineContent.props.title) {
-          updateInlineContent({
-            type: 'interlinkingLinkInline',
-            props: {
-              ...inlineContent.props,
-              title: doc.title,
-            },
-          });
-        }
-      }, [inlineContent.props, doc?.title, updateInlineContent]);
+      /**
+       * Should not happen
+       */
+      if (!uuidValidate(inlineContent.props.docId)) {
+        Sentry.captureException(
+          new Error(`Invalid docId: ${inlineContent.props.docId}`),
+          {
+            extra: { info: 'InterlinkingLinkInlineContent' },
+          },
+        );
 
-      return <LinkSelected {...inlineContent.props} />;
+        updateInlineContent({
+          type: 'interlinkingLinkInline',
+          props: {
+            docId: '',
+            title: '',
+          },
+        });
+
+        return null;
+      }
+
+      return (
+        <LinkSelected
+          docId={inlineContent.props.docId}
+          title={inlineContent.props.title}
+          isEditable={editor.isEditable}
+          updateInlineContent={updateInlineContent}
+        />
+      );
     },
   },
 );
 
 interface LinkSelectedProps {
-  url: string;
+  docId: string;
   title: string;
+  isEditable: boolean;
+  updateInlineContent: (
+    update: PartialCustomInlineContentFromConfig<
+      {
+        readonly type: 'interlinkingLinkInline';
+        readonly propSchema: {
+          readonly docId: {
+            readonly default: '';
+          };
+          readonly title: {
+            readonly default: '';
+          };
+        };
+        readonly content: 'none';
+      },
+      StyleSchema
+    >,
+  ) => void;
 }
-const LinkSelected = ({ url, title }: LinkSelectedProps) => {
+export const LinkSelected = ({
+  docId,
+  title,
+  isEditable,
+  updateInlineContent,
+}: LinkSelectedProps) => {
+  const { data: doc } = useDoc({ id: docId });
+
+  /**
+   * Update the content title if the referenced doc title changes
+   */
+  useEffect(() => {
+    if (isEditable && doc?.title && doc.title !== title) {
+      updateInlineContent({
+        type: 'interlinkingLinkInline',
+        props: {
+          docId,
+          title: doc.title,
+        },
+      });
+    }
+
+    /**
+     * ⚠️ When doing collaborative editing, doc?.title might be out of sync
+     * causing an infinite loop of updates.
+     * To prevent this, we only run this effect when doc?.title changes,
+     * not when inlineContent.props.title changes.
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [doc?.title, docId, isEditable]);
+
   const { colorsTokens } = useCunninghamTheme();
   const router = useRouter();
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
-    void router.push(url);
+    void router.push(`/docs/${docId}/`);
   };
 
   return (

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/SearchPage.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/SearchPage.tsx
@@ -225,7 +225,6 @@ export const SearchPage = ({
                   {
                     type: 'interlinkingLinkInline',
                     props: {
-                      url: `/docs/${doc.id}`,
                       docId: doc.id,
                       title: doc.title || untitledDocument,
                     },

--- a/src/frontend/apps/impress/src/features/docs/doc-export/inline-content-mapping/interlinkingLinkDocx.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/inline-content-mapping/interlinkingLinkDocx.tsx
@@ -1,16 +1,24 @@
 import { ExternalHyperlink, TextRun } from 'docx';
 
+import { getEmojiAndTitle } from '@/docs/doc-management';
+
 import { DocsExporterDocx } from '../types';
 
 export const inlineContentMappingInterlinkingLinkDocx: DocsExporterDocx['mappings']['inlineContentMapping']['interlinkingLinkInline'] =
   (inline) => {
+    if (!inline.props.docId) {
+      return new TextRun('');
+    }
+
+    const { emoji, titleWithoutEmoji } = getEmojiAndTitle(inline.props.title);
+
     return new ExternalHyperlink({
       children: [
         new TextRun({
-          text: `📄${inline.props.title}`,
+          text: `${emoji || '📄'}${titleWithoutEmoji}`,
           bold: true,
         }),
       ],
-      link: window.location.origin + inline.props.url,
+      link: window.location.origin + `/docs/${inline.props.docId}/`,
     });
   };

--- a/src/frontend/apps/impress/src/features/docs/doc-export/inline-content-mapping/interlinkingLinkPDF.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/inline-content-mapping/interlinkingLinkPDF.tsx
@@ -1,21 +1,29 @@
 import { Image, Link, Text } from '@react-pdf/renderer';
 
+import { getEmojiAndTitle } from '@/docs/doc-management';
+
 import DocSelectedIcon from '../assets/doc-selected.png';
 import { DocsExporterPDF } from '../types';
 
 export const inlineContentMappingInterlinkingLinkPDF: DocsExporterPDF['mappings']['inlineContentMapping']['interlinkingLinkInline'] =
   (inline) => {
+    if (!inline.props.docId) {
+      return <></>;
+    }
+
+    const { emoji, titleWithoutEmoji } = getEmojiAndTitle(inline.props.title);
+
     return (
       <Link
-        src={window.location.origin + inline.props.url}
+        src={window.location.origin + `/docs/${inline.props.docId}/`}
         style={{
           textDecoration: 'none',
           color: 'black',
         }}
       >
         {' '}
-        <Image src={DocSelectedIcon.src} />{' '}
-        <Text>{inline.props.title}</Text>{' '}
+        {emoji || <Image src={DocSelectedIcon.src} />}{' '}
+        <Text>{titleWithoutEmoji}</Text>{' '}
       </Link>
     );
   };


### PR DESCRIPTION
Backport of [`e807237d`](https://github.com/suitenumerique/docs/commit/e807237dbedbc189230296b81c3aeccc1c04fa77) (#1792) to `release/3.8.21` for **CVE-2026-22867**. Filed in response to issue #2248.

The interlinking fix drops the attacker-controlled `url` prop from `interlinkingLinkInline`, makes `LinkSelected` use `/docs/${docId}/` derived from the trusted `docId`, and falls back to `null` (with `Sentry.captureException`) when `uuid.validate(docId)` rejects. On `release/3.8.21` the renderer + Docx/PDF exporters still consume `inline.props.url` directly, so this brings the same gate over.

Adaptations versus master, all minor:

- `interlinkingLinkODT.tsx` — file is not present on `release/3.8.21`, so the upstream hunk for it is dropped (the patch's substantive content is on Docx/PDF/the renderer; ODT shipped later)
- `LinkSelected` body kept at the 3.8.2x styling — i.e. the static `📄`/icon + greyscale hover (no `getEmojiAndTitle` extraction, no `--docs--` className, no CSS variables). The pre-fix file on this branch was the simpler version; preserving that minimizes the visual delta. `getEmojiAndTitle` does exist on `release/3.8.21` but only the test shim consumes it; importing the renderer-side variant is unrelated cosmetics
- `package.json` — added `"uuid": "13.0.0"`; left `y-protocols` at the existing `1.0.6` (upstream's `1.0.7` bump in the same commit was an unrelated lockfile drift)
- `CHANGELOG.md` — `--ours` (no upstream-section bump on a patch branch)

Cherry-picked with `git cherry-pick -x` so the original author (Anthony LC) is preserved in the trailer; my Signed-off-by is added as the committer for DCO.

> [!NOTE]
> Tier-C check before this PR: target branch still has the `url` prop on the inline content spec and `router.push(url)` in `LinkSelected`; `uuidValidate`/`Invalid docId` not present anywhere on `release/3.8.21`. Behind-by `e807237d...release/3.8.21` is 206/2.

---
<!-- repo PR template below -->
## Purpose

Describe the purpose of this pull request. 


## Proposal

- [ ] item 1...
- [ ] item 2...

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [ ] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
- [ ] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [ ] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [ ] My commit messages follow the required format: `<gitmoji>(type) title description`
- [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [ ] I have added corresponding tests for new features or bug fixes (if applicable)
