### PR TITLE
♿️(frontend) align search modal field label with placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 - ♿️(frontend) enable blocknote heading ids for toc anchors #2449
 - ♿️(frontend) focus export modal on format select #2421
 - ♿️(frontend) configurable legal submenu in HelpMenu, remove Crisp #2416
+- ♿️(frontend) align search modal field label with placeholder #2384
 
 ## [v5.3.0] - 2026-06-19
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-grid-move.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-grid-move.spec.ts
@@ -213,7 +213,7 @@ test.describe('Doc grid move', () => {
         .getByRole('heading', { name: 'Choose a new parent doc' }),
     ).toBeVisible();
 
-    const input = page.getByRole('combobox', { name: 'Search' });
+    const input = page.getByRole('combobox', { name: 'Search for a doc...' });
     await input.click();
     await input.fill(titleDoc2);
 
@@ -303,7 +303,7 @@ test.describe('Doc grid move', () => {
         .getByRole('heading', { name: 'Choose a new parent doc' }),
     ).toBeVisible();
 
-    const input = page.getByRole('combobox', { name: 'Search' });
+    const input = page.getByRole('combobox', { name: 'Search for a doc...' });
     await input.click();
     await input.fill(titleDoc2);
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-search.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-search.spec.ts
@@ -120,9 +120,8 @@ test.describe('Document search', () => {
     const searchButton = page.getByTestId('search-docs-button');
 
     await searchButton.click();
-    await page.getByRole('combobox', { name: 'Search documents' }).click();
     await page
-      .getByRole('combobox', { name: 'Search documents' })
+      .getByRole('combobox', { name: 'Type the name of a document' })
       .fill('sub page');
 
     // Expect to find the first and second docs in the results list
@@ -144,7 +143,7 @@ test.describe('Document search', () => {
     );
     await searchButton.click();
     await page
-      .getByRole('combobox', { name: 'Search documents' })
+      .getByRole('combobox', { name: 'Type the name of a document' })
       .fill('sub page');
 
     // Display only current doc results
@@ -210,7 +209,7 @@ test.describe('Document search', () => {
 
     await otherPage.getByTestId('search-docs-button').click();
     await otherPage
-      .getByRole('combobox', { name: 'Search documents' })
+      .getByRole('combobox', { name: 'Type the name of a document' })
       .fill('sub page');
 
     // Search only in the current doc

--- a/src/frontend/apps/impress/src/components/quick-search/QuickSearch.tsx
+++ b/src/frontend/apps/impress/src/components/quick-search/QuickSearch.tsx
@@ -65,7 +65,6 @@ export const QuickSearch = ({
         >
           {showInput && (
             <QuickSearchInput
-              label={label}
               withSeparator={hasChildrens(children)}
               inputValue={inputValue}
               onFilter={onFilter}

--- a/src/frontend/apps/impress/src/components/quick-search/QuickSearchInput.tsx
+++ b/src/frontend/apps/impress/src/components/quick-search/QuickSearchInput.tsx
@@ -11,7 +11,6 @@ import { Box } from '../Box';
 
 type QuickSearchInputProps = {
   inputValue?: string;
-  label?: string;
   onFilter?: (str: string) => void;
   placeholder?: string;
   withSeparator?: boolean;
@@ -19,7 +18,6 @@ type QuickSearchInputProps = {
 };
 export const QuickSearchInput = ({
   inputValue,
-  label,
   onFilter,
   placeholder,
   children,
@@ -62,7 +60,6 @@ export const QuickSearchInput = ({
         <Command.Input
           ref={inputRef}
           autoFocus={true}
-          aria-label={label ?? t('Search')}
           aria-controls={listId}
           value={inputValue}
           placeholder={placeholder ?? t('Search')}

--- a/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchModal.tsx
@@ -126,7 +126,7 @@ const DocSearchModalGlobal = ({
         $padding={{ bottom: 'base' }}
       >
         <QuickSearch
-          label={t('Search documents')}
+          label={t('Type the name of a document')}
           placeholder={t('Type the name of a document')}
           loading={loading}
           onFilter={handleInputSearch}

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocMoveModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocMoveModal.tsx
@@ -201,6 +201,7 @@ export const DocMoveModal = ({
           }}
         >
           <QuickSearch
+            label={t('Search for a doc...')}
             placeholder={t('Search for a doc...')}
             loading={loading}
             onFilter={handleInputSearch}


### PR DESCRIPTION
## Purpose

The search modal input exposed three inconsistent names (`aria-label`, `<label>`, and `placeholder`). Screen reader users heard a different label than the visible placeholder

## Proposal

- [x] Remove redundant `aria-label` on `QuickSearchInput` so the accessible name comes from cmdk's `<label>` (`aria-labelledby`) instead of overriding it
- [x] Align `DocSearchModal` `label` and `placeholder` on `Type the name of a document`
- [x] Update e2e selectors in `doc-search.spec.ts` to match the new combobox accessible name