### PR TITLE
✨(frontend) add the presenter mode feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - 🔧(backend) allow configuring settings OIDC_OP_USER_ENDPOINT_FORMAT
 - ⚡️(helm) create a dedicated svc and deployment for yprovider converter #2368
 - ✨(backend) allow to leave a document #2365
+- ✨(frontend) add the presenter mode
 - 📈(backend) create a utils to capture event with posthog
 
 ### Changed

--- a/src/frontend/apps/e2e/__tests__/app-impress/presenter-mode.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/presenter-mode.spec.ts
@@ -1,0 +1,307 @@
+import { Page, expect, test } from '@playwright/test';
+
+import { createDoc, goToGridDoc, mockedDocument } from './utils-common';
+import { openSuggestionMenu, writeInEditor } from './utils-editor';
+
+const openPresenter = async (page: Page) => {
+  await page.getByLabel('Open the document options').click();
+  await page.getByRole('menuitem', { name: 'Present' }).click();
+
+  const overlay = page.getByRole('dialog', { name: 'Presenter mode' });
+  await expect(overlay).toBeVisible();
+  return overlay;
+};
+
+const insertDivider = async (page: Page) => {
+  const { suggestionMenu } = await openSuggestionMenu({ page });
+  await suggestionMenu.getByText('Divider', { exact: true }).click();
+};
+
+const writeMultiSlideDoc = async (page: Page) => {
+  const editor = await writeInEditor({ page, text: 'Slide one' });
+  await editor.press('Enter');
+  await insertDivider(page);
+  await editor.press('Enter');
+  await writeInEditor({ page, text: 'Slide two' });
+  await editor.press('Enter');
+  await insertDivider(page);
+  await editor.press('Enter');
+  await writeInEditor({ page, text: 'Slide three' });
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test.describe('Presenter Mode', () => {
+  test('opens the presenter overlay from the doc options menu and closes with Escape', async ({
+    page,
+    browserName,
+  }) => {
+    await createDoc(page, 'presenter-open', browserName, 1);
+    await writeInEditor({ page, text: 'Hello presenter' });
+
+    const overlay = await openPresenter(page);
+
+    await expect(
+      overlay.getByRole('toolbar', { name: 'Presenter controls' }),
+    ).toBeVisible();
+    await expect(overlay.getByText('Hello presenter')).toBeVisible();
+
+    // The presenter calls requestFullscreen on open. usePresenterShortcuts
+    // deliberately ignores Escape while in fullscreen (the browser owns Esc
+    // there to exit). Playwright grants requestFullscreen but, unlike a real
+    // browser, does NOT dispatch a fullscreen exit on Escape — so we must
+    // exit fullscreen ourselves before pressing Escape to test the close
+    // path. We also wait for the React state to settle after the exit so
+    // the keydown listener is re-bound with isFullscreen=false.
+    await page.evaluate(async () => {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      }
+    });
+    await page.waitForFunction(() => document.fullscreenElement === null);
+    await expect(
+      overlay.getByRole('button', { name: 'Enter fullscreen' }),
+    ).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(overlay).toBeHidden();
+  });
+
+  test('moves focus onto the first available control when opened', async ({
+    page,
+    browserName,
+  }) => {
+    await createDoc(page, 'presenter-focus', browserName, 1);
+    await writeMultiSlideDoc(page);
+
+    const overlay = await openPresenter(page);
+
+    // On the first slide, "Previous" is disabled, so focus lands on "Next".
+    await expect(
+      overlay.getByRole('button', { name: 'Next slide' }),
+    ).toBeFocused();
+  });
+
+  test('announces the slide position through a live region and exposes a slide role description', async ({
+    page,
+    browserName,
+  }) => {
+    await createDoc(page, 'presenter-a11y', browserName, 1);
+    await writeMultiSlideDoc(page);
+
+    const overlay = await openPresenter(page);
+
+    // The visible "1 / 3" counter is decorative (aria-hidden); the position is
+    // announced through a polite live region for screen readers instead.
+    const liveRegion = overlay.getByRole('status');
+    await expect(liveRegion).toHaveText('Slide 1 of 3');
+
+    await overlay.getByRole('button', { name: 'Next slide' }).click();
+    await expect(liveRegion).toHaveText('Slide 2 of 3');
+
+    // Each slide advertises a localized role description for screen readers.
+    await expect(overlay.getByRole('group').first()).toHaveAttribute(
+      'aria-roledescription',
+      'slide',
+    );
+  });
+
+  test('renders a single-slide doc with counter 1/1 and disabled nav buttons', async ({
+    page,
+    browserName,
+  }) => {
+    await createDoc(page, 'presenter-single', browserName, 1);
+    await writeInEditor({ page, text: 'Slide A' });
+
+    const overlay = await openPresenter(page);
+
+    await expect(overlay.getByText('1 / 1')).toBeVisible();
+    await expect(
+      overlay.getByRole('button', { name: 'Previous slide' }),
+    ).toBeDisabled();
+    await expect(
+      overlay.getByRole('button', { name: 'Next slide' }),
+    ).toBeDisabled();
+    await expect(overlay.getByText('Slide A')).toBeVisible();
+
+    await overlay.getByRole('button', { name: 'Close presenter' }).click();
+    await expect(overlay).toBeHidden();
+  });
+
+  test('navigates between slides via the floating bar buttons', async ({
+    page,
+    browserName,
+  }) => {
+    await createDoc(page, 'presenter-nav-bar', browserName, 1);
+    await writeMultiSlideDoc(page);
+
+    const overlay = await openPresenter(page);
+
+    const prev = overlay.getByRole('button', { name: 'Previous slide' });
+    const next = overlay.getByRole('button', { name: 'Next slide' });
+
+    await expect(overlay.getByText('1 / 3')).toBeVisible();
+    await expect(overlay.getByText('Slide one')).toBeVisible();
+    await expect(prev).toBeDisabled();
+    await expect(next).toBeEnabled();
+
+    await next.click();
+    await expect(overlay.getByText('2 / 3')).toBeVisible();
+    await expect(overlay.getByText('Slide two')).toBeVisible();
+
+    await next.click();
+    await expect(overlay.getByText('3 / 3')).toBeVisible();
+    await expect(overlay.getByText('Slide three')).toBeVisible();
+    await expect(next).toBeDisabled();
+    await expect(prev).toBeEnabled();
+
+    await prev.click();
+    await expect(overlay.getByText('2 / 3')).toBeVisible();
+    await expect(overlay.getByText('Slide two')).toBeVisible();
+  });
+
+  test('navigates between slides via keyboard shortcuts', async ({
+    page,
+    browserName,
+  }) => {
+    await createDoc(page, 'presenter-nav-keyboard', browserName, 1);
+    await writeMultiSlideDoc(page);
+
+    const overlay = await openPresenter(page);
+
+    await expect(overlay.getByText('1 / 3')).toBeVisible();
+
+    await page.keyboard.press('ArrowRight');
+    await expect(overlay.getByText('2 / 3')).toBeVisible();
+
+    await page.keyboard.press('End');
+    await expect(overlay.getByText('3 / 3')).toBeVisible();
+
+    await page.keyboard.press('Home');
+    await expect(overlay.getByText('1 / 3')).toBeVisible();
+
+    // ArrowLeft on the first slide is clamped — counter stays at 1 / 3.
+    await page.keyboard.press('ArrowLeft');
+    await expect(overlay.getByText('1 / 3')).toBeVisible();
+  });
+
+  test('scales each slide to fit the viewport (outer width = 900 × scale)', async ({
+    page,
+    browserName,
+  }) => {
+    await createDoc(page, 'presenter-scaling', browserName, 1);
+    await writeInEditor({ page, text: 'A short slide' });
+
+    const overlay = await openPresenter(page);
+    const currentSlide = overlay.getByRole('group').filter({ hasNotText: '' });
+    await expect(currentSlide.first()).toBeVisible();
+
+    const dims = await currentSlide.first().evaluate((el) => {
+      // DOM: <outer role="group"><stage><inner (scaled)>...
+      const stage = el.firstElementChild as HTMLElement | null;
+      const inner = stage?.firstElementChild as HTMLElement | null;
+      const innerStyle = inner ? getComputedStyle(inner) : null;
+      return {
+        outerWidth: el.getBoundingClientRect().width,
+        innerTransform: innerStyle?.transform ?? 'none',
+      };
+    });
+
+    // Inner has `transform: scale(<n>)`; match the first scale matrix value.
+    const m = /matrix\(([-\d.]+)/.exec(dims.innerTransform);
+    expect(
+      m,
+      `expected a scale matrix, got: ${dims.innerTransform}`,
+    ).not.toBeNull();
+
+    const scale = m ? parseFloat(m[1]) : NaN;
+
+    // Scale is always clamped to [MIN_SCALE, MAX_SCALE] = [0.7, 1.5].
+    // The exact value depends on viewport: sparse content typically saturates
+    // the height-based scale (→ MAX), but at default Playwright viewport
+    // (1280) the width path can constrain to scaleW = (1280 - 2*paddingX)/900.
+    // We assert the bounds, not a specific value.
+    expect(scale).toBeGreaterThanOrEqual(0.7);
+    expect(scale).toBeLessThanOrEqual(1.5);
+
+    // The core invariant: outer width = DESIGN_WIDTH (900) × scale,
+    // within a 5px tolerance for sub-pixel rounding.
+    expect(Math.abs(dims.outerWidth - 900 * scale)).toBeLessThan(5);
+  });
+
+  test('tall slide produces a vertical scrollbar on the outer wrapper with the top visible', async ({
+    page,
+    browserName,
+  }) => {
+    await createDoc(page, 'presenter-tall', browserName, 1);
+
+    // Build a tall single-slide doc: many headings + paragraphs so the
+    // natural content height blows past viewport height at MIN_SCALE.
+    const editor = await writeInEditor({ page, text: 'TOP MARKER' });
+    for (let i = 0; i < 40; i += 1) {
+      await editor.press('Enter');
+      await editor.pressSequentially(`Filler line ${i} to make the slide tall`);
+    }
+
+    const overlay = await openPresenter(page);
+    const slide = overlay.getByRole('group').filter({ hasNotText: '' }).first();
+    await expect(slide).toBeVisible();
+
+    // The first block ('TOP MARKER') must be at y=0 of the slide wrapper
+    // (i.e. visible at the top, not clipped). This is the regression we fix.
+    const topVisible = await slide.evaluate((el) => {
+      el.scrollTop = 0;
+      const first = el.querySelector('.bn-block-content');
+      if (!first) {
+        return { ok: false, reason: 'no first block' };
+      }
+      const slideRect = el.getBoundingClientRect();
+      const blockRect = first.getBoundingClientRect();
+      return {
+        ok: blockRect.top >= slideRect.top - 1,
+        slideTop: slideRect.top,
+        blockTop: blockRect.top,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+      };
+    });
+
+    expect(topVisible.ok, JSON.stringify(topVisible)).toBe(true);
+    expect(topVisible.scrollHeight ?? 0).toBeGreaterThan(
+      topVisible.clientHeight ?? 0,
+    );
+  });
+});
+
+test.describe('Presenter Mode mobile', () => {
+  test.use({ viewport: { width: 500, height: 1200 } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('hides the Present option on small mobile viewports', async ({
+    page,
+  }) => {
+    await mockedDocument(page, {
+      abilities: {
+        destroy: true,
+        link_configuration: true,
+        versions_destroy: true,
+        versions_list: true,
+        versions_retrieve: true,
+        accesses_manage: true,
+        accesses_view: true,
+        update: true,
+        partial_update: true,
+        retrieve: true,
+      },
+    });
+
+    await goToGridDoc(page);
+
+    await page.getByLabel('Open the document options').click();
+    await expect(page.getByRole('menuitem', { name: 'Present' })).toBeHidden();
+  });
+});

--- a/src/frontend/apps/impress/package.json
+++ b/src/frontend/apps/impress/package.json
@@ -42,7 +42,7 @@
     "@fontsource/material-icons": "5.2.7",
     "@gouvfr-lasuite/cunningham-react": "4.3.0",
     "@gouvfr-lasuite/integration": "1.0.3",
-    "@gouvfr-lasuite/ui-kit": "0.23.1",
+    "@gouvfr-lasuite/ui-kit": "0.23.2",
     "@hocuspocus/provider": "3.4.4",
     "@mantine/core": "9.2.1",
     "@mantine/hooks": "9.2.1",

--- a/src/frontend/apps/impress/src/components/modal/SideModal.tsx
+++ b/src/frontend/apps/impress/src/components/modal/SideModal.tsx
@@ -1,5 +1,9 @@
-import { Modal, ModalSize } from '@gouvfr-lasuite/cunningham-react';
-import { ComponentPropsWithRef, PropsWithChildren } from 'react';
+import {
+  Modal,
+  ModalDefaultVariantProps,
+  ModalSize,
+} from '@gouvfr-lasuite/cunningham-react';
+import { PropsWithChildren } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
 interface SideModalStyleProps {
@@ -35,7 +39,7 @@ const SideModalStyle = createGlobalStyle<SideModalStyleProps>`
   }
 `;
 
-type SideModalType = Omit<ComponentPropsWithRef<typeof Modal>, 'size'>;
+type SideModalType = Omit<ModalDefaultVariantProps, 'size'>;
 
 type SideModalProps = SideModalType & Partial<SideModalStyleProps>;
 

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
@@ -1,9 +1,10 @@
 import { Button, useModal } from '@gouvfr-lasuite/cunningham-react';
 import {
   DropdownMenu,
-  DropdownMenuOption,
+  DropdownMenuItem,
   useTreeContext,
 } from '@gouvfr-lasuite/ui-kit';
+import { Present } from '@gouvfr-lasuite/ui-kit/icons';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
@@ -70,6 +71,14 @@ const ModalExport =
       )
     : null;
 
+const PresenterOverlay = dynamic(
+  () =>
+    import('@/docs/doc-presenter').then((mod) => ({
+      default: mod.PresenterOverlay,
+    })),
+  { ssr: false },
+);
+
 interface DocToolBoxProps {
   doc: Doc;
 }
@@ -81,11 +90,11 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
   const { isTopRoot } = useDocUtils(doc);
   const { authenticated } = useAuth();
   const copyCurrentEditorToClipboard = useCopyCurrentEditorToClipboard();
-
   const [openDropdown, setOpenDropdown] = useState(false);
   const [isModalRemoveOpen, setIsModalRemoveOpen] = useState(false);
   const [isModalExportOpen, setIsModalExportOpen] = useState(false);
   const shareModal = useModal();
+  const [isPresenterOpen, setIsPresenterOpen] = useState(false);
   const selectHistoryModal = useModal();
 
   const { restoreFocus } = useFocusStore();
@@ -103,7 +112,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     listInvalidQueries: [KEY_LIST_DOC, KEY_DOC, KEY_LIST_FAVORITE_DOC],
   });
 
-  const options: DropdownMenuOption[] = [
+  const options: DropdownMenuItem[] = [
     {
       label: doc.is_favorite ? t('Unpin') : t('Pin'),
       icon: doc.is_favorite ? (
@@ -120,7 +129,16 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
       },
       isHidden: !doc.abilities.favorite,
       testId: `docs-actions-${doc.is_favorite ? 'unpin' : 'pin'}-${doc.id}`,
-      showSeparator: true,
+    },
+    { type: 'separator' },
+    {
+      label: t('Present'),
+      icon: <Present width={24} height={24} aria-hidden="true" />,
+      callback: () => {
+        setIsPresenterOpen(true);
+      },
+      isHidden: Boolean(doc.deleted_at) || isMobile,
+      testId: `docs-actions-present-${doc.id}`,
     },
     {
       label: t('Copy link'),
@@ -258,6 +276,16 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
           }}
           doc={doc}
           isRootDoc={treeContext?.root?.id === doc.id}
+        />
+      )}
+
+      {isPresenterOpen && (
+        <PresenterOverlay
+          doc={doc}
+          onClose={() => {
+            setIsPresenterOpen(false);
+            restoreFocus();
+          }}
         />
       )}
     </>

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/useBrowserFullscreen.spec.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/useBrowserFullscreen.spec.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useBrowserFullscreen } from '../hooks/useBrowserFullscreen';
+
+describe('useBrowserFullscreen', () => {
+  let fullscreenElement: Element | null = null;
+  const requestFullscreen = vi.fn(async () => {
+    fullscreenElement = document.documentElement;
+    document.dispatchEvent(new Event('fullscreenchange'));
+  });
+  const exitFullscreen = vi.fn(async () => {
+    fullscreenElement = null;
+    document.dispatchEvent(new Event('fullscreenchange'));
+  });
+
+  beforeEach(() => {
+    fullscreenElement = null;
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    });
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: requestFullscreen,
+    });
+    Object.defineProperty(document, 'exitFullscreen', {
+      configurable: true,
+      value: exitFullscreen,
+    });
+    requestFullscreen.mockClear();
+    exitFullscreen.mockClear();
+  });
+
+  afterEach(() => {
+    fullscreenElement = null;
+  });
+
+  test('initial state reflects current fullscreen state', () => {
+    const { result } = renderHook(() => useBrowserFullscreen());
+    expect(result.current.isFullscreen).toBe(false);
+  });
+
+  test('enter() requests fullscreen and updates state', async () => {
+    const { result } = renderHook(() => useBrowserFullscreen());
+    await act(async () => {
+      await result.current.enter();
+    });
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(result.current.isFullscreen).toBe(true);
+  });
+
+  test('enter() is a no-op if already fullscreen', async () => {
+    fullscreenElement = document.documentElement;
+    const { result } = renderHook(() => useBrowserFullscreen());
+    await act(async () => {
+      await result.current.enter();
+    });
+    expect(requestFullscreen).not.toHaveBeenCalled();
+  });
+
+  test('exit() leaves fullscreen and updates state', async () => {
+    const { result } = renderHook(() => useBrowserFullscreen());
+    await act(async () => {
+      await result.current.enter();
+    });
+    await act(async () => {
+      await result.current.exit();
+    });
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+    expect(result.current.isFullscreen).toBe(false);
+  });
+
+  test('toggle() flips state', async () => {
+    const { result } = renderHook(() => useBrowserFullscreen());
+    await act(async () => {
+      await result.current.toggle();
+    });
+    expect(result.current.isFullscreen).toBe(true);
+    await act(async () => {
+      await result.current.toggle();
+    });
+    expect(result.current.isFullscreen).toBe(false);
+  });
+
+  test('reacts to external fullscreenchange events', () => {
+    const { result } = renderHook(() => useBrowserFullscreen());
+    act(() => {
+      fullscreenElement = document.documentElement;
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+    expect(result.current.isFullscreen).toBe(true);
+  });
+
+  test('exitIfOwned() exits when we initiated the fullscreen', async () => {
+    const { result } = renderHook(() => useBrowserFullscreen());
+    await act(async () => {
+      await result.current.enter();
+    });
+    await act(async () => {
+      await result.current.exitIfOwned();
+    });
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  test('exitIfOwned() is a no-op when fullscreen pre-exists', async () => {
+    fullscreenElement = document.documentElement;
+    const { result } = renderHook(() => useBrowserFullscreen());
+    await act(async () => {
+      await result.current.exitIfOwned();
+    });
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  test('exitIfOwned() is a no-op after user exits fullscreen externally', async () => {
+    const { result } = renderHook(() => useBrowserFullscreen());
+    await act(async () => {
+      await result.current.enter();
+    });
+    // User presses Esc — fullscreen ends outside of our control.
+    act(() => {
+      fullscreenElement = null;
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+    await act(async () => {
+      await result.current.exitIfOwned();
+    });
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/useFitScale.spec.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/useFitScale.spec.ts
@@ -1,0 +1,220 @@
+import { act, renderHook } from '@testing-library/react';
+import { RefObject } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { computeFitScale, useFitScale } from '../hooks/useFitScale';
+
+// Live constants the pure function closes over (see constants.ts):
+// designWidth=900, minScale=0.7, maxScale=1.5, paddingX=64, paddingY=64.
+// So availW = frameWidth - 128 and availH = frameHeight - 128.
+describe('computeFitScale', () => {
+  // Short content: scaleW/scaleH both large, clamped down to MAX.
+  test('short content clamps to MAX scale', () => {
+    // availW=1792, availH=952; scaleW=1.99, scaleH=4.76 -> min 1.99 -> clamp 1.5
+    const fit = computeFitScale(200, 1920, 1080);
+    expect(fit).not.toBeNull();
+    expect(fit?.scale).toBeCloseTo(1.5, 5);
+    expect(fit?.outerWidth).toBeCloseTo(900 * 1.5, 5);
+    expect(fit?.stageHeight).toBeCloseTo(300, 5);
+  });
+
+  // Tall content: scaleH tiny, clamped up to MIN. The slide then overflows and
+  // scrolls — handled purely in CSS (PresenterSlide's outer is
+  // overflow-y:auto, the stage uses margin:auto so the top is never clipped).
+  test('tall content floors at MIN scale', () => {
+    // availH=952, naturalH=3000 -> scaleH=0.317 -> clamp 0.7; 3000 × 0.7 = 2100
+    const fit = computeFitScale(3000, 1920, 1080);
+    expect(fit?.scale).toBeCloseTo(0.7, 5);
+    expect(fit?.stageHeight).toBeCloseTo(2100, 5);
+  });
+
+  // Height-limited exact fit: naturalH equals availH, scaleH=1.0 wins.
+  test('content that exactly fits picks scaleH', () => {
+    // availH=952, naturalH=952 -> scaleH=1.0, scaleW=1.99 -> min 1.0
+    const fit = computeFitScale(952, 1920, 1080);
+    expect(fit?.scale).toBeCloseTo(1.0, 5);
+    expect(fit?.stageHeight).toBeCloseTo(952, 5);
+  });
+
+  test('width-limited frame below MIN clamps up to MIN', () => {
+    // availW=572 -> scaleW=0.635 < 0.7 -> clamp up to 0.7
+    const fit = computeFitScale(400, 700, 1080);
+    expect(fit?.scale).toBeCloseTo(0.7, 5);
+  });
+
+  test('width-limited frame within range picks scaleW', () => {
+    // availW=872 -> scaleW=872/900=0.969; availH=1372 -> scaleH=3.43 -> min 0.969
+    const fit = computeFitScale(400, 1000, 1500);
+    expect(fit?.scale).toBeCloseTo(872 / 900, 5);
+  });
+
+  test('returns null on non-positive dimensions', () => {
+    expect(computeFitScale(0, 1920, 1080)).toBeNull(); // no content height yet
+    expect(computeFitScale(500, 100, 1080)).toBeNull(); // availW = 100 - 128 <= 0
+    expect(computeFitScale(500, 1920, 100)).toBeNull(); // availH = 100 - 128 <= 0
+  });
+});
+
+type Callback = ResizeObserverCallback;
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  callback: Callback;
+  targets: Element[] = [];
+
+  constructor(callback: Callback) {
+    this.callback = callback;
+    FakeResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.targets.push(target);
+  }
+
+  unobserve(target: Element): void {
+    this.targets = this.targets.filter((t) => t !== target);
+  }
+
+  disconnect(): void {
+    this.targets = [];
+  }
+
+  trigger(): void {
+    this.callback([], this);
+  }
+}
+
+const triggerAll = () => {
+  for (const o of FakeResizeObserver.instances) {
+    o.trigger();
+  }
+};
+
+const makeRefs = (
+  innerScrollHeight: number,
+  frameClientWidth: number,
+  frameClientHeight: number,
+) => {
+  const inner = document.createElement('div');
+  const frame = document.createElement('div');
+  Object.defineProperty(inner, 'scrollHeight', {
+    configurable: true,
+    get: () => innerScrollHeight,
+  });
+  Object.defineProperty(frame, 'clientWidth', {
+    configurable: true,
+    get: () => frameClientWidth,
+  });
+  Object.defineProperty(frame, 'clientHeight', {
+    configurable: true,
+    get: () => frameClientHeight,
+  });
+  document.body.appendChild(inner);
+  document.body.appendChild(frame);
+  return {
+    inner,
+    frame,
+    innerRef: { current: inner } as RefObject<HTMLDivElement | null>,
+    frameRef: { current: frame } as RefObject<HTMLDivElement | null>,
+    setInnerScrollHeight: (h: number) => {
+      Object.defineProperty(inner, 'scrollHeight', {
+        configurable: true,
+        get: () => h,
+      });
+    },
+    setFrameSize: (w: number, h: number) => {
+      Object.defineProperty(frame, 'clientWidth', {
+        configurable: true,
+        get: () => w,
+      });
+      Object.defineProperty(frame, 'clientHeight', {
+        configurable: true,
+        get: () => h,
+      });
+    },
+  };
+};
+
+// Thin glue tests: the formula is covered above, so these only assert the
+// wiring (initial measure, re-measure on either resize, SSR safety, cleanup).
+// No rAF: measure() runs synchronously inside the effect and the observer
+// callback, so there is nothing async to flush.
+describe('useFitScale', () => {
+  beforeEach(() => {
+    FakeResizeObserver.instances = [];
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  test('measures synchronously on mount', () => {
+    const refs = makeRefs(500, 1920, 1080);
+    const { result } = renderHook(() =>
+      useFitScale(refs.innerRef, refs.frameRef),
+    );
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.scale).toBeCloseTo(
+      computeFitScale(500, 1920, 1080)!.scale,
+      5,
+    );
+  });
+
+  test('frame resize triggers a new computation', () => {
+    const refs = makeRefs(500, 1920, 1080);
+    const { result } = renderHook(() =>
+      useFitScale(refs.innerRef, refs.frameRef),
+    );
+
+    const initialScale = result.current?.scale;
+    expect(initialScale).not.toBeUndefined();
+
+    refs.setFrameSize(1280, 720);
+    act(() => triggerAll());
+
+    expect(result.current?.scale).not.toBe(initialScale);
+  });
+
+  test('inner resize (content grew) triggers a new computation', () => {
+    const refs = makeRefs(500, 1920, 1080);
+    const { result } = renderHook(() =>
+      useFitScale(refs.innerRef, refs.frameRef),
+    );
+
+    const initialScale = result.current?.scale;
+
+    refs.setInnerScrollHeight(2500);
+    act(() => triggerAll());
+
+    expect(result.current?.scale).not.toBe(initialScale);
+    expect(result.current?.scale).toBeCloseTo(0.7, 5);
+  });
+
+  test('stays null and does not throw without ResizeObserver (SSR)', () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+    const refs = makeRefs(500, 1920, 1080);
+    const { result } = renderHook(() =>
+      useFitScale(refs.innerRef, refs.frameRef),
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  test('cleanup on unmount disconnects observers', () => {
+    const refs = makeRefs(500, 1920, 1080);
+    const { unmount } = renderHook(() =>
+      useFitScale(refs.innerRef, refs.frameRef),
+    );
+
+    expect(FakeResizeObserver.instances).toHaveLength(1);
+    const observer = FakeResizeObserver.instances[0];
+    expect(observer.targets).toHaveLength(2);
+
+    unmount();
+
+    expect(observer.targets).toHaveLength(0);
+  });
+});

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/usePresenterShortcuts.spec.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/usePresenterShortcuts.spec.ts
@@ -1,0 +1,109 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { usePresenterShortcuts } from '../hooks/usePresenterShortcuts';
+
+const renderShortcuts = (
+  overrides: Partial<Parameters<typeof usePresenterShortcuts>[0]> = {},
+) => {
+  const handlers = {
+    onPrev: vi.fn(),
+    onNext: vi.fn(),
+    onFirst: vi.fn(),
+    onLast: vi.fn(),
+    onToggleFullscreen: vi.fn(),
+    onClose: vi.fn(),
+    isFullscreen: false,
+    ...overrides,
+  };
+  renderHook(() => usePresenterShortcuts(handlers));
+  return handlers;
+};
+
+const press = (init: KeyboardEventInit) => {
+  const event = new KeyboardEvent('keydown', { ...init, cancelable: true });
+  window.dispatchEvent(event);
+  return event;
+};
+
+describe('usePresenterShortcuts', () => {
+  test('ArrowLeft and PageUp call onPrev', () => {
+    const h = renderShortcuts();
+    press({ code: 'ArrowLeft' });
+    press({ code: 'PageUp' });
+    expect(h.onPrev).toHaveBeenCalledTimes(2);
+  });
+
+  test('ArrowRight, PageDown and Space call onNext', () => {
+    const h = renderShortcuts();
+    press({ code: 'ArrowRight' });
+    press({ code: 'PageDown' });
+    press({ code: 'Space' });
+    expect(h.onNext).toHaveBeenCalledTimes(3);
+  });
+
+  test('Home calls onFirst, End calls onLast', () => {
+    const h = renderShortcuts();
+    press({ code: 'Home' });
+    press({ code: 'End' });
+    expect(h.onFirst).toHaveBeenCalledTimes(1);
+    expect(h.onLast).toHaveBeenCalledTimes(1);
+  });
+
+  test('KeyF toggles fullscreen but ignores modifiers', () => {
+    const h = renderShortcuts();
+    press({ code: 'KeyF' });
+    press({ code: 'KeyF', metaKey: true });
+    press({ code: 'KeyF', ctrlKey: true });
+    expect(h.onToggleFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  test('Escape calls onClose only when not fullscreen', () => {
+    const h1 = renderShortcuts({ isFullscreen: false });
+    press({ code: 'Escape' });
+    expect(h1.onClose).toHaveBeenCalledTimes(1);
+
+    const h2 = renderShortcuts({ isFullscreen: true });
+    press({ code: 'Escape' });
+    expect(h2.onClose).not.toHaveBeenCalled();
+  });
+
+  test('Space prevents default to avoid page scroll', () => {
+    renderShortcuts();
+    const event = press({ code: 'Space' });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('Arrow keys prevent default', () => {
+    renderShortcuts();
+    expect(press({ code: 'ArrowLeft' }).defaultPrevented).toBe(true);
+    expect(press({ code: 'ArrowRight' }).defaultPrevented).toBe(true);
+  });
+
+  test('non-arrow repeat events are ignored', () => {
+    const h = renderShortcuts();
+    press({ code: 'Space', repeat: true });
+    expect(h.onNext).not.toHaveBeenCalled();
+  });
+
+  test('arrow repeat events are accepted', () => {
+    const h = renderShortcuts();
+    press({ code: 'ArrowRight', repeat: true });
+    expect(h.onNext).toHaveBeenCalledTimes(1);
+  });
+
+  test('Space on a button is ignored to avoid native click double-trigger', () => {
+    const h = renderShortcuts();
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    button.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        code: 'Space',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(h.onNext).not.toHaveBeenCalled();
+    document.body.removeChild(button);
+  });
+});

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/useSlides.spec.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/useSlides.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest';
+
+import { splitBlocksIntoSlides } from '../hooks/useSlides';
+
+const para = (text = 'hello') => ({
+  type: 'paragraph',
+  content: text === '' ? [] : [{ type: 'text', text }],
+});
+const divider = () => ({ type: 'divider' });
+const image = () => ({ type: 'image', props: { url: 'x' } });
+
+describe('splitBlocksIntoSlides', () => {
+  test('no divider yields one slide', () => {
+    const result = splitBlocksIntoSlides([para('a'), para('b')]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(2);
+  });
+
+  test('one divider yields two slides', () => {
+    const result = splitBlocksIntoSlides([para('a'), divider(), para('b')]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveLength(1);
+    expect(result[1]).toHaveLength(1);
+  });
+
+  test('leading divider does not produce an empty slide', () => {
+    const result = splitBlocksIntoSlides([divider(), para('a')]);
+    expect(result).toHaveLength(1);
+  });
+
+  test('trailing divider does not produce an empty slide', () => {
+    const result = splitBlocksIntoSlides([para('a'), divider()]);
+    expect(result).toHaveLength(1);
+  });
+
+  test('consecutive dividers do not produce empty slides', () => {
+    const result = splitBlocksIntoSlides([
+      para('a'),
+      divider(),
+      divider(),
+      divider(),
+      para('b'),
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  test('empty doc yields one empty slide', () => {
+    const result = splitBlocksIntoSlides([]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(0);
+  });
+
+  test('divider-only doc yields one empty slide', () => {
+    const result = splitBlocksIntoSlides([divider(), divider()]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(0);
+  });
+
+  test('empty paragraphs are preserved as intentional spacing', () => {
+    const result = splitBlocksIntoSlides([
+      para('a'),
+      divider(),
+      para(''),
+      para('   '),
+      divider(),
+      para('b'),
+    ]);
+    expect(result).toHaveLength(3);
+    expect(result[0][0]).toMatchObject({ content: [{ text: 'a' }] });
+    expect(result[1]).toHaveLength(2);
+    expect(result[2][0]).toMatchObject({ content: [{ text: 'b' }] });
+  });
+
+  test('blocks within a group are kept verbatim, empty or not', () => {
+    const result = splitBlocksIntoSlides([para(''), para('hi'), para('   ')]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(3);
+    expect(result[0][1]).toMatchObject({ content: [{ text: 'hi' }] });
+  });
+
+  test('image-only group is kept', () => {
+    const result = splitBlocksIntoSlides([para('a'), divider(), image()]);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toHaveLength(1);
+  });
+});

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
@@ -1,0 +1,140 @@
+import { Button } from '@gouvfr-lasuite/cunningham-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Maximize,
+  Minimize,
+  XMark,
+} from '@gouvfr-lasuite/ui-kit/icons';
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { css } from 'styled-components';
+
+import { Box, Text } from '@/components';
+
+interface PresenterFloatingBarProps {
+  index: number;
+  total: number;
+  isFullscreen: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onToggleFullscreen: () => void;
+  onClose: () => void;
+}
+
+const barCss = css`
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+  flex-direction: row !important;
+  align-items: center;
+  gap: 0.25rem;
+  padding: var(--c--globals--spacings--3xs, 4px);
+  border-radius: 8px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: var(--c--contextuals--content--semantic--neutral--secondary);
+  border: 1px solid var(--c--contextuals--border--surface--primary);
+  background: var(--c--contextuals--background--surface--primary);
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.05);
+`;
+
+const separatorCss = css`
+  width: 1px;
+  height: 1.25rem;
+  background: var(--c--theme--colors--greyscale-200, #e5e5e5);
+  margin: 0 0.25rem;
+`;
+
+export const PresenterFloatingBar = ({
+  index,
+  total,
+  isFullscreen,
+  onPrev,
+  onNext,
+  onToggleFullscreen,
+  onClose,
+}: PresenterFloatingBarProps) => {
+  const { t } = useTranslation();
+  const isFirst = index <= 0;
+  const isLast = index >= total - 1;
+
+  // Move focus into the dialog on open so keyboard users land on the
+  // controls (an ARIA dialog must move focus inside itself; here on the
+  // first enabled toolbar button — "Next", since "Previous" is disabled on
+  // the first slide). The rAF wins the race against the dropdown's async
+  // focus restoration — same pattern as ModalRemoveDoc.
+  const barRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      barRef.current
+        ?.querySelector<HTMLButtonElement>('button:not([disabled])')
+        ?.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  return (
+    <Box
+      ref={barRef}
+      $direction="row"
+      $align="center"
+      $css={barCss}
+      role="toolbar"
+      aria-label={t('Presenter controls')}
+    >
+      <Button
+        size="small"
+        color="neutral"
+        variant="tertiary"
+        disabled={isFirst}
+        onClick={onPrev}
+        aria-label={t('Previous slide')}
+        icon={<ChevronLeft />}
+      />
+      <Text as="span" $size="sm" $color="neutral" aria-hidden="true">
+        {index + 1} / {total}
+      </Text>
+      <Text
+        as="span"
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {t('Slide {{current}} of {{total}}', {
+          current: index + 1,
+          total,
+        })}
+      </Text>
+      <Button
+        size="small"
+        color="neutral"
+        variant="tertiary"
+        disabled={isLast}
+        onClick={onNext}
+        aria-label={t('Next slide')}
+        icon={<ChevronRight />}
+      />
+      <Box $css={separatorCss} aria-hidden />
+      <Button
+        size="small"
+        color="neutral"
+        variant="tertiary"
+        onClick={onToggleFullscreen}
+        aria-label={isFullscreen ? t('Exit fullscreen') : t('Enter fullscreen')}
+        icon={isFullscreen ? <Minimize /> : <Maximize />}
+      />
+      <Button
+        size="small"
+        color="neutral"
+        variant="tertiary"
+        onClick={onClose}
+        aria-label={t('Close presenter')}
+        icon={<XMark />}
+      />
+    </Box>
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { css } from 'styled-components';
+
+import { Box } from '@/components';
+import { useEditorStore } from '@/docs/doc-editor/stores';
+import { Doc } from '@/docs/doc-management';
+
+import { PRESENTER_WINDOW_RADIUS } from '../constants';
+import { useBrowserFullscreen } from '../hooks/useBrowserFullscreen';
+import { usePresenterShortcuts } from '../hooks/usePresenterShortcuts';
+import { useSlides } from '../hooks/useSlides';
+
+import { PresenterFloatingBar } from './PresenterFloatingBar';
+import { PresenterSlide } from './PresenterSlide';
+
+interface PresenterOverlayProps {
+  doc: Doc;
+  onClose: () => void;
+}
+
+const overlayCss = css`
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: white;
+  display: flex;
+  flex-direction: column;
+`;
+
+const slideAreaCss = css`
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: white;
+`;
+
+export const PresenterOverlay = ({
+  doc: _doc,
+  onClose,
+}: PresenterOverlayProps) => {
+  const { t } = useTranslation();
+  const editor = useEditorStore((state) => state.editor);
+
+  // Snapshot the editor's blocks once at mount. Subsequent collaborator
+  // edits do not affect the ongoing presentation (by design).
+  const snapshotRef = useRef<unknown[] | null>(null);
+  if (snapshotRef.current === null) {
+    snapshotRef.current = editor ? [...editor.document] : [];
+  }
+  const snapshotBlocks = snapshotRef.current;
+
+  const slides = useSlides(snapshotBlocks as { type: string }[]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const total = slides.length;
+  const clamp = useCallback(
+    (i: number) => Math.max(0, Math.min(i, total - 1)),
+    [total],
+  );
+
+  const goPrev = useCallback(
+    () => setCurrentIndex((i) => clamp(i - 1)),
+    [clamp],
+  );
+  const goNext = useCallback(
+    () => setCurrentIndex((i) => clamp(i + 1)),
+    [clamp],
+  );
+  const goFirst = useCallback(() => setCurrentIndex(0), []);
+  const goLast = useCallback(
+    () => setCurrentIndex(clamp(total - 1)),
+    [clamp, total],
+  );
+
+  const { isFullscreen, enter, exitIfOwned, toggle } = useBrowserFullscreen();
+
+  useEffect(() => {
+    void enter();
+    return () => {
+      void exitIfOwned();
+    };
+  }, [enter, exitIfOwned]);
+
+  usePresenterShortcuts({
+    onPrev: goPrev,
+    onNext: goNext,
+    onFirst: goFirst,
+    onLast: goLast,
+    onToggleFullscreen: () => void toggle(),
+    onClose,
+    isFullscreen,
+  });
+
+  const mountedIndices = useMemo(() => {
+    const from = Math.max(0, currentIndex - PRESENTER_WINDOW_RADIUS);
+    const to = Math.min(total - 1, currentIndex + PRESENTER_WINDOW_RADIUS);
+    const indices: number[] = [];
+    for (let i = from; i <= to; i += 1) {
+      indices.push(i);
+    }
+    return indices;
+  }, [currentIndex, total]);
+
+  const frameRef = useRef<HTMLDivElement>(null);
+
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(
+    <Box
+      $css={overlayCss}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('Presenter mode')}
+    >
+      <Box ref={frameRef} $css={slideAreaCss}>
+        {mountedIndices.map((i) => (
+          <PresenterSlide
+            key={i}
+            blocks={slides[i] as unknown[]}
+            frameRef={frameRef}
+            isCurrent={i === currentIndex}
+            ariaLabel={t('Slide {{current}} of {{total}}', {
+              current: i + 1,
+              total,
+            })}
+          />
+        ))}
+      </Box>
+
+      <PresenterFloatingBar
+        index={currentIndex}
+        total={total}
+        isFullscreen={isFullscreen}
+        onPrev={goPrev}
+        onNext={goNext}
+        onToggleFullscreen={() => void toggle()}
+        onClose={onClose}
+      />
+    </Box>,
+    document.body,
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterSlide.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterSlide.tsx
@@ -1,0 +1,139 @@
+import { BlockNoteView } from '@blocknote/mantine';
+import { useCreateBlockNote } from '@blocknote/react';
+import { RefObject, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { css } from 'styled-components';
+
+import { Box } from '@/components';
+import { blockNoteSchema } from '@/docs/doc-editor/components/BlockNoteEditor';
+
+import {
+  PRESENTER_FRAME_PADDING_Y,
+  PRESENTER_SLIDE_DESIGN_WIDTH,
+  PRESENTER_SLIDE_FADE_MS,
+} from '../constants';
+import { useFitScale } from '../hooks/useFitScale';
+
+interface PresenterSlideProps {
+  blocks: unknown[];
+  frameRef: RefObject<HTMLDivElement | null>;
+  isCurrent: boolean;
+  ariaLabel?: string;
+}
+
+// Outer is the scroll container. It always spans the full frame height so the
+// content can scroll all the way to the visual top/bottom of the viewport when
+// the user drags the scrollbar. The top/bottom padding provides the breathing
+// room at rest (scrollTop = 0 shows the content offset by paddingY); when the
+// user scrolls, the padding scrolls off with the content (classic scroll-padding
+// behaviour you get for free from padding on a scroll container).
+//
+// We use display: flex + margin: auto on the stage to centre vertically when
+// the content fits, while still allowing the stage to overflow (and scroll)
+// when it doesn't fit — a well-known CSS idiom (`align-items: center` would
+// instead clip the overflowing top).
+const outerCss = css`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  height: 100%;
+  box-sizing: border-box;
+  padding-top: ${PRESENTER_FRAME_PADDING_Y}px;
+  padding-bottom: ${PRESENTER_FRAME_PADDING_Y}px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: white;
+  transition: opacity ${PRESENTER_SLIDE_FADE_MS}ms ease;
+  /* Hide editor chrome that may leak through despite editable={false} */
+  .bn-side-menu,
+  .bn-formatting-toolbar,
+  .bn-slash-menu {
+    display: none !important;
+  }
+`;
+
+// The stage absorbs the un-scaled inner's layout box. Its explicit height
+// matches the painted height of the scaled inner (`naturalH × scale`), so
+// the scroll container sees a `scrollHeight` aligned with what the user
+// actually sees — not the un-transformed layout box.
+// `margin: auto` centres the stage vertically when it fits the outer's
+// content area, and collapses to 0 when it doesn't (enabling natural
+// top-anchored scroll).
+const stageCss = css`
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+  margin: auto;
+  flex-shrink: 0;
+`;
+
+const innerCss = css`
+  display: block;
+  width: ${PRESENTER_SLIDE_DESIGN_WIDTH}px;
+  transform-origin: left top;
+`;
+
+export const PresenterSlide = ({
+  blocks,
+  frameRef,
+  isCurrent,
+  ariaLabel,
+}: PresenterSlideProps) => {
+  const { t } = useTranslation();
+  const innerRef = useRef<HTMLDivElement>(null);
+  const editor = useCreateBlockNote({
+    initialContent:
+      // BlockNote rejects an empty initialContent array — fall back to one empty paragraph.
+      blocks.length > 0
+        ? (blocks as NonNullable<
+            Parameters<typeof useCreateBlockNote>[0]
+          >['initialContent'])
+        : undefined,
+    schema: blockNoteSchema,
+  });
+
+  const fit = useFitScale(innerRef, frameRef);
+
+  const outerStyle: React.CSSProperties = {
+    width: fit ? `${fit.outerWidth}px` : undefined,
+    opacity: fit && isCurrent ? 1 : 0,
+    visibility: isCurrent ? 'visible' : 'hidden',
+    pointerEvents: isCurrent ? 'auto' : 'none',
+  };
+
+  const stageStyle: React.CSSProperties = {
+    height: fit ? `${fit.stageHeight}px` : undefined,
+  };
+
+  const innerStyle: React.CSSProperties = {
+    transform: fit ? `scale(${fit.scale})` : 'none',
+  };
+
+  return (
+    <Box
+      $css={outerCss}
+      style={outerStyle}
+      role="group"
+      aria-roledescription={t('slide')}
+      aria-label={ariaLabel ?? t('Presenter slide')}
+      aria-hidden={!isCurrent}
+    >
+      <Box $css={stageCss} style={stageStyle}>
+        <Box ref={innerRef} $css={innerCss} style={innerStyle}>
+          <BlockNoteView
+            editor={editor}
+            editable={false}
+            theme="light"
+            formattingToolbar={false}
+            slashMenu={false}
+            comments={false}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/constants.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/constants.ts
@@ -1,0 +1,44 @@
+/**
+ * Half-window of slide renderers mounted around the current slide.
+ * Total mounted = 2 * PRESENTER_WINDOW_RADIUS + 1.
+ * 1 = three slides mounted (prev, current, next) — sweet spot between
+ * memory and navigation flash. Tune freely.
+ */
+export const PRESENTER_WINDOW_RADIUS = 1;
+
+/**
+ * Intrinsic design width of slide content, in CSS pixels. The slide's
+ * inner wrapper renders at this exact width then `transform: scale(...)`
+ * fits it into the available viewport.
+ */
+export const PRESENTER_SLIDE_DESIGN_WIDTH = 900;
+
+/**
+ * Lower bound of the per-slide scale. Below this, vertical scroll kicks
+ * in instead of further shrinking the content.
+ */
+export const PRESENTER_SLIDE_MIN_SCALE = 0.7;
+
+/**
+ * Upper bound of the per-slide scale. Prevents sparse slides from
+ * ballooning to an unreadable cinematic size.
+ */
+export const PRESENTER_SLIDE_MAX_SCALE = 1.5;
+
+/**
+ * Horizontal breathing room around the active slide, subtracted from
+ * the frame's clientWidth before computing the width-based scale.
+ */
+export const PRESENTER_FRAME_PADDING_X = 64;
+
+/**
+ * Vertical breathing room around the active slide. Also leaves clearance
+ * for the floating action bar.
+ */
+export const PRESENTER_FRAME_PADDING_Y = 64;
+
+/**
+ * Duration of the cross-fade between slides AND of the first-frame
+ * fade-in, in milliseconds.
+ */
+export const PRESENTER_SLIDE_FADE_MS = 100;

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useBrowserFullscreen.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useBrowserFullscreen.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const isCurrentlyFullscreen = () =>
+  typeof document !== 'undefined' && !!document.fullscreenElement;
+
+export const useBrowserFullscreen = () => {
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(
+    isCurrentlyFullscreen,
+  );
+  // Tracks whether the *current* fullscreen session was started by us.
+  // Prevents tearing down a fullscreen the user (or OS) had already
+  // entered before this hook was mounted.
+  const ownedRef = useRef(false);
+
+  useEffect(() => {
+    const handleChange = () => {
+      const fs = isCurrentlyFullscreen();
+      // Anytime fullscreen ends — Esc, our exit(), OS — release ownership.
+      if (!fs) {
+        ownedRef.current = false;
+      }
+      setIsFullscreen(fs);
+    };
+    document.addEventListener('fullscreenchange', handleChange);
+    return () => {
+      document.removeEventListener('fullscreenchange', handleChange);
+    };
+  }, []);
+
+  const enter = useCallback(async () => {
+    if (isCurrentlyFullscreen()) {
+      return;
+    }
+    if (!document.documentElement.requestFullscreen) {
+      return;
+    }
+    try {
+      await document.documentElement.requestFullscreen();
+      ownedRef.current = true;
+    } catch {
+      // Browsers reject the request when not triggered by a user gesture
+      // or when the API is unavailable. The presenter remains usable
+      // without fullscreen, so we swallow the rejection silently.
+    }
+  }, []);
+
+  const exit = useCallback(async () => {
+    if (!isCurrentlyFullscreen()) {
+      return;
+    }
+    if (!document.exitFullscreen) {
+      return;
+    }
+    try {
+      await document.exitFullscreen();
+    } catch {
+      // Ignore: nothing actionable if exit fails.
+    }
+  }, []);
+
+  // Same as exit() but bails out if we didn't initiate the fullscreen.
+  // Use this for cleanup-on-unmount so we don't yank a user out of a
+  // session they opened themselves before the presenter mounted.
+  const exitIfOwned = useCallback(async () => {
+    if (!ownedRef.current) {
+      return;
+    }
+    await exit();
+  }, [exit]);
+
+  const toggle = useCallback(async () => {
+    if (isCurrentlyFullscreen()) {
+      await exit();
+    } else {
+      await enter();
+    }
+  }, [enter, exit]);
+
+  return { isFullscreen, enter, exit, exitIfOwned, toggle };
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useFitScale.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useFitScale.ts
@@ -1,0 +1,117 @@
+import { RefObject, useEffect, useState } from 'react';
+
+import {
+  PRESENTER_FRAME_PADDING_X,
+  PRESENTER_FRAME_PADDING_Y,
+  PRESENTER_SLIDE_DESIGN_WIDTH,
+  PRESENTER_SLIDE_MAX_SCALE,
+  PRESENTER_SLIDE_MIN_SCALE,
+} from '../constants';
+
+/**
+ * Dimensions of a slide scaled to fit its frame. `null` until measured —
+ * render the slide at opacity 0 until then to avoid a scale-jump on first
+ * paint.
+ */
+export interface FitScale {
+  /** Clamped scale factor to apply via `transform: scale(...)`. */
+  scale: number;
+  /** Visible width of the scaled slide (`designWidth × scale`). */
+  outerWidth: number;
+  /** Painted height of the scaled inner content (`naturalHeight × scale`). */
+  stageHeight: number;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value));
+
+/**
+ * Pure scaling formula, extracted so it can be unit-tested without the DOM.
+ * `naturalHeight` is the inner's un-transformed `scrollHeight`; `frameWidth`/
+ * `frameHeight` are the frame's client box. Honours the more constraining axis
+ * (`min(scaleW, scaleH)`) then clamps into `[MIN, MAX]`: below MIN the slide
+ * scrolls (pure CSS), above MAX sparse slides are capped. Returns `null` for
+ * non-positive inputs (transient zero sizes during mount).
+ *
+ * `transform: scale(...)` does not affect layout boxes, so reading
+ * `naturalHeight` off the same element the consumer scales is safe.
+ */
+export const computeFitScale = (
+  naturalHeight: number,
+  frameWidth: number,
+  frameHeight: number,
+): FitScale | null => {
+  const availW = frameWidth - 2 * PRESENTER_FRAME_PADDING_X;
+  const availH = frameHeight - 2 * PRESENTER_FRAME_PADDING_Y;
+  if (naturalHeight <= 0 || availW <= 0 || availH <= 0) {
+    return null;
+  }
+
+  const scale = clamp(
+    Math.min(availW / PRESENTER_SLIDE_DESIGN_WIDTH, availH / naturalHeight),
+    PRESENTER_SLIDE_MIN_SCALE,
+    PRESENTER_SLIDE_MAX_SCALE,
+  );
+
+  return {
+    scale,
+    outerWidth: PRESENTER_SLIDE_DESIGN_WIDTH * scale,
+    stageHeight: naturalHeight * scale,
+  };
+};
+
+/**
+ * Reactively fit a slide's content into the available frame. Returns the
+ * scaled dimensions, or `null` until the first measurement. Re-measures
+ * whenever `inner` (content height) or `frame` (available area) resizes —
+ * viewport resize, fullscreen toggle, late image load, font swap.
+ *
+ * No rAF / re-render guard: committing only sets the outer width (the outer is
+ * `position: absolute`, so it cannot resize the observed frame), the stage
+ * height (the stage is not observed), and the inner's `transform` (ignored by
+ * ResizeObserver, which reports the layout box). No committed value resizes an
+ * observed element, so the observer cannot re-fire itself — there is no loop
+ * to coalesce or debounce. (Trade-off: true sub-pixel oscillation of the
+ * observed boxes would cause a few cheap re-renders rather than being swallowed
+ * — acceptable, and not worth a guard.)
+ *
+ * SSR-safe: DOM/ResizeObserver are touched only inside the effect.
+ *
+ * `inner` must be rendered at `PRESENTER_SLIDE_DESIGN_WIDTH` with no transform
+ * during measurement.
+ */
+export const useFitScale = (
+  innerRef: RefObject<HTMLDivElement | null>,
+  frameRef: RefObject<HTMLDivElement | null>,
+): FitScale | null => {
+  const [fit, setFit] = useState<FitScale | null>(null);
+
+  useEffect(() => {
+    const inner = innerRef.current;
+    const frame = frameRef.current;
+    if (!inner || !frame || typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    const measure = () => {
+      setFit(
+        computeFitScale(
+          inner.scrollHeight,
+          frame.clientWidth,
+          frame.clientHeight,
+        ),
+      );
+    };
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(inner);
+    observer.observe(frame);
+    // Measure synchronously for a flicker-free first paint instead of waiting
+    // for the observer's initial (async) callback.
+    measure();
+
+    return () => observer.disconnect();
+  }, [innerRef, frameRef]);
+
+  return fit;
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/usePresenterShortcuts.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/usePresenterShortcuts.ts
@@ -1,0 +1,99 @@
+import { useEffect } from 'react';
+
+interface ShortcutHandlers {
+  onPrev: () => void;
+  onNext: () => void;
+  onFirst: () => void;
+  onLast: () => void;
+  onToggleFullscreen: () => void;
+  onClose: () => void;
+  isFullscreen: boolean;
+}
+
+const ARROW_CODES = new Set(['ArrowLeft', 'ArrowRight']);
+
+export const usePresenterShortcuts = ({
+  onPrev,
+  onNext,
+  onFirst,
+  onLast,
+  onToggleFullscreen,
+  onClose,
+  isFullscreen,
+}: ShortcutHandlers) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat && !ARROW_CODES.has(event.code)) {
+        return;
+      }
+
+      switch (event.code) {
+        case 'ArrowLeft':
+        case 'PageUp':
+          event.preventDefault();
+          onPrev();
+          return;
+        case 'Space': {
+          // A focused button activates on `keyup` (native click). If we
+          // also call onNext() here on `keydown`, Space on the toolbar's
+          // Next button fires twice. Skip when the event target handles
+          // Space natively.
+          const target = event.target;
+          if (
+            target instanceof Element &&
+            target.closest(
+              'button, [role="button"], a, input, textarea, select, [contenteditable="true"]',
+            )
+          ) {
+            return;
+          }
+          event.preventDefault();
+          onNext();
+          return;
+        }
+        case 'ArrowRight':
+        case 'PageDown':
+          event.preventDefault();
+          onNext();
+          return;
+        case 'Home':
+          event.preventDefault();
+          onFirst();
+          return;
+        case 'End':
+          event.preventDefault();
+          onLast();
+          return;
+        case 'KeyF':
+          if (event.ctrlKey || event.metaKey || event.altKey) {
+            return;
+          }
+          event.preventDefault();
+          onToggleFullscreen();
+          return;
+        case 'Escape':
+          // While fullscreen, the browser handles Esc natively (exits
+          // fullscreen) and we deliberately stay open. Once out of
+          // fullscreen, Esc closes the presenter.
+          if (!isFullscreen) {
+            event.preventDefault();
+            onClose();
+          }
+          return;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [
+    onPrev,
+    onNext,
+    onFirst,
+    onLast,
+    onToggleFullscreen,
+    onClose,
+    isFullscreen,
+  ]);
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useSlides.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useSlides.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+
+type Block = {
+  type: string;
+  content?: unknown;
+  children?: Block[];
+};
+
+/**
+ * Split a flat list of top-level blocks into slide groups.
+ *
+ * - Each `divider` block separates two slides; the divider itself is dropped.
+ * - Blocks are otherwise preserved verbatim — including empty paragraphs
+ *   (intentional spacing) and custom blocks (interlinks, embeds, ...). The
+ *   presenter renders whatever the editor holds; it does not second-guess
+ *   the author's content.
+ * - Groups with no blocks at all are removed (handles leading, trailing or
+ *   consecutive dividers).
+ * - The returned array is never empty: an empty doc yields one empty group.
+ */
+export const splitBlocksIntoSlides = <T extends Block>(blocks: T[]): T[][] => {
+  const groups: T[][] = [];
+  let current: T[] = [];
+
+  for (const block of blocks) {
+    if (block.type === 'divider') {
+      groups.push(current);
+      current = [];
+      continue;
+    }
+    current.push(block);
+  }
+  groups.push(current);
+
+  const nonEmpty = groups.filter((group) => group.length > 0);
+
+  return nonEmpty.length > 0 ? nonEmpty : [[]];
+};
+
+export const useSlides = <T extends Block>(blocks: T[]): T[][] => {
+  return useMemo(() => splitBlocksIntoSlides(blocks), [blocks]);
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/index.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/index.ts
@@ -1,0 +1,1 @@
+export { PresenterOverlay } from './components/PresenterOverlay';

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2063,10 +2063,10 @@
   resolved "https://registry.yarnpkg.com/@gouvfr-lasuite/integration/-/integration-1.0.3.tgz#7aca824ba61d343a7905dc90c8a8bbdbce8f9a09"
   integrity sha512-OgP28CqlPi35wQPul1Dr52SngACXAk8buLGqHYXDp23fbTOJThqarrZE/pgJHoc9Ndwiu7ngwBSO4rZ7OPyMpA==
 
-"@gouvfr-lasuite/ui-kit@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@gouvfr-lasuite/ui-kit/-/ui-kit-0.23.1.tgz#fc82cd611ea84e5adef9869800e27cf626ca211c"
-  integrity sha512-H9+0zXxvAoCQYRLsq4wChx8KkpxcLEDrFZyIwrHNMqDDgV4YcSgeUIYE5clCRybnglrgK7ZcNGJdMqzf9sji/Q==
+"@gouvfr-lasuite/ui-kit@0.23.2":
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/@gouvfr-lasuite/ui-kit/-/ui-kit-0.23.2.tgz#9a7531fb35821b75b786bfc3167ad53aab116c4c"
+  integrity sha512-o6bQjqJadBbWMbFiwDYwVeNKYAD/EGeU2W0/omqNgTEYWjKQCGYwgcxgeYR+SZN9GnWKCXEARs18aYgBl+oRbQ==
   dependencies:
     "@dnd-kit/core" "6.3.1"
     "@dnd-kit/modifiers" "9.0.0"


### PR DESCRIPTION
## Purpose

  Adds a built-in **presenter mode** to any document. Press *Present* in the
  doc actions menu and the document becomes a slide deck — splits on each
  `divider` block, navigates with `←/→` `Space` `Home/End`, toggles browser
  fullscreen with `F`, closes with `Esc`. Snapshot-based: live edits do not
  affect the running presentation.

  Each slide is **dynamically scaled** to fit the viewport (Notion-style
  pattern: outer wrapper + `transform: scale` on an 800px inner). Scale is
  clamped to `[0.7, 1.5]`; vertical scroll only kicks in when the content
  can't fit even at min scale, and the slide top is always reachable.
  Short slides centre vertically, long slides scroll past a small top
  padding to reach the viewport edge. Smooth cross-fade between slides.

To avoid the reviewer having to create a set of slides, here is a markdown file to copy and paste into a docs file to test the mode:
[test-slides.md](https://github.com/user-attachments/files/28379962/test-slides.md)

  ## Demo

https://github.com/user-attachments/assets/4ee9a60f-7c24-4e08-ad59-059509f55f23


