### PR TITLE
♿️(frontend) align mobile header menu aria-label i18n pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 - ♻️(frontend) move doc action buttons to fix toolbar #2360
 - ♿️(frontend) add aria-hidden to decorative avatar SVGs in share modal #2324
 - 🏗️(frontend) move comments to its own folder feature #2374
+- ♿️(frontend) align mobile header menu aria-label i18n pattern #2377
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelToggleMobile.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelToggleMobile.tsx
@@ -12,9 +12,11 @@ export const LeftPanelToggleMobile = () => {
     <Button
       size="medium"
       onClick={() => togglePanel({ type: 'mobile' })}
-      aria-label={t(
-        isPanelOpenMobile ? 'Close the header menu' : 'Open the header menu',
-      )}
+      aria-label={
+        isPanelOpenMobile
+          ? t('Close the header menu')
+          : t('Open the header menu')
+      }
       aria-expanded={isPanelOpenMobile}
       variant="tertiary"
       icon={


### PR DESCRIPTION
## Purpose

Fix the mobile header menu toggle `aria-label` i18n usage so both strings can be picked up by the parser.

* [x] Refactor `LeftPanelToggleMobile` to use `condition ? t('…') : t('…')` instead of `t(condition ? '…' : '…')`

note : translation was missing for this one before, we will need it