### PR TITLE
♿️(frontend) use anchor links for table of contents entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 
 - 👷(CI) remove test-e2e-other-browser job #2404
 - ♿️(frontend) use heading element for pinned documents section title #2380
+- ♿️(frontend) use anchor links for table of contents entries #2390
 
 ### Fixed 
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-table-content.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-table-content.spec.ts
@@ -32,34 +32,43 @@ test.describe('Doc Table Content', () => {
 
     const elSidePanel = page.getByLabel('Table of contents side panel');
 
-    const level1 = elSidePanel.getByText('Level 1');
+    const link1 = elSidePanel.getByRole('link', { name: 'Level 1' });
+    const link2 = elSidePanel.getByRole('link', { name: 'Level 2' });
+    const link3 = elSidePanel.getByRole('link', { name: 'Level 3' });
+    const level1 = link1.getByText('Level 1');
     const editorLevel1 = editor.getByText('Level 1');
-    const level2 = elSidePanel.getByText('Level 2');
+    const level2 = link2.getByText('Level 2');
     const editorLevel2 = editor.getByText('Level 2');
-    const level3 = elSidePanel.getByText('Level 3');
+    const level3 = link3.getByText('Level 3');
+
+    // TOC entries must be <a> links with fragment hrefs
+    await expect(link1).toBeVisible();
+    await expect(link1).toHaveAttribute('href', /^#heading-/);
+    await expect(link2).toHaveAttribute('href', /^#heading-/);
+    await expect(link3).toHaveAttribute('href', /^#heading-/);
 
     await expect(level1).toBeVisible();
     await expect(editorLevel1).not.toBeInViewport();
-    await expect(level1).toHaveAttribute('aria-selected', 'false');
+    await expect(link1).not.toHaveAttribute('aria-current');
 
     await expect(level2).toBeVisible();
     await expect(level2).toHaveCSS('padding-left', /14.4px/);
     await expect(editorLevel2).toBeInViewport();
-    await expect(level2).toHaveAttribute('aria-selected', 'true');
+    await expect(link2).toHaveAttribute('aria-current', 'true');
 
     await expect(level3).toBeVisible();
     await expect(level3).toHaveCSS('padding-left', /24px/);
-    await expect(level3).toHaveAttribute('aria-selected', 'false');
+    await expect(link3).not.toHaveAttribute('aria-current');
 
-    await level1.click();
+    await link1.click();
     await expect(editorLevel1).toBeInViewport();
-    await expect(level1).toHaveAttribute('aria-selected', 'true');
-    await expect(level2).toHaveAttribute('aria-selected', 'false');
+    await expect(link1).toHaveAttribute('aria-current', 'true');
+    await expect(link2).not.toHaveAttribute('aria-current');
 
-    await level2.click();
+    await link2.click();
     await expect(editorLevel1).not.toBeInViewport();
     await expect(editorLevel2).toBeInViewport();
-    await expect(level2).toHaveAttribute('aria-selected', 'true');
-    await expect(level1).toHaveAttribute('aria-selected', 'false');
+    await expect(link2).toHaveAttribute('aria-current', 'true');
+    await expect(link1).not.toHaveAttribute('aria-current');
   });
 });

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useHeadings.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/hook/useHeadings.tsx
@@ -7,7 +7,6 @@ export const useHeadings = (editor: DocsBlockNoteEditor) => {
   const { setHeadings, resetHeadings } = useHeadingStore();
 
   useEffect(() => {
-    // Check if editor and its view are mounted before accessing document
     if (!editor) {
       return;
     }

--- a/src/frontend/apps/impress/src/features/docs/doc-table-content/components/Heading.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-table-content/components/Heading.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { css } from 'styled-components';
 
-import { BoxButton, Text } from '@/components';
+import { Box, Text } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
 import { DocsBlockNoteEditor } from '@/docs/doc-editor/types';
 import { useResponsiveStore } from '@/stores';
@@ -38,15 +38,18 @@ export const Heading = ({
   const isActive = isHighlight || isHover;
 
   return (
-    <BoxButton
-      id={`heading-${headingId}`}
+    <Box
+      as="a"
+      href={`#heading-${headingId}`}
       className="--docs--table-content-heading"
       $width="100%"
       $minHeight="var(--c--globals--spacings--lg)"
       onMouseOver={() => setIsHover(true)}
       onMouseLeave={() => setIsHover(false)}
-      onClick={() => {
+      onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
         // With mobile the focus open the keyboard and the scroll is not working
+        e.preventDefault();
+
         if (!isMobile) {
           editor.focus();
         }
@@ -68,17 +71,22 @@ export const Heading = ({
           : 'none'
       }
       $justify="center"
+      $padding="none"
+      $margin="none"
+      $hasTransition
       $css={css`
         text-align: left;
+        display: flex;
+        text-decoration: none;
+        color: inherit;
+        cursor: pointer;
         &:focus-visible {
-          /* Scoped focus style: same footprint as hover, with theme shadow */
           outline: none;
           box-shadow: 0 0 0 2px ${colorsTokens['brand-400']};
           border-radius: var(--c--globals--spacings--st);
         }
       `}
       aria-label={text}
-      aria-selected={isHighlight}
       aria-current={isHighlight ? 'true' : undefined}
     >
       <Text
@@ -87,10 +95,9 @@ export const Heading = ({
         $weight={isHighlight ? '700' : '500'}
         $css="overflow-wrap: break-word;"
         $hasTransition
-        aria-selected={isHighlight}
       >
         {text}
       </Text>
-    </BoxButton>
+    </Box>
   );
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContentSideBar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-table-content/components/TableContentSideBar.tsx
@@ -95,7 +95,13 @@ export const TableContentSideBar = ({ onClose }: TableContentSideBarProps) => {
         `}
       >
         <Box $direction="row" $align="center" $justify="space-between">
-          <Text as="h2" $weight="bold" $size="16px" $margin="0">
+          <Text
+            as="h2"
+            id="toc-heading"
+            $weight="bold"
+            $size="16px"
+            $margin="0"
+          >
             {t('Table of Contents')}
           </Text>
           <ButtonCloseModal
@@ -106,33 +112,40 @@ export const TableContentSideBar = ({ onClose }: TableContentSideBarProps) => {
       </Box>
       {editor && headings && headings.length > 0 && (
         <Box
-          as="ul"
-          role="list"
-          $gap={spacingsTokens['3xs']}
-          $padding={{
-            vertical: 'base',
-            horizontal: 'sm',
-          }}
+          as="nav"
+          aria-labelledby="toc-heading"
           $css={css`
             overflow-y: auto;
-            list-style: none;
-            margin: 0;
           `}
         >
-          {headings.map(
-            (heading) =>
-              heading.contentText && (
-                <Box as="li" role="listitem" key={heading.id}>
-                  <Heading
-                    editor={editor}
-                    headingId={heading.id}
-                    level={heading.props.level}
-                    text={heading.contentText}
-                    isHighlight={headingIdHighlight === heading.id}
-                  />
-                </Box>
-              ),
-          )}
+          <Box
+            as="ul"
+            role="list"
+            $gap={spacingsTokens['3xs']}
+            $padding={{
+              vertical: 'base',
+              horizontal: 'sm',
+            }}
+            $css={css`
+              list-style: none;
+              margin: 0;
+            `}
+          >
+            {headings.map(
+              (heading) =>
+                heading.contentText && (
+                  <Box as="li" role="listitem" key={heading.id}>
+                    <Heading
+                      editor={editor}
+                      headingId={heading.id}
+                      level={heading.props.level}
+                      text={heading.contentText}
+                      isHighlight={headingIdHighlight === heading.id}
+                    />
+                  </Box>
+                ),
+            )}
+          </Box>
         </Box>
       )}
     </Box>


### PR DESCRIPTION
## Purpose

Fix table of contents accessibility: TOC entries were `<button>` elements, so they were invisible in screen reader link navigation (RGAA criterion 6.1).

## Proposal

* [x] Replace TOC entries with `<a href="#heading-{blockId}">` links
* [x] Wrap the TOC list in a `<nav>` landmark with `aria-labelledby` referencing the existing `h2`
* [x] Use `aria-current` on the active TOC link (instead of invalid `aria-selected` on links)
* [x] Keep scroll via BlockNote `[data-id]` + `setTextCursorPosition` (same behavior as before)
* [x] Update `doc-table-content` e2e tests for link role and `href` / `aria-current`

## Note

Focus on the target heading is not yet implemented: BlockNote does not expose `id` attributes on heading DOM elements, and manual DOM manipulation is wiped by ProseMirror re-renders. An upstream feature request has been opened on BlockNote to support native heading `id`s.