### PR TITLE
🐛(docs) run migration 0027 without superuser role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 - ✨(backend) support creating subdoc from file #1987
 
+### Fixed
+
+- 🐛(docs) run migration 0027 without superuser role
+
 
 ## [v5.1.0] - 2026-05-11
 

--- a/compose.yml
+++ b/compose.yml
@@ -13,6 +13,8 @@ services:
       - env.d/development/postgresql.local
     ports:
       - "15432:5432"
+    volumes:
+      - ./docker/files/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:ro
 
   redis:
     image: redis:5

--- a/docker/files/docker-entrypoint-initdb.d/01_create_app_user.sh
+++ b/docker/files/docker-entrypoint-initdb.d/01_create_app_user.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Create a non-superuser for the application to test migrations.
+# Uses DB_USER and DB_PASSWORD from the environment so it stays in
+# sync with the application database configuration.
+# Only creates the user when DB_USER differs from POSTGRES_USER.
+
+
+# Validate required environment variables
+if [ -z "${POSTGRES_USER}" ] || [ -z "${POSTGRES_DB}" ] || [ -z "${DB_USER}" ] || [ -z "${DB_PASSWORD}" ]; then
+    echo "Required environment variables (POSTGRES_USER, POSTGRES_DB, DB_USER, DB_PASSWORD) must be set."
+    exit 0
+fi
+
+
+if [ "${DB_USER}" = "${POSTGRES_USER}" ]; then
+    echo "DB_USER is the same as POSTGRES_USER, skipping non-superuser creation."
+    exit 0
+fi
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE USER "${DB_USER}" WITH PASSWORD '${DB_PASSWORD}';
+    ALTER DATABASE "${POSTGRES_DB}" OWNER TO "${DB_USER}";
+EOSQL

--- a/env.d/development/postgresql
+++ b/env.d/development/postgresql
@@ -9,3 +9,8 @@ DB_NAME=impress
 DB_USER=dinum
 DB_PASSWORD=pass
 DB_PORT=5432
+
+# If you want to create a user without superuser permissions, you can change it.
+# The database must be deleted in order to be recreated.
+# DB_USER=docs
+# DB_PASSWORD=docs

--- a/src/backend/core/migrations/0027_auto_20251120_0956.py
+++ b/src/backend/core/migrations/0027_auto_20251120_0956.py
@@ -11,15 +11,10 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             sql="""
-                CREATE OR REPLACE FUNCTION public.immutable_unaccent(regdictionary, text)
-                RETURNS text
-                LANGUAGE c IMMUTABLE PARALLEL SAFE STRICT AS
-                '$libdir/unaccent', 'unaccent_dict';
-
                 CREATE OR REPLACE FUNCTION public.f_unaccent(text)
                 RETURNS text
-                LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
-                RETURN public.immutable_unaccent(regdictionary 'public.unaccent', $1);
+                LANGUAGE sql IMMUTABLE PARALLEL SAFE strict
+                return unaccent($1);
 
                 CREATE INDEX IF NOT EXISTS user_email_unaccent_trgm_idx
                 ON impress_user


### PR DESCRIPTION
## Purpose

In development environment, we want to use the application with a
postgres user not having superuser role. The migration 0027 needs
superuser role to be executed, so we want to be able to test migrations
and other scenarios with a normal user. In order to create this user,
the compose service must be deleted first and then recreated with
DB_USER and DB_PASSWORD environment variable values different with
POSTGRES_USER and POSTGRES_PASSWORD.

Once with user without superuser role, we modified the migration 0027 to make it runnable with a user without superuser role.


## Proposal

* [x] 🔧(postgres) create a user without superuser role
* [x] 🐛(docs) run migration 0027 without superuser role


Fix #1895 
