### PR TITLE
♿️(frontend) use semantic <p> elements in document info card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to
 
 - 🐛(frontend) redirect homepage to login when homepage feat is disabled #2521
 
+### Changed
+
+- ♿️(frontend) use semantic `<dl>` structure in document info card #2379
+
 ## [v5.4.1] - 2026-07-09
 
 ### Changed

--- a/src/frontend/apps/impress/src/components/Text.tsx
+++ b/src/frontend/apps/impress/src/components/Text.tsx
@@ -9,7 +9,18 @@ const { sizes } = tokens.themes.default.globals.font;
 type TextSizes = keyof typeof sizes;
 
 export interface TextProps extends BoxProps {
-  as?: 'p' | 'span' | 'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  as?:
+    | 'p'
+    | 'span'
+    | 'div'
+    | 'h1'
+    | 'h2'
+    | 'h3'
+    | 'h4'
+    | 'h5'
+    | 'h6'
+    | 'dt'
+    | 'dd';
   $ellipsis?: boolean;
   $weight?: CSSProperties['fontWeight'];
   $textAlign?: CSSProperties['textAlign'];

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeaderInfo.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeaderInfo.tsx
@@ -26,34 +26,44 @@ export const DocHeaderInfo = ({ doc }: DocHeaderInfoProps) => {
 
   const relativeOnly = relativeDate(doc.updated_at);
 
-  let dateToDisplay = t('Last update: {{update}}', {
-    update: relativeOnly,
-  });
+  const trashbinCutoff = config?.TRASHBIN_CUTOFF_DAYS;
 
-  if (config?.TRASHBIN_CUTOFF_DAYS && doc.deleted_at) {
-    const daysLeft = calculateDaysLeft(
-      doc.deleted_at,
-      config.TRASHBIN_CUTOFF_DAYS,
-    );
+  let dateLabel: string;
+  let dateValue: string;
 
-    dateToDisplay = `${t('Days remaining:')} ${daysLeft} ${t('days', { count: daysLeft })}`;
+  if (trashbinCutoff && doc.deleted_at) {
+    const daysLeft = calculateDaysLeft(doc.deleted_at, trashbinCutoff);
+    dateLabel = t('Days remaining:');
+    dateValue = `${daysLeft} ${t('days', { count: daysLeft })}`;
+  } else {
+    dateLabel = t('Last update:');
+    dateValue = relativeOnly;
   }
 
   return (
-    <Box $direction="row">
+    <Box as="dl" $direction="row" $align="center" $margin="0">
+      <Text as="dt" className="sr-only">
+        {t('Role')}
+      </Text>
       <Text
+        as="dd"
         $variation="tertiary"
         $size="s"
         $weight="bold"
         $theme={isEditable ? 'neutral' : 'warning'}
         $direction="row"
+        $margin="0"
       >
         <VisibilityDoc doc={doc} />
         {transRole(isEditable ? doc.user_role || doc.link_role : Role.READER)}
         &nbsp;·&nbsp;
       </Text>
-      <Text $variation="tertiary" $size="s">
-        {dateToDisplay}
+      <Text as="dt" $variation="tertiary" $size="s" $margin="0">
+        {dateLabel}
+        &nbsp;
+      </Text>
+      <Text as="dd" $variation="tertiary" $size="s" $margin="0">
+        {dateValue}
       </Text>
     </Box>
   );


### PR DESCRIPTION
## Purpose

Use a semantic `<dl>` (definition list) instead of `<p>` for the user role and last update date in the document information card (`DocHeaderInfo`), as suggested in review. These are key/value metadata pairs, not paragraphs.

## Proposal

* [x] Wrap the info card in a `<dl>` via `Box as="dl"`
* [x] Add screen-reader-only `<dt>` labels for each metadata entry
* [x] Render role and date values as `<dd>` via `Text as="dd"`
* [x] Extend `Text` component `as` prop to accept `dt` and `dd`
* [x] Reset native `<dl>`/`<dd>` margins to preserve existing layout
