### PR TITLE
🔧(ci) ignore uv.lock in spell-mistakes job

### DIFF
--- a/.github/workflows/impress.yml
+++ b/.github/workflows/impress.yml
@@ -86,7 +86,8 @@ jobs:
             --skip "**/*.po" \
             --skip "**/*.pot" \
             --skip "**/*.json" \
-            --skip "**/yarn.lock"
+            --skip "**/yarn.lock" \
+            --skip "./src/backend/uv.lock"
 
   lint-back:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

In the spell-mistakes job we wanto to ignore the uv.lock file, the content of this file can't be modified.

## Proposal

* [x] 🔧(ci) ignore uv.lock in spell-mistakes job