### PR TITLE
🐛(frontend) fix application crashes when using GTranslate and zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to
 - 🐛(backend) prevent admins/owners from overwriting other users comments
 - 🐛(y-provider) return empty output when converting empty Yjs document
 - 🐛(backend) use computed_link_reach in handle_onboarding_document #2305
+- 🐛(frontend) fix application crashes when using GTranslate and zoom #2372
 - 🐛(frontend) fix emoji pdf not matching #2375
 
 ### Changed

--- a/src/frontend/apps/impress/src/features/skeletons/components/DocEditorSkeleton.tsx
+++ b/src/frontend/apps/impress/src/features/skeletons/components/DocEditorSkeleton.tsx
@@ -8,6 +8,7 @@ import { SkeletonLine } from './SkeletionUI';
 export const DocEditorSkeleton = () => {
   return (
     <>
+      <SkeletonEditorFloatingBar />
       {/* Main Editor Container */}
       <Box
         $maxWidth="868px"
@@ -15,7 +16,6 @@ export const DocEditorSkeleton = () => {
         $height="100%"
         className="--docs--doc-editor-skeleton"
       >
-        <SkeletonEditorFloatingBar />
         <SkeletonEditorHeader />
         <SkeletonEditorCore />
       </Box>

--- a/src/frontend/apps/impress/src/layouts/PageLayout.tsx
+++ b/src/frontend/apps/impress/src/layouts/PageLayout.tsx
@@ -12,11 +12,13 @@ import { MAIN_LAYOUT_ID } from './conf';
 
 interface PageLayoutProps {
   withFooter?: boolean;
+  withLeftPanel?: boolean;
 }
 
 export function PageLayout({
   children,
   withFooter = true,
+  withLeftPanel = true,
 }: PropsWithChildren<PageLayoutProps>) {
   const { isLargeScreen } = useResponsiveStore();
   const { t } = useTranslation();
@@ -45,7 +47,7 @@ export function PageLayout({
         `}
         aria-label={t('Main content')}
       >
-        {!isLargeScreen && <LeftPanel />}
+        {withLeftPanel && !isLargeScreen && <LeftPanel />}
         {children}
       </Box>
       {withFooter && <Footer />}

--- a/src/frontend/apps/impress/src/pages/_error.tsx
+++ b/src/frontend/apps/impress/src/pages/_error.tsx
@@ -42,7 +42,11 @@ Error.getInitialProps = async (contextData: NextPageContext) => {
 };
 
 Error.getLayout = function getLayout(page: ReactElement) {
-  return <PageLayout withFooter={false}>{page}</PageLayout>;
+  return (
+    <PageLayout withFooter={false} withLeftPanel={false}>
+      {page}
+    </PageLayout>
+  );
 };
 
 export default Error;


### PR DESCRIPTION
## Purpose

Error boundary page is used when an error occurs in the application, this page can have states still set, causing side effects depend the component that throw the error. 
In this case, the left panel is still loaded and try to load the tree, but the provider is not set, causing a crash error inside the error boundary page.
We don't need the left panel in the error boundary page, so we can just not load it to avoid this issue.