### PR TITLE
Fix export format select keyboard focus

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-export.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-export.spec.ts
@@ -37,6 +37,11 @@ test.describe('Doc Export', () => {
       ),
     ).toBeVisible();
     await expect(page.getByRole('combobox', { name: 'Format' })).toBeVisible();
+    const formatSelectToggle = page.locator(
+      '.--docs--modal-export-content .c__select__inner__actions__open',
+    );
+    await expect(formatSelectToggle).toHaveAttribute('aria-hidden', 'true');
+    await expect(formatSelectToggle).toHaveAttribute('tabindex', '-1');
     await expect(
       page.getByRole('button', {
         name: 'Close the download modal',

--- a/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
@@ -14,7 +14,13 @@ import { DocumentProps, pdf } from '@react-pdf/renderer';
 import jsonemoji from 'emoji-datasource-apple' with { type: 'json' };
 import i18next from 'i18next';
 import JSZip from 'jszip';
-import { cloneElement, isValidElement, useState } from 'react';
+import {
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
@@ -59,6 +65,16 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
   );
   const { untitledDocument } = useTrans();
   const mediaUrl = useMediaUrl();
+  const formatSelectRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const toggleButton = formatSelectRef.current?.querySelector<HTMLElement>(
+      '.c__select__inner__actions__open',
+    );
+
+    toggleButton?.setAttribute('aria-hidden', 'true');
+    toggleButton?.setAttribute('tabindex', '-1');
+  });
 
   const formatOptions = [
     { label: t('PDF'), value: DocDownloadFormat.PDF },
@@ -271,16 +287,18 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
             'Export your document to print or download in .docx, .odt, .pdf or .html(zip) format.',
           )}
         </Text>
-        <Select
-          clearable={false}
-          fullWidth
-          label={t('Format')}
-          options={formatOptions}
-          value={format}
-          onChange={(options) =>
-            setFormat(options.target.value as DocDownloadFormat)
-          }
-        />
+        <Box ref={formatSelectRef}>
+          <Select
+            clearable={false}
+            fullWidth
+            label={t('Format')}
+            options={formatOptions}
+            value={format}
+            onChange={(options) =>
+              setFormat(options.target.value as DocDownloadFormat)
+            }
+          />
+        </Box>
 
         {isExporting && (
           <Box


### PR DESCRIPTION
## Summary
- remove the decorative export format select arrow from the tab order
- hide the arrow button from assistive technologies

## Why
In the export modal, keyboard and screen reader users currently encounter a separate focus stop for the dropdown arrow even though the combobox itself is the interactive control. This adds noise and makes the modal harder to navigate.

Fixes #2342.

## Checks
- `npx -y prettier@3.8.3 --check apps/impress/src/features/docs/doc-export/components/ModalExport.tsx`
- static assertion that the patch sets `aria-hidden="true"` and `tabindex="-1"`

Note: I did not run the full app test suite because dependencies are not installed in this checkout.
