### PR TITLE
♿️(frontend) use anchor links for interlinking sub-documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 - ♿️(frontend) add aria-hidden to decorative avatar SVGs in share modal #2324
 - 🏗️(frontend) move comments to its own folder feature #2374
 - ♿️(frontend) align mobile header menu aria-label i18n pattern #2377
+- ♿️(frontend) use anchor links for interlinking sub-documents #2391
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♿️(frontend) use anchor links for interlinking sub-documents #2391
+
 ## [v5.5.0] - 2026-08-24
 
 ### Added

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/LinkSelected.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/LinkSelected.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { css } from 'styled-components';
 
-import { Box, BoxButton, Text } from '@/components';
+import { Box, Text } from '@/components';
 import SelectedPageIcon from '@/docs/doc-editor/assets/doc-selected.svg';
 import { getEmojiAndTitle, useDoc } from '@/docs/doc-management/';
 
@@ -41,10 +41,9 @@ export const LinkSelected = ({
   const router = useRouter();
   const href = `/docs/${docId}/`;
 
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
 
-    // If ctrl or command is pressed, it opens a new tab. If shift is pressed, it opens a new window
     if (e.metaKey || e.ctrlKey || e.shiftKey) {
       window.open(href, '_blank');
       return;
@@ -52,8 +51,7 @@ export const LinkSelected = ({
     void router.push(href);
   };
 
-  // This triggers on middle-mouse click
-  const handleAuxClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleAuxClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (e.button !== 1) {
       return;
     }
@@ -63,8 +61,9 @@ export const LinkSelected = ({
   };
 
   return (
-    <BoxButton
-      as="span"
+    <Box
+      as="a"
+      href={href}
       className="--docs--interlinking-link-inline-content"
       data-href={href}
       onClick={handleClick}
@@ -75,6 +74,7 @@ export const LinkSelected = ({
         display: inline;
         padding: 0.1rem 0.4rem;
         border-radius: 4px;
+        cursor: pointer;
         & svg {
           position: relative;
           top: 2px;
@@ -84,6 +84,11 @@ export const LinkSelected = ({
           background-color: var(
             --c--contextuals--background--semantic--contextual--primary
           );
+        }
+        .--docs--interlinking-link-inline-content:focus-visible {
+          outline: 2px solid
+            var(--c--contextuals--content--semantic--gray--primary);
+          outline-offset: 2px;
         }
         transition: background-color var(--c--globals--transitions--duration)
           var(--c--globals--transitions--ease-out);
@@ -129,6 +134,6 @@ export const LinkSelected = ({
           {titleWithoutEmoji}
         </Box>
       </Text>
-    </BoxButton>
+    </Box>
   );
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/LinkSelected.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/LinkSelected.tsx
@@ -85,9 +85,8 @@ export const LinkSelected = ({
             --c--contextuals--background--semantic--contextual--primary
           );
         }
-        .--docs--interlinking-link-inline-content:focus-visible {
-          outline: 2px solid
-            var(--c--contextuals--content--semantic--gray--primary);
+        &:focus-within {
+          outline: 2px solid var(--c--globals--colors--brand-400);
           outline-offset: 2px;
         }
         transition: background-color var(--c--globals--transitions--duration)

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/LinkSelected.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/custom-inline-content/Interlinking/LinkSelected.tsx
@@ -2,9 +2,9 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { css } from 'styled-components';
 
-import { Box, BoxButton, Text } from '@/components';
+import { Box, Text } from '@/components';
 import SelectedPageIcon from '@/docs/doc-editor/assets/doc-selected.svg';
-import { getEmojiAndTitle, useDoc } from '@/docs/doc-management/';
+import { getEmojiAndTitle, useDoc, useDocStore } from '@/docs/doc-management/';
 
 interface LinkSelectedProps {
   docId: string;
@@ -38,11 +38,17 @@ export const LinkSelected = ({
   }, [doc?.title, docId, isEditable]);
 
   const { emoji, titleWithoutEmoji } = getEmojiAndTitle(title);
+  const { currentDoc } = useDocStore();
+  const isDeletedDoc = !!currentDoc?.deleted_at;
   const router = useRouter();
   const href = `/docs/${docId}/`;
 
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleClick = (e: React.MouseEvent<HTMLSpanElement>) => {
     e.preventDefault();
+
+    if (isDeletedDoc) {
+      return;
+    }
 
     // If ctrl or command is pressed, it opens a new tab. If shift is pressed, it opens a new window
     if (e.metaKey || e.ctrlKey || e.shiftKey) {
@@ -53,8 +59,8 @@ export const LinkSelected = ({
   };
 
   // This triggers on middle-mouse click
-  const handleAuxClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (e.button !== 1) {
+  const handleAuxClick = (e: React.MouseEvent<HTMLSpanElement>) => {
+    if (e.button !== 1 || isDeletedDoc) {
       return;
     }
     e.preventDefault();
@@ -62,19 +68,36 @@ export const LinkSelected = ({
     window.open(href, '_blank');
   };
 
+  /**
+   * A link is activated with Enter only, Space is a button behaviour and stays
+   * available to the editor.
+   */
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (e.key !== 'Enter' || isDeletedDoc) {
+      return;
+    }
+    e.preventDefault();
+    void router.push(href);
+  };
+
   return (
-    <BoxButton
+    <Box
       as="span"
+      role="link"
+      tabIndex={isDeletedDoc ? -1 : 0}
+      aria-disabled={isDeletedDoc || undefined}
       className="--docs--interlinking-link-inline-content"
       data-href={href}
       onClick={handleClick}
       onAuxClick={handleAuxClick}
+      onKeyDown={handleKeyDown}
       draggable="false"
       $height="28px"
       $css={css`
         display: inline;
         padding: 0.1rem 0.4rem;
         border-radius: 4px;
+        cursor: pointer;
         & svg {
           position: relative;
           top: 2px;
@@ -129,6 +152,6 @@ export const LinkSelected = ({
           {titleWithoutEmoji}
         </Box>
       </Text>
-    </BoxButton>
+    </Box>
   );
 };


### PR DESCRIPTION
## Purpose

Make sub-doc interlinks accessible by using real `<a href>` links instead of invalid `<span type="button">` markup.

## Proposal

* [x] Render interlinks as `<a href>` in `LinkSelected.tsx`
* [x] Add `:focus-visible` outline for keyboard users
