### PR TITLE
♿️(frontend) use heading element for pinned documents section title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♿️(frontend) use heading element for pinned documents section title #2380
+
 ## [v5.2.1] - 2026-06-05
 
 ### Changed
@@ -14,7 +18,7 @@ and this project adheres to
 
 ### Fixed
 
-- 🐛(backend) close thread DB connections to fix test teardown 
+- 🐛(backend) close thread DB connections to fix test teardown
   OperationalError #2385
 - 🐛(frontend) fix crash when orphaned threads #2395
 - 🐛(backend) order trashbin response by most recently deleted #2392
@@ -54,7 +58,7 @@ and this project adheres to
 - 🐛(frontend) fix toolbar blocknote hidden #2373
 - 🐛(frontend) fix application crashes when using GTranslate and zoom #2372
 - 🐛(frontend) fix emoji pdf not matching #2375
-- 🐛(backend) fix UnorderedObjectListWarning for DocumentAskForAccess 
+- 🐛(backend) fix UnorderedObjectListWarning for DocumentAskForAccess
   viewset #2382
 
 ## [v5.1.0] - 2026-05-11

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFavorites.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFavorites.tsx
@@ -22,11 +22,7 @@ export const LeftPanelFavorites = () => {
   }
 
   return (
-    <Box
-      as="section"
-      aria-labelledby="pinned-docs-title"
-      className="--docs--left-panel-favorites"
-    >
+    <Box as="section" className="--docs--left-panel-favorites">
       <HorizontalSeparator $margin="none" />
       <Box
         $justify="center"
@@ -36,10 +32,11 @@ export const LeftPanelFavorites = () => {
         data-testid="left-panel-favorites"
       >
         <Text
+          as="h2"
           $size="sm"
           $padding={{ horizontal: '3xs' }}
           $weight="700"
-          id="pinned-docs-title"
+          $margin="0"
         >
           {t('Pinned documents')}
         </Text>


### PR DESCRIPTION
## Purpose

Replace the `<span>` section title with an `<h2>` for the "Pinned documents" section in the left panel (`LeftPanelFavorites`).

## Proposal

* [x] Render "Pinned documents" as `<h2>` via `Text as="h2"`
* [x] Remove `aria-labelledby` and `id="pinned-docs-title"` from the `<section>`
* [x] Reset heading margin (`$margin="0"`) to preserve the existing visual appearance