### PR TITLE
♿️(frontend) improve presenter mode screen reader and keyboard support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to
 - 👷(CI) remove test-e2e-other-browser job #2404
 - ♿️(frontend) use heading element for pinned documents section title #2380
 - ♿️(frontend) use anchor links for table of contents entries #2390
+- ♿️(frontend) improve presenter mode screen reader and keyboard support #2383
 
-### Fixed 
+### Fixed
 
 - 🐛(frontend) overlap of block menu dropdown #2406
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/presenter-mode.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/presenter-mode.spec.ts
@@ -94,11 +94,17 @@ test.describe('Presenter Mode', () => {
 
     // The visible "1 / 3" counter is decorative (aria-hidden); the position is
     // announced through a polite live region for screen readers instead.
-    const liveRegion = overlay.getByRole('status');
-    await expect(liveRegion).toHaveText('Slide 1 of 3');
+    // react-aria/live-announcer creates a global role="log" div on document.body
+    // (outside the dialog), so we query from `page`, not `overlay`.
+    const liveRegion = page.locator(
+      '[data-live-announcer="true"] [aria-live="polite"]',
+    );
+    // The announcement includes the slide title extracted from the first
+    // text block (getSlideTitle), so assert the full message.
+    await expect(liveRegion).toContainText('Slide 1 of 3: Slide one');
 
     await overlay.getByRole('button', { name: 'Next slide' }).click();
-    await expect(liveRegion).toHaveText('Slide 2 of 3');
+    await expect(liveRegion).toContainText('Slide 2 of 3: Slide two');
 
     // Each slide advertises a localized role description for screen readers.
     await expect(overlay.getByRole('group').first()).toHaveAttribute(

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocToolBox.tsx
@@ -135,7 +135,9 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
       label: t('Present'),
       icon: <Present width={24} height={24} aria-hidden="true" />,
       callback: () => {
-        setIsPresenterOpen(true);
+        requestAnimationFrame(() => {
+          setIsPresenterOpen(true);
+        });
       },
       isHidden: Boolean(doc.deleted_at) || isMobile,
       testId: `docs-actions-present-${doc.id}`,
@@ -284,7 +286,6 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
           doc={doc}
           onClose={() => {
             setIsPresenterOpen(false);
-            restoreFocus();
           }}
         />
       )}

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/useSlides.spec.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/useSlides.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { splitBlocksIntoSlides } from '../hooks/useSlides';
+import { getSlideTitle, splitBlocksIntoSlides } from '../hooks/useSlides';
 
 const para = (text = 'hello') => ({
   type: 'paragraph',
@@ -82,5 +82,61 @@ describe('splitBlocksIntoSlides', () => {
     const result = splitBlocksIntoSlides([para('a'), divider(), image()]);
     expect(result).toHaveLength(2);
     expect(result[1]).toHaveLength(1);
+  });
+});
+
+const heading = (text: string) => ({
+  type: 'heading',
+  content: [{ type: 'text', text }],
+});
+
+describe('getSlideTitle', () => {
+  test('returns text from the first heading', () => {
+    expect(getSlideTitle([para('intro'), heading('My Title')])).toBe(
+      'My Title',
+    );
+  });
+
+  test('falls back to first paragraph when no heading', () => {
+    expect(getSlideTitle([para('fallback text')])).toBe('fallback text');
+  });
+
+  test('returns empty string for empty slide', () => {
+    expect(getSlideTitle([])).toBe('');
+  });
+
+  test('returns empty string when all blocks have empty content', () => {
+    expect(getSlideTitle([para(''), { type: 'image' }])).toBe('');
+  });
+
+  test('skips whitespace-only blocks and picks the first with text', () => {
+    expect(getSlideTitle([para('   '), para('real text')])).toBe('real text');
+  });
+
+  test('prefers heading over paragraph even when paragraph comes first', () => {
+    expect(getSlideTitle([para('first'), heading('Title')])).toBe('Title');
+  });
+
+  test('extracts text from nested inline content (e.g. links)', () => {
+    const linkBlock = {
+      type: 'paragraph',
+      content: [
+        { type: 'text', text: 'Visit ' },
+        {
+          type: 'link',
+          content: [{ type: 'text', text: 'our site' }],
+          href: 'https://example.com',
+        },
+      ],
+    };
+    expect(getSlideTitle([linkBlock])).toBe('Visit our site');
+  });
+
+  test('handles blocks without content property', () => {
+    expect(getSlideTitle([{ type: 'divider' }, para('after')])).toBe('after');
+  });
+
+  test('trims leading and trailing whitespace', () => {
+    expect(getSlideTitle([para('  spaced  ')])).toBe('spaced');
   });
 });

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
@@ -97,18 +97,6 @@ export const PresenterFloatingBar = ({
       <Text as="span" $size="sm" $color="neutral" aria-hidden="true">
         {index + 1} / {total}
       </Text>
-      <Text
-        as="span"
-        className="sr-only"
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-      >
-        {t('Slide {{current}} of {{total}}', {
-          current: index + 1,
-          total,
-        })}
-      </Text>
       <Button
         size="small"
         color="neutral"

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
@@ -1,3 +1,4 @@
+import { announce } from '@react-aria/live-announcer';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
@@ -10,7 +11,7 @@ import { Doc } from '@/docs/doc-management';
 import { PRESENTER_WINDOW_RADIUS } from '../constants';
 import { useBrowserFullscreen } from '../hooks/useBrowserFullscreen';
 import { usePresenterShortcuts } from '../hooks/usePresenterShortcuts';
-import { useSlides } from '../hooks/useSlides';
+import { getSlideTitle, useSlides } from '../hooks/useSlides';
 
 import { PresenterFloatingBar } from './PresenterFloatingBar';
 import { PresenterSlide } from './PresenterSlide';
@@ -104,6 +105,21 @@ export const PresenterOverlay = ({
   }, [currentIndex, total]);
 
   const frameRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const title = getSlideTitle(slides[currentIndex] ?? []);
+    const message = title
+      ? t('Slide {{current}} of {{total}}: {{title}}', {
+          current: currentIndex + 1,
+          total,
+          title,
+        })
+      : t('Slide {{current}} of {{total}}', {
+          current: currentIndex + 1,
+          total,
+        });
+    announce(message, 'polite');
+  }, [slides, currentIndex, total, t]);
 
   if (typeof document === 'undefined') {
     return null;

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
@@ -1,4 +1,4 @@
-import { announce } from '@react-aria/live-announcer';
+import { announce, clearAnnouncer } from '@react-aria/live-announcer';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FocusScope } from 'react-aria';
 import { createPortal } from 'react-dom';
@@ -120,6 +120,7 @@ export const PresenterOverlay = ({
           total,
         });
     announce(message, 'polite');
+    return () => clearAnnouncer('polite');
   }, [slides, currentIndex, total, t]);
 
   if (typeof document === 'undefined') {
@@ -127,7 +128,7 @@ export const PresenterOverlay = ({
   }
 
   return createPortal(
-    <FocusScope contain>
+    <FocusScope contain autoFocus restoreFocus>
       <Box
         $css={overlayCss}
         role="dialog"

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
@@ -1,5 +1,6 @@
 import { announce } from '@react-aria/live-announcer';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FocusScope } from 'react-aria';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
@@ -126,37 +127,39 @@ export const PresenterOverlay = ({
   }
 
   return createPortal(
-    <Box
-      $css={overlayCss}
-      role="dialog"
-      aria-modal="true"
-      aria-label={t('Presenter mode')}
-    >
-      <Box ref={frameRef} $css={slideAreaCss}>
-        {mountedIndices.map((i) => (
-          <PresenterSlide
-            key={i}
-            blocks={slides[i] as unknown[]}
-            frameRef={frameRef}
-            isCurrent={i === currentIndex}
-            ariaLabel={t('Slide {{current}} of {{total}}', {
-              current: i + 1,
-              total,
-            })}
-          />
-        ))}
-      </Box>
+    <FocusScope contain>
+      <Box
+        $css={overlayCss}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('Presenter mode')}
+      >
+        <Box ref={frameRef} $css={slideAreaCss}>
+          {mountedIndices.map((i) => (
+            <PresenterSlide
+              key={i}
+              blocks={slides[i] as unknown[]}
+              frameRef={frameRef}
+              isCurrent={i === currentIndex}
+              ariaLabel={t('Slide {{current}} of {{total}}', {
+                current: i + 1,
+                total,
+              })}
+            />
+          ))}
+        </Box>
 
-      <PresenterFloatingBar
-        index={currentIndex}
-        total={total}
-        isFullscreen={isFullscreen}
-        onPrev={goPrev}
-        onNext={goNext}
-        onToggleFullscreen={() => void toggle()}
-        onClose={onClose}
-      />
-    </Box>,
+        <PresenterFloatingBar
+          index={currentIndex}
+          total={total}
+          isFullscreen={isFullscreen}
+          onPrev={goPrev}
+          onNext={goNext}
+          onToggleFullscreen={() => void toggle()}
+          onClose={onClose}
+        />
+      </Box>
+    </FocusScope>,
     document.body,
   );
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterSlide.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterSlide.tsx
@@ -1,6 +1,6 @@
 import { BlockNoteView } from '@blocknote/mantine';
 import { useCreateBlockNote } from '@blocknote/react';
-import { RefObject, useRef } from 'react';
+import { RefObject, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
@@ -95,6 +95,18 @@ export const PresenterSlide = ({
         : undefined,
     schema: blockNoteSchema,
   });
+
+  // ProseMirror adds role="textbox" and contenteditable on its root even
+  // when editable=false, making the SR announce "editing, autocomplete" on
+  // focus. Strip those attributes so the slide reads as plain content.
+  useEffect(() => {
+    const pm = innerRef.current?.querySelector('.ProseMirror');
+    if (pm) {
+      pm.removeAttribute('role');
+      pm.removeAttribute('contenteditable');
+      pm.setAttribute('tabindex', '-1');
+    }
+  }, []);
 
   const fit = useFitScale(innerRef, frameRef);
 

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useSlides.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useSlides.ts
@@ -40,3 +40,41 @@ export const splitBlocksIntoSlides = <T extends Block>(blocks: T[]): T[][] => {
 export const useSlides = <T extends Block>(blocks: T[]): T[][] => {
   return useMemo(() => splitBlocksIntoSlides(blocks), [blocks]);
 };
+
+const extractInlineText = (content: unknown): string => {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  return content
+    .map((node) => {
+      if (typeof node === 'string') {
+        return node;
+      }
+      if (node && typeof node === 'object') {
+        const inline = node as { text?: unknown; content?: unknown };
+        if (typeof inline.text === 'string') {
+          return inline.text;
+        }
+        if (inline.content !== undefined) {
+          return extractInlineText(inline.content);
+        }
+      }
+      return '';
+    })
+    .join('');
+};
+
+/** First heading text, or first block with text — for SR announcements. */
+export const getSlideTitle = (
+  blocks: { type: string; content?: unknown }[],
+): string => {
+  const heading = blocks.find((block) => block.type === 'heading');
+  const source =
+    heading ??
+    blocks.find((block) => extractInlineText(block.content).trim().length > 0);
+
+  return source ? extractInlineText(source.content).trim() : '';
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useSlides.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/useSlides.ts
@@ -41,6 +41,7 @@ export const useSlides = <T extends Block>(blocks: T[]): T[][] => {
   return useMemo(() => splitBlocksIntoSlides(blocks), [blocks]);
 };
 
+// Extract text from a node's inline content for summarization or accessibility.
 const extractInlineText = (content: unknown): string => {
   if (typeof content === 'string') {
     return content;
@@ -67,7 +68,7 @@ const extractInlineText = (content: unknown): string => {
     .join('');
 };
 
-/** First heading text, or first block with text — for SR announcements. */
+/** First heading text, or first block with text, for SR announcements. */
 export const getSlideTitle = (
   blocks: { type: string; content?: unknown }[],
 ): string => {


### PR DESCRIPTION
## Purpose

Make the presenter mode accessible to keyboard and screen reader users:
announce slide changes, trap focus inside the overlay, and restore focus
to the trigger button on close.

## Proposal

* [x] Announce "Slide X of Y: <title>" on navigation via a `polite` live region (`@react-aria/live-announcer`).
* [x] Remove the redundant slide-counter `<span>` label: the live announcer now handles it, so keeping the `aria-label` made screen readers read the same info twice. The visual counter is hidden with `aria-hidden="true"`.
* [x] Trap focus inside the overlay with react-aria `FocusScope contain`.
* [x] Strip the ProseMirror editor role (`textbox`/`contenteditable`, `tabindex="-1"`) so slides aren't announced as editable, keeping links tabbable.
* [x] Update e2e tests to target content via `role="group"`.