### PR TITLE
♿️(frontend) link export modal name to its heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 - ♿️(frontend) use heading element for pinned documents section title #2380
 - ♿️(frontend) use anchor links for table of contents entries #2390
 - ♿️(frontend) improve presenter mode screen reader and keyboard support #2383
+♿️(frontend) link export modal name to its heading #2422
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-export/components/ModalExport.tsx
@@ -219,8 +219,8 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
       closeOnClickOutside
       onClose={() => onClose()}
       hideCloseButton
-      aria-label={t('Export')}
-      aria-describedby="modal-export-title"
+      aria-labelledby="modal-export-title"
+      aria-describedby="modal-export-description"
       rightActions={
         <>
           <Button
@@ -272,7 +272,12 @@ export const ModalExport = ({ onClose, doc }: ModalExportProps) => {
         $gap="1rem"
         className="--docs--modal-export-content"
       >
-        <Text $variation="secondary" $size="sm" as="p">
+        <Text
+          $variation="secondary"
+          $size="sm"
+          as="p"
+          id="modal-export-description"
+        >
           {t(
             'Export your document to print or download in .docx, .odt, .pdf or .html(zip) format.',
           )}


### PR DESCRIPTION
## Purpose

Fix the export modal accessible name so it is derived from the visible `<h1>` title instead of a static `aria-label`.

## Proposal

* [x] Use `aria-labelledby="modal-export-title"` on the dialog
* [x] Point `aria-describedby` to the description paragraph, not the title