### PR TITLE
🐛(frontend) fix removed item in the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(frontend) fix removed item in the tree #2420
+
+
 ## [v5.3.0] - 2026-06-19
 
 ### Added

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocSubPageItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocSubPageItem.tsx
@@ -7,13 +7,12 @@ import {
   TreeViewNodeTypeEnum,
   useTreeContext,
 } from '@gouvfr-lasuite/ui-kit';
-import { useRouter } from 'next/navigation';
+import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
 import { Box, Icon, StyledLink, Text } from '@/components';
-import { useCunninghamTheme } from '@/cunningham';
 import {
   Doc,
   DocIcon,
@@ -52,6 +51,7 @@ export const DocSubPageItem = (props: TreeViewNodeProps<Doc>) => {
 
 const DocSubPageLoadMore = (props: TreeViewNodeProps<Doc>) => {
   const treeContext = useTreeContext<Doc>();
+  const { t } = useTranslation();
   const loaderRef = useRef<HTMLDivElement>(null);
   const inFlightRef = useRef<boolean>(false);
 
@@ -91,8 +91,10 @@ const DocSubPageLoadMore = (props: TreeViewNodeProps<Doc>) => {
       $align="center"
       $justify="center"
       $padding={{ vertical: 'xs' }}
+      role="status"
+      aria-label={t('Loading more documents')}
     >
-      <Spinner size="sm" />
+      <Spinner size="sm" aria-hidden="true" />
     </Box>
   );
 };
@@ -102,23 +104,14 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
   const treeContext = useTreeContext<Doc>();
   const { untitledDocument } = useTrans();
   const { node } = props;
-  const { spacingsTokens } = useCunninghamTheme();
   const { isDesktop } = useResponsiveStore();
   const { t } = useTranslation();
-
   const [menuOpen, setMenuOpen] = useState(false);
-  const isSelectedNow = treeContext?.treeData.selectedNode?.id === doc.id;
-
   const router = useRouter();
   const { togglePanel } = useLeftPanelStore();
 
   const { emoji, titleWithoutEmoji } = getEmojiAndTitle(doc.title || '');
   const displayTitle = titleWithoutEmoji || untitledDocument;
-
-  const handleActivate = () => {
-    treeContext?.treeData.setSelectedNode(doc);
-    router.push(`/docs/${doc.id}`);
-  };
 
   const afterCreate = (createdDoc: Doc) => {
     const actualChildren = node.data.children ?? [];
@@ -129,12 +122,11 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
         .then((allChildren) => {
           node.open();
 
-          router.push(`/docs/${createdDoc.id}`);
+          void router.push(`/docs/${createdDoc.id}`);
           treeContext?.treeData.setChildren(
             node.data.value.id,
             allChildren as TreeViewDataType<Doc>[],
           );
-          treeContext?.treeData.setSelectedNode(createdDoc);
           togglePanel({ type: 'mobile' });
         })
         .catch(console.error);
@@ -147,17 +139,13 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
       };
       treeContext?.treeData.addChild(node.data.value.id, newDoc);
       node.open();
-      router.push(`/docs/${createdDoc.id}`);
-      treeContext?.treeData.setSelectedNode(newDoc);
+      void router.push(`/docs/${createdDoc.id}`);
       togglePanel({ type: 'mobile' });
     }
   };
 
   const docTitle = doc.title || untitledDocument;
-  const hasChildren = (doc.children?.length || 0) > 0;
-  const isExpanded = node.isOpen;
-  const isSelected = isSelectedNow;
-  const ariaLabel = docTitle;
+  const isCurrentPage = router.query?.id === doc.id;
   const isDisabled = !!doc.deleted_at;
   const actionsRef = useRef<HTMLDivElement>(null);
   const buttonOptionRef = useRef<ButtonElement | null>(null);
