### PR TITLE
🐛(compose) set lasuite network as external

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ generate-secret-keys: ## generate secret keys to be stored in common.local
 .PHONY: generate-secret-keys
 
 pre-bootstrap: \
+	create-docker-network \
 	data/media \
 	data/static \
 	create-env-local-files \

--- a/compose.yml
+++ b/compose.yml
@@ -260,3 +260,4 @@ networks:
   lasuite:
     name: lasuite-network
     driver: bridge
+    external: true


### PR DESCRIPTION
## Purpose

The docker network lasuite is created in the makefile using the command `docker network create lasuite-network`. When a network is created with this command it can not be used by docker compose if this one is not set as external. We must use `external: true` in the compose file to fix this issue.`

## Proposal

* [x] 🐛(compose) set lasuite network as external