### PR TITLE
💚(docker) ignore .venv with compilemessages command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ RUN mkdir /cert && \
 
 # Generate compiled translation messages
 RUN DJANGO_CONFIGURATION=Build \
-  python manage.py compilemessages
+  python manage.py compilemessages --ignore=".venv/**/*"
 
 
 # We wrap commands run in this container by the following entrypoint that

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ FROM python:3.13.13-alpine AS base
 # Upgrade system packages to install security updates
 RUN apk update && apk upgrade --no-cache
 
-
-# Remove pip. We don't use it.
-RUN python -m pip uninstall -y pip
+# We must do that to avoid having an outdated pip version with security issues
+RUN python -m pip install --upgrade pip
 
 # ---- Back-end builder image ----
 FROM base AS back-builder


### PR DESCRIPTION
## Purpose

The compilemessages management command was also compiling messages for all the libraries present in the .venv folder. We have to ignore it, on arm64 this management command is taking too much time otherwise.

## Proposal

* [x] 💚(docker) ignore .venv with compilemessages command