@@ -188,18 +176,38 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
   };
 
   return (
-    <Box
+    <StyledLink
       className="--docs-sub-page-item"
       draggable={doc.abilities.move && isDesktop}
-      $position="relative"
-      role="treeitem"
-      aria-label={ariaLabel}
-      aria-selected={isSelected}
-      aria-expanded={hasChildren ? isExpanded : undefined}
-      aria-disabled={isDisabled}
+      href={`/docs/${doc.id}`}
+      tabIndex={-1}
+      aria-label={
+        isDisabled
+          ? t('{{title}} (deleted)', { title: docTitle })
+          : t('Open document {{title}}', { title: docTitle })
+      }
+      aria-current={isCurrentPage ? 'page' : undefined}
+      data-testid={`doc-sub-page-item-${doc.id}`}
       onKeyDown={handleKeyDown}
+      aria-disabled={isDisabled}
+      onClick={isDisabled ? (e) => e.preventDefault() : undefined}
+      /**
+       * Prevent the default click behavior when clicking on the expand/collapse arrow to avoid
+       * navigating to the document page.
+       * This allows users to expand/collapse the tree node without triggering navigation,
+       * while still allowing clicks on the rest of the item to navigate as expected.
+       */
+      onClickCapture={(e) => {
+        if ((e.target as HTMLElement).closest('.c__tree-view--node__arrow')) {
+          e.preventDefault();
+        }
+      }}
       $css={css`
         background-color: var(--c--contextuals--background--surface--primary);
+        text-align: left;
+        display: block;
+        width: 100%;
+        border-radius: var(--c--globals--spacings--st);
         .light-doc-item-actions {
           display: ${menuOpen || !isDesktop ? 'flex' : 'none'};
           right: var(--c--globals--spacings--0);
@@ -224,7 +232,6 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
           background-color: var(
             --c--contextuals--background--semantic--gray--tertiary
           );
-          border-radius: var(--c--globals--spacings--st);
           .light-doc-item-actions {
             display: flex;
           }
@@ -239,7 +246,7 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
         }
       `}
     >
-      <TreeViewItem {...props} onClick={handleActivate}>
+      <TreeViewItem {...props}>
         <DocIcon
           emoji={emoji}
           withEmojiPicker={doc.abilities.partial_update}
@@ -265,13 +272,30 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
         <Box
           $direction="row"
           $align="center"
+          $gap="xs"
+          $minHeight="24px"
+          $minWidth="0"
+          $width="100%"
+          $overflow="hidden"
+        >
+          <Text $css={ItemTextCss} $size="sm">
+            {displayTitle}
+          </Text>
+          {doc.nb_accesses_direct >= 1 && (
+            <Icon
+              variant="filled"
+              iconName="group"
+              $size="md"
+              aria-label={t('Shared with others')}
+            />
+          )}
+        </Box>
+        <Box
+          $direction="row"
+          $align="center"
           className="light-doc-item-actions actions"
           role="toolbar"
-          aria-label={`${t('Actions for {{title}}', { title: docTitle })}`}
-          $css={css`
-            margin-left: auto;
-            order: 2;
-          `}
+          aria-label={t('Actions for {{title}}', { title: docTitle })}
         >
           <DocTreeItemActions
             doc={doc}
@@ -283,48 +307,7 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
             buttonOptionRef={buttonOptionRef}
           />
         </Box>
-        <StyledLink
-          href={`/docs/${doc.id}`}
-          onClick={() => {
-            treeContext?.treeData.setSelectedNode(doc);
-          }}
-          tabIndex={-1}
-          data-testid={`doc-sub-page-item-${doc.id}`}
-          aria-label={`${t('Open document {{title}}', { title: docTitle })}`}
-          $css={css`
-            text-align: left;
-            min-width: 0;
-          `}
-        >
-          <Box
-            $direction="row"
-            $align="center"
-            $gap={spacingsTokens['xs']}
-            $minHeight="24px"
-            $css={css`
-              display: flex;
-              flex-direction: row;
-              width: 100%;
-              min-width: 0;
-              gap: 0.5rem;
-              align-items: center;
-              overflow: hidden;
-            `}
-          >
-            <Text $css={ItemTextCss} $size="sm">
-              {displayTitle}
-            </Text>
-            {doc.nb_accesses_direct >= 1 && (
-              <Icon
-                variant="filled"
-                iconName="group"
-                $size="md"
-                aria-hidden="true"
-              />
-            )}
-          </Box>
-        </StyledLink>
       </TreeViewItem>
-    </Box>
+    </StyledLink>
   );
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
@@ -1,19 +1,22 @@
 import { ButtonElement } from '@gouvfr-lasuite/cunningham-react';
 import {
   OpenMap,
+  TreeDataItem,
   TreeView,
   TreeViewMoveResult,
   useResponsive,
   useTreeContext,
 } from '@gouvfr-lasuite/ui-kit';
-import { useRouter } from 'next/navigation';
+import { useRouter } from 'next/router';
 import {
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
 } from 'react';
