### PR TITLE
fix: guard choices[0] and message=None before content access in ai_services

### DIFF
--- a/src/backend/core/services/ai_services/legacy.py
+++ b/src/backend/core/services/ai_services/legacy.py
@@ -113,6 +113,9 @@ class LegacyAiServiceMistralClient(LegacyAiClient):
             stream=False,
         )
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
+
         if langfuse:
             langfuse.update_current_generation(
                 usage_details={
@@ -149,6 +152,8 @@ class LegacyAiServiceOpenAiClient(LegacyAiClient):
             ],
         )
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
 
 


### PR DESCRIPTION
## Summary

In `src/backend/core/services/ai_services/legacy.py`, both `LegacyAiServiceMistralClient.call_ai_api` and `LegacyAiServiceOpenAiClient.call_ai_api` access `response.choices[0].message.content` without checking:
- Whether `choices` is non-empty (can be `[]` on API error or rate-limiting → `IndexError`)
- Whether `choices[0].message` is non-None (Gemini returns `None` on `PROHIBITED_CONTENT` with HTTP 200 → `AttributeError`; other providers may do the same)

This PR adds the comprehensive guard:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```
before each `choices[0].message.content` access (2 sites).

Static analysis via [pact](https://github.com/qizwiz/pact) (Z3 Fixedpoint datalog, `llm_response_unguarded` rule); post-fix scan returns 0 violations.