### PR TITLE
🐛(backend) use computed_link_reach in handle_onboarding_document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 - 🐛(docs) run migration 0027 without superuser role
 - 🐛(backend) prevent admins/owners from overwriting other users comments
+- 🐛(backend) use computed_link_reach in handle_onboarding_document #2305
 
 ### Changed
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -244,7 +244,7 @@ class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
                     )
                     continue
 
-                if document.link_reach == LinkReachChoices.RESTRICTED:
+                if document.computed_link_reach == LinkReachChoices.RESTRICTED:
                     logger.warning(
                         "Onboarding on a restricted document is not allowed. Must be public or "
                         "connected. Restricted document: %s",

--- a/src/backend/core/tests/test_models_users.py
+++ b/src/backend/core/tests/test_models_users.py
@@ -195,6 +195,25 @@ def test_models_users_handle_onboarding_documents_on_restricted_document_is_not_
     assert not models.LinkTrace.objects.filter(user=user, document=document).exists()
 
 
+def test_models_users_handle_onboarding_documents_computed_link_reach_not_restricted():
+    """Test that the computed_link_reach is used to check the real link_reach is used."""
+
+    parent = factories.DocumentFactory(link_reach=models.LinkReachChoices.PUBLIC)
+    document = factories.DocumentFactory(
+        parent=parent, link_reach=models.LinkReachChoices.RESTRICTED
+    )
+
+    assert document.computed_link_reach == models.LinkReachChoices.PUBLIC
+
+    with override_settings(USER_ONBOARDING_DOCUMENTS=[str(document.id)]):
+        user = factories.UserFactory()
+
+    assert models.LinkTrace.objects.filter(user=user, document=document).exists()
+    user_favorites = models.DocumentFavorite.objects.filter(user=user)
+    assert user_favorites.count() == 1
+    assert user_favorites.filter(document=document).exists()
+
+
 @override_settings(USER_ONBOARDING_SANDBOX_DOCUMENT=None)
 def test_models_users_duplicate_onboarding_sandbox_document_no_setting():
     """


### PR DESCRIPTION
## Purpose

In the model method User::_handle_onboarding_documents_access we do not allow using documents with restricted link_reach to be added as onboarding documents. To check the real link_reach of the document, we must use instead the computed_link_reach to be sure that a sub document can also be used and compute its correct link_reach.

## Proposal

* [x] 🐛(backend) use computed_link_reach in handle_onboarding_document

Fix #2015 