+import { NodeApi } from 'react-arborist';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
@@ -40,7 +43,6 @@ type DocTreeProps = {
 
 export const DocTree = ({ currentDoc }: DocTreeProps) => {
   const { spacingsTokens } = useCunninghamTheme();
-  const { isDesktop } = useResponsive();
   const { untitledDocument } = useTrans();
   const [treeRoot, setTreeRoot] = useState<HTMLElement | null>(null);
   const treeContext = useTreeContext<Doc | null>();
@@ -59,8 +61,6 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
     undefined,
   );
 
-  const { mutate: moveDoc } = useMoveDoc();
-
   const { data: tree, isFetching } = useDocTree(
     { docId: currentDoc.id },
     {
@@ -68,15 +68,6 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
       queryKey: [KEY_DOC_TREE, { id: currentDoc.id }],
     },
   );
-
-  const handleMove = (result: TreeViewMoveResult) => {
-    moveDoc({
-      sourceDocumentId: result.sourceId,
-      targetDocumentId: result.targetModeId,
-      position: result.mode,
-    });
-    treeContext?.treeData.handleMove(result);
-  };
 
   /**
    * This function resets the tree states.
@@ -95,7 +86,7 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
   const navigateToRoot = useCallback(() => {
     const id = treeContext?.root?.id;
     if (id) {
-      router.push(`/docs/${id}`);
+      void router.push(`/docs/${id}`);
     }
   }, [router, treeContext?.root?.id]);
 
@@ -158,41 +149,6 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
         rootItemRef.current?.focus();
       });
     }
-  }, []);
-
-  const handleRowKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Tab' && e.shiftKey) {
-      e.preventDefault();
-      e.stopPropagation();
-      rootItemRef.current?.focus();
-      return;
-    }
-
-    if (e.key !== 'Enter') {
-      return;
-    }
-
-    const target = e.target as HTMLElement | null;
-    if (
-      !target ||
-      !(
-        target.classList.contains('c__tree-view--row') ||
-        target.classList.contains('c__tree-view--node')
-      )
-    ) {
-      return;
-    }
-
-    const treeItem = e.currentTarget.querySelector('[role="treeitem"]');
-    if (treeItem?.getAttribute('aria-selected') === 'true') {
-      e.preventDefault();
-      document.querySelector<HTMLElement>(`.${CLASS_DOC_TITLE}`)?.focus();
-      return;
-    }
-
-    e.currentTarget
-      .querySelector<HTMLDivElement>('.c__tree-view--node')
-      ?.click();
   }, []);
 
   /**
@@ -303,7 +259,7 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
           `[data-testid="doc-sub-page-item-${currentDoc.id}"]`,
         )
         ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-    }, 100);
+    }, 500);
 
     return () => {
       clearTimeout(timeoutId);
@@ -426,7 +382,7 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
               treeContext.treeData.setSelectedNode(
                 treeContext.root ?? undefined,
               );
-              router.push(`/docs/${treeContext?.root?.id}`);
+              void router.push(`/docs/${treeContext?.root?.id}`);
             }}
             aria-label={`${t('Open root document')}: ${treeContext.root?.title || untitledDocument}`}
             tabIndex={-1} // avoid double tabstop
@@ -458,37 +414,128 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
       {initialOpenState &&
         treeContext.treeData.nodes.length > 0 &&
         treeRoot && (
-          <Overlayer isOverlay={currentDoc.deleted_at != null} inert>
-            <TreeView
-              dndRootElement={treeRoot}
-              initialOpenState={initialOpenState}
-              afterMove={handleMove}
-              selectedNodeId={
-                treeContext.treeData.selectedNode?.id ??
-                treeContext.initialTargetId ??
-                undefined
-              }
-              canDrop={({ parentNode }) => {
-                const parentValue = parentNode?.data.value;
-                if (!parentValue || !isDocNode(parentValue)) {
-                  return currentDoc.abilities.move && isDesktop;
-                }
-                return parentValue.abilities.move && isDesktop;
-              }}
-              canDrag={(node) => {
-                if (!isDocNode(node.value)) {
-                  return false;
-                }
-                return node.value.abilities.move && isDesktop;
-              }}
-              rootNodeId={treeContext.root.id}
-              renderNode={DocSubPageItem}
-              rowProps={{
-                onKeyDown: handleRowKeyDown,
-              }}
-            />
-          </Overlayer>
+          <DocTreeView
+            doc={currentDoc}
+            treeRoot={treeRoot}
+            initialOpenState={initialOpenState}
+            rootNodeId={treeContext.root.id}
+            rootItem={rootItemRef.current}
+          />
         )}
     </Box>
   );
 };
+
+interface DocTreeViewProps {
+  doc: Doc;
+  treeRoot: HTMLElement;
+  initialOpenState: OpenMap;
+  rootNodeId: string;
+  rootItem: HTMLDivElement | null;
+}
+
+const DocTreeView = memo(function DocTreeView({
+  doc,
+  treeRoot,
+  initialOpenState,
+  rootNodeId,
+  rootItem,
+}: DocTreeViewProps) {
+  const { isDesktop } = useResponsive();
+  const treeContext = useTreeContext<Doc | null>();
+  const { mutate: moveDoc } = useMoveDoc();
+  const { query } = useRouter();
+
+  const handleMove = useCallback(
+    (result: TreeViewMoveResult) => {
+      moveDoc({
+        sourceDocumentId: result.sourceId,
+        targetDocumentId: result.targetModeId,
+        position: result.mode,
+      });
+      treeContext?.treeData.handleMove(result);
+    },
+    [moveDoc, treeContext],
+  );
+
+  const canDrop = useCallback(
+    ({ parentNode }: { parentNode: NodeApi<TreeDataItem<Doc>> | null }) => {
+      const parentValue = parentNode?.data.value;
+      if (!parentValue || !isDocNode(parentValue)) {
+        return doc.abilities.move && isDesktop;
+      }
+      return parentValue.abilities.move && isDesktop;
+    },
+    [doc.abilities.move, isDesktop],
+  );
+
+  const canDrag = useCallback(
+    (node: TreeDataItem<Doc>) => {
+      if (!isDocNode(node.value)) {
+        return false;
+      }
+      return node.value.abilities.move && isDesktop;
+    },
+    [isDesktop],
+  );
+
+  const handleRowKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Tab' && e.shiftKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        rootItem?.focus();
+        return;
+      }
+
+      if (e.key !== 'Enter') {
+        return;
+      }
+
+      const target = e.target as HTMLElement | null;
+      if (
+        !target ||
+        !(
+          target.classList.contains('c__tree-view--row') ||
+          target.classList.contains('c__tree-view--node')
+        )
+      ) {
+        return;
+      }
+
+      const treeItem = e.currentTarget.querySelector('[role="treeitem"]');
+      if (treeItem?.getAttribute('aria-selected') === 'true') {
+        e.preventDefault();
+        document.querySelector<HTMLElement>(`.${CLASS_DOC_TITLE}`)?.focus();
+        return;
+      }
+
+      e.currentTarget
+        .querySelector<HTMLDivElement>('.c__tree-view--node')
+        ?.click();
+    },
+    [rootItem],
+  );
+
+  return (
+    <Overlayer isOverlay={doc.deleted_at != null} inert>
+      <TreeView
+        dndRootElement={treeRoot}
+        initialOpenState={initialOpenState}
+        afterMove={handleMove}
+        selectedNodeId={
+          (query.id as string | undefined) ??
+          treeContext?.initialTargetId ??
+          undefined
+        }
+        canDrop={canDrop}
+        canDrag={canDrag}
+        rootNodeId={rootNodeId}
+        renderNode={DocSubPageItem}
+        rowProps={{
+          onKeyDown: handleRowKeyDown,
+        }}
+      />
+    </Overlayer>
+  );
+});

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
@@ -7,7 +7,13 @@ import {
   useTreeContext,
 } from '@gouvfr-lasuite/ui-kit';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
@@ -257,6 +263,52 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
       treeContext?.treeData.selectNodeById(currentDoc.id);
     }
   }, [currentDoc, treeContext]);
+
+  /**
+   * react-arborist's scrollTo calls react-window's scrollToItem, which mutates
+   * the internal scrollOffset state. When navigating to a deep item in a large
+   * tree, this causes all items above the target to be removed from the DOM
+   * (virtualized away), making the tree appear empty above the selected node.
+   * We no-op it to prevent that — the panel's own overflow-y handles scrolling.
+   */
+  const treeApiRef = treeContext?.treeApiRef;
+  useLayoutEffect(() => {
+    if (!treeRoot || !treeApiRef?.current) {
+      return;
+    }
+    const api = treeApiRef.current as unknown as Record<string, unknown>;
+    const origScrollTo = api['scrollTo'];
+    if (typeof origScrollTo !== 'function') {
+      return;
+    }
+    api['scrollTo'] = () => {};
+    return () => {
+      api['scrollTo'] = origScrollTo;
+    };
+  }, [treeRoot, treeApiRef]);
+
+  /**
+   * On initial tree load, scroll the panel to show the current document.
+   * This fires once when initialOpenState is first set (tree data just loaded).
+   * It does not re-fire on user navigation — clicked items are already in view.
+   */
+  useEffect(() => {
+    if (!treeRoot || !initialOpenState) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      treeRoot
+        .querySelector<HTMLElement>(
+          `[data-testid="doc-sub-page-item-${currentDoc.id}"]`,
+        )
+        ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }, 100);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [treeRoot, initialOpenState, currentDoc.id]);
 
   if (!treeContext || !treeContext.root) {
     return <TreeSkeleton />;


### PR DESCRIPTION
## Purpose

`react-arborist's` scrollTo calls react-window's scrollToItem, which mutates the internal scrollOffset state. When navigating to a deep item in a large tree, this causes all items above the target to be removed from the DOM (virtualized away), making the tree appear empty above the selected node. 
We no-op it to prevent that — the panel's own overflow-y handles scrolling.

----

We tried to improve the performance of tree as well.

The tree rerenders crazily, creating performance issues, especially on big trees. 
To fix it properly we will need a big refacto, on the uikit side.
Before doing that, we try to optimize the current code by memoizing the tree view, and by using the selected node from the url instead of the one from the context.
We improve the treeitem link, we can now easily opening a new tab by doing CTRL+Click.

