### PR TITLE
🐛(frontend) fix toolbar blocknote hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 - ♻️(backend) allow global search in sub documents
 - ✨(backend) add a breadcrumb in the search response
 - ♻️(frontend) move doc action buttons to fix toolbar #2360
+- ♿️(frontend) add aria-hidden to decorative avatar SVGs in share modal #2324
 
 ### Fixed
 
@@ -28,12 +29,9 @@ and this project adheres to
 - 🐛(backend) prevent admins/owners from overwriting other users comments
 - 🐛(y-provider) return empty output when converting empty Yjs document
 - 🐛(backend) use computed_link_reach in handle_onboarding_document #2305
+- 🐛(frontend) fix toolbar blocknote hidden #2373
 - 🐛(frontend) fix application crashes when using GTranslate and zoom #2372
 - 🐛(frontend) fix emoji pdf not matching #2375
-
-### Changed
-
-- ♿️(frontend) add aria-hidden to decorative avatar SVGs in share modal #2324
 
 ## [v5.1.0] - 2026-05-11
 

--- a/src/frontend/apps/impress/src/features/header/components/Header.tsx
+++ b/src/frontend/apps/impress/src/features/header/components/Header.tsx
@@ -35,7 +35,7 @@ export const Header = () => {
           top: 0;
           left: 0;
           right: 0;
-          z-index: 1000;
+          z-index: 10;
           flex-direction: row;
           align-items: center;
           justify-content: space-between;


### PR DESCRIPTION
## Purpose

The header could hide the formatting bar of the Blocknote editor. 
This PR improve the z-index of the header to ensure that the formatting bar is always visible.

