### PR TITLE
Display sub-docs in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 ### Changed
 
 - ♻️(backend) allow global search in sub documents
+- ✨(backend) add a breadcrumb in the search response
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - ✨(buildpack) add PaaS deployment support, tested with Scalingo #2293
 - 🔧(backend) allow configuring settings OIDC_OP_USER_ENDPOINT_FORMAT
 
+### Changed
+
+- ♻️(backend) allow global search in sub documents
+
 ### Fixed
 
 - 🐛(docs) run migration 0027 without superuser role

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -167,6 +167,17 @@ class ListDocumentSerializer(serializers.ModelSerializer):
         return instance.ancestors_deleted_at
 
 
+class SearchDocumentSerializer(ListDocumentSerializer):
+    """Serialize items for search."""
+
+    parents = ListDocumentSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = models.Document
+        fields = ListDocumentSerializer.Meta.fields + ["parents"]
+        read_only_fields = ListDocumentSerializer.Meta.read_only_fields + ["parents"]
+
+
 class DocumentLightSerializer(serializers.ModelSerializer):
     """Minial document serializer for nesting in document accesses."""
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -982,7 +982,7 @@ class ThreadSerializer(serializers.ModelSerializer):
         return {}
 
 
-class SearchDocumentSerializer(serializers.Serializer):
+class SearchQueryParamDocumentSerializer(serializers.Serializer):
     """Serializer for fulltext search requests through Find application"""
 
     q = serializers.CharField(required=True, allow_blank=True, trim_whitespace=True)

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1434,21 +1434,27 @@ class DocumentViewSet(
         params.is_valid(raise_exception=True)
         search_type = self._get_search_type()
         if search_type == SearchType.TITLE:
-            return self._title_search(request, params.validated_data, *args, **kwargs)
+            return self._search_using_database(
+                request, params.validated_data, *args, **kwargs
+            )
 
         indexer = get_document_indexer()
         if indexer is None:
             # fallback on title search if the indexer is not configured
-            return self._title_search(request, params.validated_data, *args, **kwargs)
+            return self._search_using_database(
+                request, params.validated_data, *args, **kwargs
+            )
 
         try:
-            return self._search_with_indexer(
+            return self._search_using_indexer(
                 indexer, request, params=params, search_type=search_type
             )
         except requests.exceptions.RequestException as e:
             logger.error("Error while searching documents with indexer: %s", e)
             # fallback on title search if the indexer is not reached
-            return self._title_search(request, params.validated_data, *args, **kwargs)
+            return self._search_using_database(
+                request, params.validated_data, *args, **kwargs
+            )
 
     def _get_search_type(self) -> SearchType:
         """
@@ -1464,7 +1470,7 @@ class DocumentViewSet(
         return SearchType.TITLE
 
     @staticmethod
-    def _search_with_indexer(indexer, request, params, search_type):
+    def _search_using_indexer(indexer, request, params, search_type):
         """
         Returns a list of documents matching the query (q) according to the configured indexer.
         """
@@ -1491,7 +1497,7 @@ class DocumentViewSet(
             }
         )
 
-    def _title_search(self, request, validated_data, *args, **kwargs):
+    def _search_using_database(self, request, validated_data, *args, **kwargs):
         """
         Fallback search method when no indexer is configured.
         Only searches in the title field of documents.

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -558,7 +558,7 @@ class DocumentViewSet(
     list_serializer_class = serializers.ListDocumentSerializer
     trashbin_serializer_class = serializers.ListDocumentSerializer
     tree_serializer_class = serializers.ListDocumentSerializer
-    search_serializer_class = serializers.ListDocumentSerializer
+    search_serializer_class = serializers.SearchDocumentSerializer
 
     def get_queryset(self):
         """Get queryset performing all annotation and filtering on the document tree structure."""
@@ -610,6 +610,48 @@ class DocumentViewSet(
 
         serializer = self.get_serializer(queryset, many=True, context=context)
         return drf.response.Response(serializer.data)
+
+    def _compute_parents(self, documents):
+        """
+        Compute parents for the documents by analyzing their paths and fetching missing parents.
+
+        Nota bene: current implementation may appear naive, but it has been
+        optimized to avoid n+1 database queries issue. At this time, we only
+        perform a single database request when parents are missing.
+        """
+        documents = list(documents)
+        steplen = models.Document.steplen
+
+        # Build parents dictionary and collect missing parent paths
+        parents = {document.path: document for document in documents}
+        missing_parent_paths = set()
+
+        for document in documents:
+            path = document.path
+            for i in range(steplen, len(path), steplen):
+                parent_path = path[:i]
+                if parent_path not in parents:
+                    missing_parent_paths.add(parent_path)
+
+        # Fetch missing ancestors from database
+        if missing_parent_paths:
+            for parent in (
+                models.Document.objects.annotate_user_roles(self.request.user)
+                .annotate_is_favorite(self.request.user)
+                .filter(path__in=missing_parent_paths)
+                .iterator()
+            ):
+                parents[parent.path] = parent
+
+        # Set parents for each item
+        for document in documents:
+            path = document.path
+            document_parents = []
+            for i in range(steplen, len(path), steplen):
+                document_parents.append(parents[path[:i]])
+            document.parents = document_parents
+
+        return documents
 
     def list(self, request, *args, **kwargs):
         """
@@ -1499,6 +1541,17 @@ class DocumentViewSet(
             }
         )
 
+    def _get_response_for_search_queryset(self, queryset):
+        page = self.paginate_queryset(queryset)
+        documents_queryset = page if page else queryset
+        documents = self._compute_parents(documents_queryset)
+        serializer = self.get_serializer(documents, many=True)
+
+        if page is None:
+            return drf.response.Response(serializer.data)
+
+        return self.get_paginated_response(serializer.data)
+
     def _search_using_database(self, request, validated_data, *args, **kwargs):
         """
         Fallback search method when no indexer is configured.
@@ -1581,7 +1634,7 @@ class DocumentViewSet(
             raise drf.exceptions.ValidationError(filterset.errors)
 
         queryset = filterset.qs
-        return self.get_response_for_queryset(queryset)
+        return self._get_response_for_search_queryset(queryset)
 
     @drf.decorators.action(detail=True, methods=["get"], url_path="versions")
     def versions_list(self, request, *args, **kwargs):

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1430,7 +1430,9 @@ class DocumentViewSet(
         It depends on a search configurable Search Indexer. If no Search Indexer is configured
         or if it is not reachable, the function falls back to a basic title search.
         """
-        params = serializers.SearchDocumentSerializer(data=request.query_params)
+        params = serializers.SearchQueryParamDocumentSerializer(
+            data=request.query_params
+        )
         params.is_valid(raise_exception=True)
         search_type = self._get_search_type()
         if search_type == SearchType.TITLE:

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1502,10 +1502,47 @@ class DocumentViewSet(
         Fallback search method when no indexer is configured.
         Only searches in the title field of documents.
         """
-        if not validated_data.get("path"):
-            return self.list(request, *args, **kwargs)
 
-        return self._list_descendants(request, validated_data)
+        if validated_data.get("path"):
+            return self._list_descendants(request, validated_data)
+
+        top_level_documents = self.get_queryset()
+        queryset = self.queryset
+        user = request.user
+
+        filterset = DocumentFilter(request.GET, queryset=queryset, request=request)
+        if not filterset.is_valid():
+            raise drf.exceptions.ValidationError(filterset.errors)
+
+        # Among the results, we may have documents that are ancestors/descendants
+        # of each other. In this case we want to keep only the highest ancestors.
+        root_paths = utils.filter_root_paths(
+            top_level_documents.order_by("path").values_list("path", flat=True),
+            skip_sorting=True,
+        )
+
+        if not root_paths:
+            return self.get_response_for_queryset(top_level_documents.none())
+
+        path_list = db.Q()
+        for top_level_document in root_paths:
+            path_list |= db.Q(path__startswith=top_level_document)
+
+        queryset = (
+            queryset.filter(path_list)
+            .filter(ancestors_deleted_at__isnull=True)
+            .annotate_user_roles(user)
+            .annotate_is_favorite(user)
+        )
+
+        queryset = filterset.filter_queryset(queryset)
+
+        # Apply ordering only now that everything is filtered and annotated
+        queryset = filters.OrderingFilter().filter_queryset(
+            self.request, queryset, self
+        )
+
+        return self._get_response_for_search_queryset(queryset)
 
     def _list_descendants(self, request, validated_data):
         """

--- a/src/backend/core/tests/documents/test_api_documents_search.py
+++ b/src/backend/core/tests/documents/test_api_documents_search.py
@@ -88,7 +88,9 @@ def test_api_documents_search_simple_search_anonymous(settings):
     assert response.json()["count"] == 0
 
 
-def test_api_documents_search_fall_back_on_simple_search(settings):
+def test_api_documents_search_fall_back_on_simple_search(
+    settings, django_assert_num_queries
+):
     """
     When indexer is not configured the search should be made in the database on the
     title field.
@@ -125,7 +127,8 @@ def test_api_documents_search_fall_back_on_simple_search(settings):
     client.force_login(user)
 
     q = "alpha"
-    response = client.get("/api/v1.0/documents/search/", data={"q": q})
+    with django_assert_num_queries(13):
+        response = client.get("/api/v1.0/documents/search/", data={"q": q})
 
     assert response.status_code == 200
 
@@ -371,7 +374,7 @@ def test_api_documents_search_simple_search_only_match_in_depth(settings):
     }
 
 
-def test_api_documents_saerch_with_title_also_matching_link_traces(settings):
+def test_api_documents_search_with_title_also_matching_link_traces(settings):
     """Test that link_traces can also be present in the search result."""
     assert get_document_indexer() is None
     assert settings.OIDC_STORE_REFRESH_TOKEN is False

--- a/src/backend/core/tests/documents/test_api_documents_search.py
+++ b/src/backend/core/tests/documents/test_api_documents_search.py
@@ -142,8 +142,10 @@ def test_api_documents_search_fallback_on_search_list_sub_docs(
     assert response.json() == mocked_response
 
 
-@mock.patch("core.api.viewsets.DocumentViewSet._title_search")
-def test_api_documents_search_indexer_crashes(mock_title_search, indexer_settings):
+@mock.patch("core.api.viewsets.DocumentViewSet._search_using_database")
+def test_api_documents_search_indexer_crashes(
+    mock_search_using_database, indexer_settings
+):
     """
     When indexer is configured but crashes -> falls back on title_search
     """
@@ -170,7 +172,7 @@ def test_api_documents_search_indexer_crashes(mock_title_search, indexer_setting
         "previous": None,
         "results": [{"title": "mocked title_search result"}],
     }
-    mock_title_search.return_value = drf_response.Response(mocked_response)
+    mock_search_using_database.return_value = drf_response.Response(mocked_response)
 
     parent = factories.DocumentFactory(title="parent", users=[user])
     q = "alpha"
@@ -181,9 +183,9 @@ def test_api_documents_search_indexer_crashes(mock_title_search, indexer_setting
     # the search endpoint did not crash
     assert response.status_code == 200
     # fallback on title_search
-    assert mock_title_search.call_count == 1
-    assert mock_title_search.call_args[0][0].GET.get("q") == q
-    assert mock_title_search.call_args[0][0].GET.get("path") == parent.path
+    assert mock_search_using_database.call_count == 1
+    assert mock_search_using_database.call_args[0][0].GET.get("q") == q
+    assert mock_search_using_database.call_args[0][0].GET.get("path") == parent.path
     assert response.json() == mocked_response
 
 

--- a/src/backend/core/tests/documents/test_api_documents_search.py
+++ b/src/backend/core/tests/documents/test_api_documents_search.py
@@ -13,6 +13,7 @@ from waffle.testutils import override_flag
 
 from core import factories
 from core.enums import FeatureFlag, SearchType
+from core.models import LinkReachChoices
 from core.services.search_indexers import get_document_indexer
 
 fake = Faker()
@@ -69,77 +70,463 @@ def test_api_documents_search_anonymous(search_query, indexer_settings):
     }
 
 
-@mock.patch("core.api.viewsets.DocumentViewSet.list")
-def test_api_documents_search_fall_back_on_search_list(mock_list, settings):
+def test_api_documents_search_simple_search_anonymous(settings):
+    """Anonymous users should not be able to use the global search."""
+    assert get_document_indexer() is None
+    assert settings.OIDC_STORE_REFRESH_TOKEN is False
+    assert settings.OIDC_STORE_ACCESS_TOKEN is False
+
+    factories.DocumentFactory(link_reach=LinkReachChoices.PUBLIC, title="alpha")
+    parent = factories.DocumentFactory(link_reach=LinkReachChoices.PUBLIC)
+    factories.DocumentFactory.create_batch(3, parent=parent, title="alpha")
+
+    client = APIClient()
+    q = "alpha"
+    response = client.get("/api/v1.0/documents/search/", data={"q": q})
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+def test_api_documents_search_fall_back_on_simple_search(settings):
     """
-    When indexer is not configured and no path is provided,
-    should fall back on list method
+    When indexer is not configured the search should be made in the database on the
+    title field.
     """
     assert get_document_indexer() is None
     assert settings.OIDC_STORE_REFRESH_TOKEN is False
     assert settings.OIDC_STORE_ACCESS_TOKEN is False
 
     user = factories.UserFactory()
-    client = APIClient()
-    client.force_login(
-        user, backend="core.authentication.backends.OIDCAuthenticationBackend"
-    )
 
-    mocked_response = {
-        "count": 0,
-        "next": None,
-        "previous": None,
-        "results": [{"title": "mocked list result"}],
-    }
-    mock_list.return_value = drf_response.Response(mocked_response)
+    document = factories.DocumentFactory(
+        creator=user, users=[(user, "owner")], title="alpha"
+    )
+    factories.DocumentFactory(creator=user, users=[(user, "owner")], title="bar")
+
+    # return a matching doc in a tree
+    parent = factories.DocumentFactory(
+        creator=user, users=[(user, "owner")], title="top parent"
+    )
+    child = factories.DocumentFactory(parent=parent, title="alpha blondy")
+    child_to_delete = factories.DocumentFactory(parent=parent, title="deleted alpha")
+    child_to_delete.soft_delete()
+
+    deleted_parent = factories.DocumentFactory(creator=user, users=[(user, "owner")])
+    factories.DocumentFactory.create_batch(3, parent=deleted_parent, title="alpha")
+
+    deleted_parent.soft_delete()
+
+    # not reachable documents for the current user
+    factories.DocumentFactory(title="alpha", link_reach=LinkReachChoices.AUTHENTICATED)
+    factories.DocumentFactory(title="alpha foo", link_reach=LinkReachChoices.PUBLIC)
+
+    client = APIClient()
+    client.force_login(user)
 
     q = "alpha"
     response = client.get("/api/v1.0/documents/search/", data={"q": q})
 
     assert response.status_code == 200
 
-    assert mock_list.call_count == 1
-    assert mock_list.call_args[0][0].GET.get("q") == q
-    assert response.json() == mocked_response
+    # all `nb_access_*` should be in cache
+    with django_assert_num_queries(6):
+        response = client.get("/api/v1.0/documents/search/", data={"q": q})
+
+    assert response.status_code == 200
+
+    assert response.json() == {
+        "count": 2,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "abilities": child.get_abilities(user),
+                "ancestors_link_reach": child.ancestors_link_reach,
+                "ancestors_link_role": child.ancestors_link_role,
+                "computed_link_reach": child.computed_link_reach,
+                "computed_link_role": child.computed_link_role,
+                "created_at": child.created_at.isoformat().replace("+00:00", "Z"),
+                "creator": str(child.creator.id),
+                "deleted_at": None,
+                "depth": 2,
+                "excerpt": child.excerpt,
+                "id": str(child.id),
+                "is_favorite": False,
+                "link_reach": child.link_reach,
+                "link_role": child.link_role,
+                "numchild": 0,
+                "nb_accesses_ancestors": child.nb_accesses_ancestors,
+                "nb_accesses_direct": child.nb_accesses_direct,
+                "path": child.path,
+                "title": child.title,
+                "updated_at": child.updated_at.isoformat().replace("+00:00", "Z"),
+                "user_role": "owner",
+                "parents": [
+                    {
+                        "abilities": parent.get_abilities(user),
+                        "ancestors_link_role": None,
+                        "ancestors_link_reach": None,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_direct,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": "owner",
+                    },
+                ],
+            },
+            {
+                "abilities": document.get_abilities(user),
+                "ancestors_link_role": None,
+                "ancestors_link_reach": None,
+                "computed_link_reach": document.computed_link_reach,
+                "computed_link_role": document.computed_link_role,
+                "created_at": document.created_at.isoformat().replace("+00:00", "Z"),
+                "creator": str(document.creator.id),
+                "deleted_at": None,
+                "depth": 1,
+                "excerpt": document.excerpt,
+                "id": str(document.id),
+                "is_favorite": False,
+                "link_reach": document.link_reach,
+                "link_role": document.link_role,
+                "numchild": 0,
+                "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                "nb_accesses_direct": document.nb_accesses_direct,
+                "path": document.path,
+                "title": document.title,
+                "updated_at": document.updated_at.isoformat().replace("+00:00", "Z"),
+                "user_role": "owner",
+                "parents": [],
+            },
+        ],
+    }
 
 
-@mock.patch("core.api.viewsets.DocumentViewSet._list_descendants")
-def test_api_documents_search_fallback_on_search_list_sub_docs(
-    mock_list_descendants, settings
-):
-    """
-    When indexer is not configured and path parameter is provided,
-    should call _list_descendants() method
-    """
+def test_api_documents_search_simple_search_only_match_in_depth(settings):
+    """Test with results only matching documents in depth."""
     assert get_document_indexer() is None
     assert settings.OIDC_STORE_REFRESH_TOKEN is False
     assert settings.OIDC_STORE_ACCESS_TOKEN is False
 
     user = factories.UserFactory()
-    client = APIClient()
-    client.force_login(
-        user, backend="core.authentication.backends.OIDCAuthenticationBackend"
+
+    document = factories.DocumentFactory(creator=user, users=[(user, "owner")])
+    subdocument = factories.DocumentFactory(parent=document, title="alpha")
+
+    factories.DocumentFactory(creator=user, users=[(user, "owner")], title="bar")
+
+    # return a matching doc in a tree
+    parent = factories.DocumentFactory(
+        creator=user, users=[(user, "owner")], title="top parent"
     )
+    child = factories.DocumentFactory(parent=parent, title="alpha blondy")
+    child_to_delete = factories.DocumentFactory(parent=parent, title="deleted alpha")
+    child_to_delete.soft_delete()
 
-    parent = factories.DocumentFactory(title="parent", users=[user])
+    deleted_parent = factories.DocumentFactory(creator=user, users=[(user, "owner")])
+    factories.DocumentFactory.create_batch(3, parent=deleted_parent, title="alpha")
 
-    mocked_response = {
-        "count": 0,
-        "next": None,
-        "previous": None,
-        "results": [{"title": "mocked _list_descendants result"}],
-    }
-    mock_list_descendants.return_value = drf_response.Response(mocked_response)
+    deleted_parent.soft_delete()
+
+    # not reachable documents for the current user
+    factories.DocumentFactory(title="alpha", link_reach=LinkReachChoices.AUTHENTICATED)
+    factories.DocumentFactory(title="alpha foo", link_reach=LinkReachChoices.PUBLIC)
+
+    client = APIClient()
+    client.force_login(user)
 
     q = "alpha"
-    response = client.get(
-        "/api/v1.0/documents/search/", data={"q": q, "path": parent.path}
+    response = client.get("/api/v1.0/documents/search/", data={"q": q})
+
+    assert response.status_code == 200
+
+    assert response.json() == {
+        "count": 2,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "abilities": child.get_abilities(user),
+                "ancestors_link_reach": child.ancestors_link_reach,
+                "ancestors_link_role": child.ancestors_link_role,
+                "computed_link_reach": child.computed_link_reach,
+                "computed_link_role": child.computed_link_role,
+                "created_at": child.created_at.isoformat().replace("+00:00", "Z"),
+                "creator": str(child.creator.id),
+                "deleted_at": None,
+                "depth": 2,
+                "excerpt": child.excerpt,
+                "id": str(child.id),
+                "is_favorite": False,
+                "link_reach": child.link_reach,
+                "link_role": child.link_role,
+                "numchild": 0,
+                "nb_accesses_ancestors": child.nb_accesses_ancestors,
+                "nb_accesses_direct": child.nb_accesses_direct,
+                "path": child.path,
+                "title": child.title,
+                "updated_at": child.updated_at.isoformat().replace("+00:00", "Z"),
+                "user_role": "owner",
+                "parents": [
+                    {
+                        "abilities": parent.get_abilities(user),
+                        "ancestors_link_role": None,
+                        "ancestors_link_reach": None,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_direct,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": "owner",
+                    },
+                ],
+            },
+            {
+                "abilities": subdocument.get_abilities(user),
+                "ancestors_link_role": subdocument.ancestors_link_role,
+                "ancestors_link_reach": subdocument.ancestors_link_reach,
+                "computed_link_reach": subdocument.computed_link_reach,
+                "computed_link_role": subdocument.computed_link_role,
+                "created_at": subdocument.created_at.isoformat().replace("+00:00", "Z"),
+                "creator": str(subdocument.creator.id),
+                "deleted_at": None,
+                "depth": 2,
+                "excerpt": subdocument.excerpt,
+                "id": str(subdocument.id),
+                "is_favorite": False,
+                "link_reach": subdocument.link_reach,
+                "link_role": subdocument.link_role,
+                "numchild": 0,
+                "nb_accesses_ancestors": subdocument.nb_accesses_ancestors,
+                "nb_accesses_direct": subdocument.nb_accesses_direct,
+                "path": subdocument.path,
+                "title": subdocument.title,
+                "updated_at": subdocument.updated_at.isoformat().replace("+00:00", "Z"),
+                "user_role": "owner",
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_role": None,
+                        "ancestors_link_reach": None,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": "owner",
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def test_api_documents_saerch_with_title_also_matching_link_traces(settings):
+    """Test that link_traces can also be present in the search result."""
+    assert get_document_indexer() is None
+    assert settings.OIDC_STORE_REFRESH_TOKEN is False
+    assert settings.OIDC_STORE_ACCESS_TOKEN is False
+
+    user = factories.UserFactory()
+
+    document = factories.DocumentFactory(
+        creator=user, users=[(user, "owner")], title="alpha"
+    )
+    factories.DocumentFactory(creator=user, users=[(user, "owner")], title="bar")
+
+    # return a matching doc in a tree
+    parent = factories.DocumentFactory(
+        creator=user, users=[(user, "owner")], title="top parent"
+    )
+    child = factories.DocumentFactory(parent=parent, title="alpha blondy")
+    child_to_delete = factories.DocumentFactory(parent=parent, title="deleted alpha")
+    child_to_delete.soft_delete()
+
+    deleted_parent = factories.DocumentFactory(creator=user, users=[(user, "owner")])
+    factories.DocumentFactory.create_batch(3, parent=deleted_parent, title="alpha")
+
+    deleted_parent.soft_delete()
+
+    # Document reachable through link_traces
+    document_link_trace = factories.DocumentFactory(
+        link_reach=LinkReachChoices.AUTHENTICATED,
+        link_traces=[user],
+        title="too much alpha",
     )
 
-    mock_list_descendants.assert_called_with(
-        mock.ANY, {"q": "alpha", "path": parent.path}
-    )
-    assert response.json() == mocked_response
+    # not reachable documents for the current user
+    factories.DocumentFactory(title="alpha", link_reach=LinkReachChoices.AUTHENTICATED)
+    factories.DocumentFactory(title="alpha foo", link_reach=LinkReachChoices.PUBLIC)
+
+    client = APIClient()
+    client.force_login(user)
+
+    q = "alpha"
+    response = client.get("/api/v1.0/documents/search/", data={"q": q})
+
+    assert response.status_code == 200
+
+    assert response.json() == {
+        "count": 3,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "abilities": document_link_trace.get_abilities(user),
+                "ancestors_link_role": None,
+                "ancestors_link_reach": None,
+                "computed_link_reach": document_link_trace.computed_link_reach,
+                "computed_link_role": document_link_trace.computed_link_role,
+                "created_at": document_link_trace.created_at.isoformat().replace(
+                    "+00:00", "Z"
+                ),
+                "creator": str(document_link_trace.creator.id),
+                "deleted_at": None,
+                "depth": 1,
+                "excerpt": document_link_trace.excerpt,
+                "id": str(document_link_trace.id),
+                "is_favorite": False,
+                "link_reach": document_link_trace.link_reach,
+                "link_role": document_link_trace.link_role,
+                "numchild": 0,
+                "nb_accesses_ancestors": document_link_trace.nb_accesses_ancestors,
+                "nb_accesses_direct": document_link_trace.nb_accesses_direct,
+                "path": document_link_trace.path,
+                "title": document_link_trace.title,
+                "updated_at": document_link_trace.updated_at.isoformat().replace(
+                    "+00:00", "Z"
+                ),
+                "user_role": None,
+                "parents": [],
+            },
+            {
+                "abilities": child.get_abilities(user),
+                "ancestors_link_reach": child.ancestors_link_reach,
+                "ancestors_link_role": child.ancestors_link_role,
+                "computed_link_reach": child.computed_link_reach,
+                "computed_link_role": child.computed_link_role,
+                "created_at": child.created_at.isoformat().replace("+00:00", "Z"),
+                "creator": str(child.creator.id),
+                "deleted_at": None,
+                "depth": 2,
+                "excerpt": child.excerpt,
+                "id": str(child.id),
+                "is_favorite": False,
+                "link_reach": child.link_reach,
+                "link_role": child.link_role,
+                "numchild": 0,
+                "nb_accesses_ancestors": child.nb_accesses_ancestors,
+                "nb_accesses_direct": child.nb_accesses_direct,
+                "path": child.path,
+                "title": child.title,
+                "updated_at": child.updated_at.isoformat().replace("+00:00", "Z"),
+                "user_role": "owner",
+                "parents": [
+                    {
+                        "abilities": parent.get_abilities(user),
+                        "ancestors_link_role": None,
+                        "ancestors_link_reach": None,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_direct,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": "owner",
+                    },
+                ],
+            },
+            {
+                "abilities": document.get_abilities(user),
+                "ancestors_link_role": None,
+                "ancestors_link_reach": None,
+                "computed_link_reach": document.computed_link_reach,
+                "computed_link_role": document.computed_link_role,
+                "created_at": document.created_at.isoformat().replace("+00:00", "Z"),
+                "creator": str(document.creator.id),
+                "deleted_at": None,
+                "depth": 1,
+                "excerpt": document.excerpt,
+                "id": str(document.id),
+                "is_favorite": False,
+                "link_reach": document.link_reach,
+                "link_role": document.link_role,
+                "numchild": 0,
+                "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                "nb_accesses_direct": document.nb_accesses_direct,
+                "path": document.path,
+                "title": document.title,
+                "updated_at": document.updated_at.isoformat().replace("+00:00", "Z"),
+                "user_role": "owner",
+                "parents": [],
+            },
+        ],
+    }
 
 
 @mock.patch("core.api.viewsets.DocumentViewSet._search_using_database")

--- a/src/backend/core/tests/documents/test_api_documents_search_descendants.py
+++ b/src/backend/core/tests/documents/test_api_documents_search_descendants.py
@@ -2,6 +2,7 @@
 Tests for search API endpoint in impress's core app when indexer is not
 available and a path param is given.
 """
+# pylint: disable=too-many-lines
 
 import random
 
@@ -65,6 +66,7 @@ def test_api_documents_search_descendants_list_anonymous_public_standalone():
                 "title": document.title,
                 "updated_at": document.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [],
             },
             {
                 "abilities": child1.get_abilities(AnonymousUser()),
@@ -88,6 +90,35 @@ def test_api_documents_search_descendants_list_anonymous_public_standalone():
                 "title": child1.title,
                 "updated_at": child1.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(AnonymousUser()),
+                        "ancestors_link_role": None,
+                        "ancestors_link_reach": None,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": 0,
+                        "nb_accesses_direct": 0,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
             {
                 "abilities": grand_child.get_abilities(AnonymousUser()),
@@ -111,6 +142,62 @@ def test_api_documents_search_descendants_list_anonymous_public_standalone():
                 "title": grand_child.title,
                 "updated_at": grand_child.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(AnonymousUser()),
+                        "ancestors_link_role": None,
+                        "ancestors_link_reach": None,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": 0,
+                        "nb_accesses_direct": 0,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": child1.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": child1.ancestors_link_reach,
+                        "ancestors_link_role": child1.ancestors_link_role,
+                        "computed_link_reach": child1.computed_link_reach,
+                        "computed_link_role": child1.computed_link_role,
+                        "created_at": child1.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(child1.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": child1.excerpt,
+                        "id": str(child1.id),
+                        "is_favorite": False,
+                        "link_reach": child1.link_reach,
+                        "link_role": child1.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": 1,
+                        "nb_accesses_direct": 1,
+                        "path": child1.path,
+                        "title": child1.title,
+                        "updated_at": child1.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
             {
                 "abilities": child2.get_abilities(AnonymousUser()),
@@ -134,6 +221,35 @@ def test_api_documents_search_descendants_list_anonymous_public_standalone():
                 "title": child2.title,
                 "updated_at": child2.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(AnonymousUser()),
+                        "ancestors_link_role": None,
+                        "ancestors_link_reach": None,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": 0,
+                        "nb_accesses_direct": 0,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
         ],
     }
@@ -197,6 +313,62 @@ def test_api_documents_search_descendants_list_anonymous_public_parent():
                 "title": document.title,
                 "updated_at": document.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_ancestors,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": parent.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_ancestors,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
             {
                 "abilities": child1.get_abilities(AnonymousUser()),
@@ -220,6 +392,89 @@ def test_api_documents_search_descendants_list_anonymous_public_parent():
                 "title": child1.title,
                 "updated_at": child1.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_ancestors,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": parent.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_ancestors,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": document.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": "public",
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 3,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": 0,
+                        "nb_accesses_direct": 0,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
             {
                 "abilities": grand_child.get_abilities(AnonymousUser()),
@@ -243,6 +498,116 @@ def test_api_documents_search_descendants_list_anonymous_public_parent():
                 "title": grand_child.title,
                 "updated_at": grand_child.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_ancestors,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": parent.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_ancestors,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": document.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": "public",
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 3,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": 0,
+                        "nb_accesses_direct": 0,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": child1.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": "public",
+                        "ancestors_link_role": child1.ancestors_link_role,
+                        "computed_link_reach": child1.computed_link_reach,
+                        "computed_link_role": child1.computed_link_role,
+                        "created_at": child1.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(child1.creator.id),
+                        "deleted_at": None,
+                        "depth": 4,
+                        "excerpt": child1.excerpt,
+                        "id": str(child1.id),
+                        "is_favorite": False,
+                        "link_reach": child1.link_reach,
+                        "link_role": child1.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": 1,
+                        "nb_accesses_direct": 1,
+                        "path": child1.path,
+                        "title": child1.title,
+                        "updated_at": child1.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
             {
                 "abilities": child2.get_abilities(AnonymousUser()),
@@ -266,6 +631,89 @@ def test_api_documents_search_descendants_list_anonymous_public_parent():
                 "title": child2.title,
                 "updated_at": child2.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_ancestors,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": parent.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_ancestors,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": document.get_abilities(AnonymousUser()),
+                        "ancestors_link_reach": "public",
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 3,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": 0,
+                        "nb_accesses_direct": 0,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
         ],
     }
@@ -344,10 +792,39 @@ def test_api_documents_search_descendants_list_authenticated_unrelated_public_or
                 "title": child1.title,
                 "updated_at": child1.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
             {
                 "abilities": grand_child.get_abilities(user),
-                "ancestors_link_reach": reach,
+                "ancestors_link_reach": grand_child.ancestors_link_reach,
                 "ancestors_link_role": grand_child.ancestors_link_role,
                 "computed_link_reach": grand_child.computed_link_reach,
                 "computed_link_role": grand_child.computed_link_role,
@@ -367,6 +844,62 @@ def test_api_documents_search_descendants_list_authenticated_unrelated_public_or
                 "title": grand_child.title,
                 "updated_at": grand_child.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": child1.get_abilities(user),
+                        "ancestors_link_reach": child1.ancestors_link_reach,
+                        "ancestors_link_role": child1.ancestors_link_role,
+                        "computed_link_reach": child1.computed_link_reach,
+                        "computed_link_role": child1.computed_link_role,
+                        "created_at": child1.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(child1.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": child1.excerpt,
+                        "id": str(child1.id),
+                        "is_favorite": False,
+                        "link_reach": child1.link_reach,
+                        "link_role": child1.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": 1,
+                        "nb_accesses_direct": 1,
+                        "path": child1.path,
+                        "title": child1.title,
+                        "updated_at": child1.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
             {
                 "abilities": child2.get_abilities(user),
@@ -390,6 +923,35 @@ def test_api_documents_search_descendants_list_authenticated_unrelated_public_or
                 "title": child2.title,
                 "updated_at": child2.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
         ],
     }
@@ -454,6 +1016,89 @@ def test_api_documents_search_descendants_list_authenticated_public_or_authentic
                 "title": child1.title,
                 "updated_at": child1.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(user),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_direct,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": parent.get_abilities(user),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_direct,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 3,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
             {
                 "abilities": grand_child.get_abilities(user),
@@ -477,6 +1122,116 @@ def test_api_documents_search_descendants_list_authenticated_public_or_authentic
                 "title": grand_child.title,
                 "updated_at": grand_child.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(user),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_direct,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": parent.get_abilities(user),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_direct,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 3,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": child1.get_abilities(user),
+                        "ancestors_link_reach": reach,
+                        "ancestors_link_role": child1.ancestors_link_role,
+                        "computed_link_reach": child1.computed_link_reach,
+                        "computed_link_role": child1.computed_link_role,
+                        "created_at": child1.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(child1.creator.id),
+                        "deleted_at": None,
+                        "depth": 4,
+                        "excerpt": child1.excerpt,
+                        "id": str(child1.id),
+                        "is_favorite": False,
+                        "link_reach": child1.link_reach,
+                        "link_role": child1.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": 1,
+                        "nb_accesses_direct": 1,
+                        "path": child1.path,
+                        "title": child1.title,
+                        "updated_at": child1.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
             {
                 "abilities": child2.get_abilities(user),
@@ -500,6 +1255,89 @@ def test_api_documents_search_descendants_list_authenticated_public_or_authentic
                 "title": child2.title,
                 "updated_at": child2.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": None,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(user),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_direct,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": parent.get_abilities(user),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_direct,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 3,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": None,
+                    },
+                ],
             },
         ],
     }
@@ -584,6 +1422,35 @@ def test_api_documents_search_descendants_list_authenticated_related_direct():
                 "title": child1.title,
                 "updated_at": child1.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": access.role,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": access.role,
+                    }
+                ],
             },
             {
                 "abilities": grand_child.get_abilities(user),
@@ -607,6 +1474,62 @@ def test_api_documents_search_descendants_list_authenticated_related_direct():
                 "title": grand_child.title,
                 "updated_at": grand_child.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": access.role,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": access.role,
+                    },
+                    {
+                        "abilities": child1.get_abilities(user),
+                        "ancestors_link_reach": child1.ancestors_link_reach,
+                        "ancestors_link_role": child1.ancestors_link_role,
+                        "computed_link_reach": child1.computed_link_reach,
+                        "computed_link_role": child1.computed_link_role,
+                        "created_at": child1.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(child1.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": child1.excerpt,
+                        "id": str(child1.id),
+                        "is_favorite": False,
+                        "link_reach": child1.link_reach,
+                        "link_role": child1.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": 3,
+                        "nb_accesses_direct": 1,
+                        "path": child1.path,
+                        "title": child1.title,
+                        "updated_at": child1.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": access.role,
+                    },
+                ],
             },
             {
                 "abilities": child2.get_abilities(user),
@@ -630,6 +1553,35 @@ def test_api_documents_search_descendants_list_authenticated_related_direct():
                 "title": child2.title,
                 "updated_at": child2.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": access.role,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": access.role,
+                    }
+                ],
             },
         ],
     }
@@ -695,6 +1647,89 @@ def test_api_documents_search_descendants_list_authenticated_related_parent():
                 "title": child1.title,
                 "updated_at": child1.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": grand_parent_access.role,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(user),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_direct,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                    {
+                        "abilities": parent.get_abilities(user),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_direct,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 3,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                ],
             },
             {
                 "abilities": grand_child.get_abilities(user),
@@ -718,6 +1753,116 @@ def test_api_documents_search_descendants_list_authenticated_related_parent():
                 "title": grand_child.title,
                 "updated_at": grand_child.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": grand_parent_access.role,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(user),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_direct,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                    {
+                        "abilities": parent.get_abilities(user),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_direct,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 3,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                    {
+                        "abilities": child1.get_abilities(user),
+                        "ancestors_link_reach": child1.ancestors_link_reach,
+                        "ancestors_link_role": child1.ancestors_link_role,
+                        "computed_link_reach": child1.computed_link_reach,
+                        "computed_link_role": child1.computed_link_role,
+                        "created_at": child1.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(child1.creator.id),
+                        "deleted_at": None,
+                        "depth": 4,
+                        "excerpt": child1.excerpt,
+                        "id": str(child1.id),
+                        "is_favorite": False,
+                        "link_reach": child1.link_reach,
+                        "link_role": child1.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": 2,
+                        "nb_accesses_direct": 1,
+                        "path": child1.path,
+                        "title": child1.title,
+                        "updated_at": child1.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                ],
             },
             {
                 "abilities": child2.get_abilities(user),
@@ -741,6 +1886,89 @@ def test_api_documents_search_descendants_list_authenticated_related_parent():
                 "title": child2.title,
                 "updated_at": child2.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": grand_parent_access.role,
+                "parents": [
+                    {
+                        "abilities": grand_parent.get_abilities(user),
+                        "ancestors_link_reach": grand_parent.ancestors_link_reach,
+                        "ancestors_link_role": grand_parent.ancestors_link_role,
+                        "computed_link_reach": grand_parent.computed_link_reach,
+                        "computed_link_role": grand_parent.computed_link_role,
+                        "created_at": grand_parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(grand_parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": grand_parent.excerpt,
+                        "id": str(grand_parent.id),
+                        "is_favorite": False,
+                        "link_reach": grand_parent.link_reach,
+                        "link_role": grand_parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": grand_parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": grand_parent.nb_accesses_direct,
+                        "path": grand_parent.path,
+                        "title": grand_parent.title,
+                        "updated_at": grand_parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                    {
+                        "abilities": parent.get_abilities(user),
+                        "ancestors_link_reach": parent.ancestors_link_reach,
+                        "ancestors_link_role": parent.ancestors_link_role,
+                        "computed_link_reach": parent.computed_link_reach,
+                        "computed_link_role": parent.computed_link_role,
+                        "created_at": parent.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(parent.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": parent.excerpt,
+                        "id": str(parent.id),
+                        "is_favorite": False,
+                        "link_reach": parent.link_reach,
+                        "link_role": parent.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": parent.nb_accesses_ancestors,
+                        "nb_accesses_direct": parent.nb_accesses_direct,
+                        "path": parent.path,
+                        "title": parent.title,
+                        "updated_at": parent.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 3,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": grand_parent_access.role,
+                    },
+                ],
             },
         ],
     }
@@ -853,6 +2081,35 @@ def test_api_documents_search_descendants_list_authenticated_related_team_member
                 "title": child1.title,
                 "updated_at": child1.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": access.role,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": access.role,
+                    }
+                ],
             },
             {
                 "abilities": grand_child.get_abilities(user),
@@ -876,6 +2133,62 @@ def test_api_documents_search_descendants_list_authenticated_related_team_member
                 "title": grand_child.title,
                 "updated_at": grand_child.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": access.role,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": access.role,
+                    },
+                    {
+                        "abilities": child1.get_abilities(user),
+                        "ancestors_link_reach": child1.ancestors_link_reach,
+                        "ancestors_link_role": child1.ancestors_link_role,
+                        "computed_link_reach": child1.computed_link_reach,
+                        "computed_link_role": child1.computed_link_role,
+                        "created_at": child1.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(child1.creator.id),
+                        "deleted_at": None,
+                        "depth": 2,
+                        "excerpt": child1.excerpt,
+                        "id": str(child1.id),
+                        "is_favorite": False,
+                        "link_reach": child1.link_reach,
+                        "link_role": child1.link_role,
+                        "numchild": 1,
+                        "nb_accesses_ancestors": 1,
+                        "nb_accesses_direct": 0,
+                        "path": child1.path,
+                        "title": child1.title,
+                        "updated_at": child1.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": access.role,
+                    },
+                ],
             },
             {
                 "abilities": child2.get_abilities(user),
@@ -899,6 +2212,35 @@ def test_api_documents_search_descendants_list_authenticated_related_team_member
                 "title": child2.title,
                 "updated_at": child2.updated_at.isoformat().replace("+00:00", "Z"),
                 "user_role": access.role,
+                "parents": [
+                    {
+                        "abilities": document.get_abilities(user),
+                        "ancestors_link_reach": document.ancestors_link_reach,
+                        "ancestors_link_role": document.ancestors_link_role,
+                        "computed_link_reach": document.computed_link_reach,
+                        "computed_link_role": document.computed_link_role,
+                        "created_at": document.created_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "creator": str(document.creator.id),
+                        "deleted_at": None,
+                        "depth": 1,
+                        "excerpt": document.excerpt,
+                        "id": str(document.id),
+                        "is_favorite": False,
+                        "link_reach": document.link_reach,
+                        "link_role": document.link_role,
+                        "numchild": 2,
+                        "nb_accesses_ancestors": document.nb_accesses_ancestors,
+                        "nb_accesses_direct": document.nb_accesses_direct,
+                        "path": document.path,
+                        "title": document.title,
+                        "updated_at": document.updated_at.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "user_role": access.role,
+                    }
+                ],
             },
         ],
     }

--- a/src/backend/core/tests/documents/test_api_documents_search_feature_flag.py
+++ b/src/backend/core/tests/documents/test_api_documents_search_feature_flag.py
@@ -18,13 +18,13 @@ pytestmark = pytest.mark.django_db
 
 
 @responses.activate
-@mock.patch("core.api.viewsets.DocumentViewSet._title_search")
-@mock.patch("core.api.viewsets.DocumentViewSet._search_with_indexer")
+@mock.patch("core.api.viewsets.DocumentViewSet._search_using_database")
+@mock.patch("core.api.viewsets.DocumentViewSet._search_using_indexer")
 @pytest.mark.parametrize(
     "activated_flags,"
     "expected_search_type,"
-    "expected_search_with_indexer_called,"
-    "expected_title_search_called",
+    "expected_search_using_indexer_called,"
+    "expected_search_using_database_called",
     [
         ([], SearchType.TITLE, False, True),
         ([FeatureFlag.FLAG_FIND_HYBRID_SEARCH], SearchType.HYBRID, True, False),
@@ -40,15 +40,15 @@ pytestmark = pytest.mark.django_db
         ([FeatureFlag.FLAG_FIND_FULL_TEXT_SEARCH], SearchType.FULL_TEXT, True, False),
     ],
 )
+@pytest.mark.usefixtures("indexer_settings")
 # pylint: disable=too-many-arguments, too-many-positional-arguments
 def test_api_documents_search_success(  # noqa : PLR0913
-    mock_search_with_indexer,
-    mock_title_search,
+    mock_search_using_indexer,
+    mock_search_using_database,
     activated_flags,
     expected_search_type,
-    expected_search_with_indexer_called,
-    expected_title_search_called,
-    indexer_settings,
+    expected_search_using_indexer_called,
+    expected_search_using_database_called,
 ):
     """
     Test that the API endpoint for searching documents returns a successful response
@@ -57,8 +57,8 @@ def test_api_documents_search_success(  # noqa : PLR0913
     """
     assert get_document_indexer() is not None
 
-    mock_search_with_indexer.return_value = HttpResponse()
-    mock_title_search.return_value = HttpResponse()
+    mock_search_using_indexer.return_value = HttpResponse()
+    mock_search_using_database.return_value = HttpResponse()
 
     with override_flag(
         FeatureFlag.FLAG_FIND_HYBRID_SEARCH,
@@ -74,17 +74,17 @@ def test_api_documents_search_success(  # noqa : PLR0913
 
     assert response.status_code == 200
 
-    if expected_search_with_indexer_called:
-        mock_search_with_indexer.assert_called_once()
+    if expected_search_using_indexer_called:
+        mock_search_using_indexer.assert_called_once()
         assert (
-            mock_search_with_indexer.call_args.kwargs["search_type"]
+            mock_search_using_indexer.call_args.kwargs["search_type"]
             == expected_search_type
         )
     else:
-        assert not mock_search_with_indexer.called
+        assert not mock_search_using_indexer.called
 
-    if expected_title_search_called:
+    if expected_search_using_database_called:
         assert SearchType.TITLE == expected_search_type
-        mock_title_search.assert_called_once()
+        mock_search_using_database.assert_called_once()
     else:
-        assert not mock_title_search.called
+        assert not mock_search_using_database.called


### PR DESCRIPTION
## Purpose

The global search endpoint filtering by title in the database was not
 searching for accessible sub documents. We change the global search is
 made and is now returning accessible sub documents matching the the
 title query.

In the search response, we want to display a breadcrumb for every
document return. For this we added a parents property containing a list
of documents, all are the parents of the current document order by thei
depth. With this we can easily create a breadcrumb.

## Proposal

* [x] (backend) rename DocumentViewset::_title_search in _search_title
* [x] ♻️(backend) allow global search in sub documents
* [x] ♻️(backend) rename SearchDocumentSerializer in SearchQueryParam
* [x] ✨(backend) add a breadcrumb in the search response

Fix #677