### PR TITLE
🐛(y-provider) return empty output when converting empty Yjs document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 
 - 🐛(docs) run migration 0027 without superuser role
 - 🐛(backend) prevent admins/owners from overwriting other users comments
+- 🐛(y-provider) return empty output when converting empty Yjs document
 - 🐛(backend) use computed_link_reach in handle_onboarding_document #2305
 
 ### Changed

--- a/src/frontend/servers/y-provider/__tests__/convert.test.ts
+++ b/src/frontend/servers/y-provider/__tests__/convert.test.ts
@@ -315,4 +315,31 @@ describe('Conversion Testing', () => {
     expect(response.body).toStrictEqual({ error: 'Invalid content' });
     expect(destroySpy).toHaveBeenCalledTimes(1);
   });
+
+  test('POST /api/convert empty Yjs document returns 200 with empty content', async () => {
+    const app = initApp();
+    const yjsUpdate = Y.encodeStateAsUpdate(new Y.Doc());
+
+    const htmlResponse = await request(app)
+      .post('/api/convert')
+      .set('origin', origin)
+      .set('authorization', `Bearer ${apiKey}`)
+      .set('content-type', 'application/vnd.yjs.doc')
+      .set('accept', 'text/html')
+      .send(Buffer.from(yjsUpdate));
+
+    expect(htmlResponse.status).toBe(200);
+    expect(htmlResponse.text).toBe('');
+
+    const markdownResponse = await request(app)
+      .post('/api/convert')
+      .set('origin', origin)
+      .set('authorization', `Bearer ${apiKey}`)
+      .set('content-type', 'application/vnd.yjs.doc')
+      .set('accept', 'text/markdown')
+      .send(Buffer.from(yjsUpdate));
+
+    expect(markdownResponse.status).toBe(200);
+    expect(markdownResponse.text).toBe('\n');
+  });
 });

--- a/src/frontend/servers/y-provider/src/handlers/convertHandler.ts
+++ b/src/frontend/servers/y-provider/src/handlers/convertHandler.ts
@@ -151,15 +151,10 @@ export const convertHandler = async (
       return;
     }
 
-    if (!blocks || blocks.length === 0) {
-      res.status(500).json({ error: 'No valid blocks were generated' });
-      return;
-    }
-
     res
       .status(200)
       .setHeader('content-type', accept)
-      .send(await writer.write(blocks));
+      .send(await writer.write(blocks ?? []));
   } catch (e) {
     logger('conversion failed:', e);
     res.status(500).json({ error: 'An error occurred' });


### PR DESCRIPTION
The convert handler returned 500 "No valid blocks were generated" whenever the reader produced an empty blocks array, which is the normal state of a freshly-created Yjs document. Treat empty input as a valid case and return 200 with an empty body for every supported output format.