### PR TITLE
👷(CI) remove test-e2e-other-browser job

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,23 @@
 name: E2E Tests
 
 on:
+  workflow_dispatch:
+    inputs:
+      browser-name:
+        description: "Name used for cache keys and artifact names (e.g. chromium, other-browser)"
+        required: false
+        default: "other-browser"
+        type: string
+      projects:
+        description: "Playwright --project flags (e.g. --project=firefox --project=webkit)"
+        required: false
+        default: "--project=firefox --project=webkit"
+        type: string
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        default: "30"
+        type: string
   workflow_call:
     inputs:
       browser-name:

--- a/.github/workflows/impress-frontend.yml
+++ b/.github/workflows/impress-frontend.yml
@@ -73,14 +73,6 @@ jobs:
       projects: --project=chromium
       timeout-minutes: 25
 
-  test-e2e-other-browser:
-    needs: test-e2e-chromium
-    uses: ./.github/workflows/e2e-tests.yml
-    with:
-      browser-name: other-browser
-      projects: --project=firefox --project=webkit
-      timeout-minutes: 30
-
   bundle-size-check:
     runs-on: ubuntu-latest
     needs: install-dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Changed
 
+- 👷(CI) remove test-e2e-other-browser job #2404
 - ♿️(frontend) use heading element for pinned documents section title #2380
 
 ## [v5.2.1] - 2026-06-05


### PR DESCRIPTION
## Purpose

We don't maintain the `test-e2e-other-browser` job, and it often fails due to various reasons.
To avoid unnecessary noise in our CI pipeline, we will remove this job.

We are adding `workflow_dispatch` trigger to the `e2e-tests` workflow, so that we can still run e2e tests on other browsers when needed from the Github actions UI.