### PR TITLE
🐛(backend) fix UnorderedObjectListWarning for DocumentAskForAccess viewset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to
 - 🐛(frontend) fix toolbar blocknote hidden #2373
 - 🐛(frontend) fix application crashes when using GTranslate and zoom #2372
 - 🐛(frontend) fix emoji pdf not matching #2375
+- 🐛(backend) fix UnorderedObjectListWarning for DocumentAskForAccess viewset
 
 ## [v5.1.0] - 2026-05-11
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -2943,7 +2943,7 @@ class DocumentAskForAccessViewSet(
         permissions.ResourceWithAccessPermission,
     ]
     throttle_scope = "document_ask_for_access"
-    queryset = models.DocumentAskForAccess.objects.all()
+    queryset = models.DocumentAskForAccess.objects.all().order_by("updated_at")
     serializer_class = serializers.DocumentAskForAccessSerializer
     _document = None
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -173,7 +173,6 @@ class SerializerPerActionMixin:
 class Pagination(drf.pagination.PageNumberPagination):
     """Pagination to display no more than 100 objects per page sorted by creation date."""
 
-    ordering = "-created_on"
     max_page_size = 200
     page_size_query_param = "page_size"
 


### PR DESCRIPTION
## Purpose

In the tests there is a UnorderedObjectListWarning, we also find this same
warning in the logs in production. This warning appears because the
queryset used by the DocumentAskForAccess paginator is not ordered and
can lead to inconsistent result. Ordering the queryset fix this warning.

## Proposal

* [x] 🐛(backend) fix UnorderedObjectListWarning for DocumentAskForAccess viewset
* [x] 🔥(backend) remove unused order parameter in Paginator class