### PR TITLE
✨(backend) specific user delete method to delete its relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 - ✨(frontend) leave a document #2410
 - ✨(frontend) add top parent on sub docs search #1952
 - ✨(frontend) unauthenticated users can search #2407
+- ✨(backend) specific user delete method to delete its relations
 
 ### Changed
 

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -98,6 +98,30 @@ class UserAdmin(auth_admin.UserAdmin):
         "updated_at",
     )
     search_fields = ("id", "sub", "admin_email", "email", "full_name")
+    actions = ["permanently_delete_users"]
+
+    def __init__(self, model, admin_site):
+        """
+        Disable delete_selected action.
+        Only the `permanently_delete_users` should be used to delete a user.
+        """
+        super().__init__(model, admin_site)
+
+        self.admin_site.disable_action("delete_selected")
+
+    def has_delete_permission(self, request, obj=None):
+        """
+        Force delete permission to False to remove the delete button.
+        Only the `permanently_delete_users` should be used to delete a user.
+        """
+        return False
+
+    @admin.action(description=_("Permanently delete selected users"))
+    def permanently_delete_users(self, request, queryset):
+        """Permanently delete users present in the queryset."""
+        self.log_deletions(request, queryset)
+        for user in queryset:
+            user.delete()
 
 
 @admin.register(models.UserReconciliationCsvImport)

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -246,7 +246,7 @@ class UserViewSet(
         # For security results, users that match neither of these proximity criteria
         # are not returned at all, to prevent email enumeration.
         current_user = self.request.user
-        shared_map = users_sharing_documents_with(current_user)
+        shared_map = users_sharing_documents_with(current_user.id)
 
         user_email_domain = get_domain_from_email(current_user.email) or ""
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -20,6 +20,7 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.mail import send_mail
 from django.db import models, transaction
+from django.db.models import Count
 from django.db.models.functions import Left, Length
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -224,6 +225,55 @@ class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
             self._handle_onboarding_documents_access()
             self._duplicate_onboarding_sandbox_document()
             self._convert_valid_invitations()
+
+    def delete(self, using=None, keep_parents=False):
+        """Completely delete a user and its relations."""
+        with transaction.atomic():
+            self._delete_user_shared_documents_accesses()
+            self._delete_documents_single_owner()
+            self._clear_user_created_documents()
+
+            return super().delete(using=using, keep_parents=keep_parents)
+
+    def _delete_user_shared_documents_accesses(self):
+        """
+        accesses to delete where there are more than one owner.
+
+        Create first a subquery to filter all the the accesses having more than one
+        owner. Then use this subquery to filter the accesses belonging to this list of
+        documents and to the user to delete
+        """
+        docs_ids = (
+            DocumentAccess.objects.filter(role=RoleChoices.OWNER)
+            .values("document_id")
+            .annotate(owner_count=Count("id"))
+            .filter(owner_count__gte=2)
+            .values("document_id")
+        )
+        DocumentAccess.objects.filter(user=self, document_id__in=docs_ids).delete()
+
+        logger.info(
+            "user_delete: shared documents accesses for user %s have been deleted",
+            self.id,
+        )
+
+    def _delete_documents_single_owner(self):
+        """Delete the documents where the user is the single owner."""
+        Document.objects.filter(
+            accesses__user=self, accesses__role=RoleChoices.OWNER
+        ).delete()
+        logger.info(
+            "user_delete: documents where the user %s is the sole owner deleted",
+            self.id,
+        )
+
+    def _clear_user_created_documents(self):
+        """Set creator to Null for documents where the user is the creator."""
+        Document.objects.filter(creator=self).update(creator=None)
+        logger.info(
+            "user_delete: documents created by user %s have been cleared",
+            self.id,
+        )
 
     def _handle_onboarding_documents_access(self):
         """

--- a/src/backend/core/signals.py
+++ b/src/backend/core/signals.py
@@ -36,9 +36,8 @@ def document_access_post_save(sender, instance, created, **kwargs):  # pylint: d
         )
 
     # Invalidate cache for the user
-    if instance.user:
-        cache_key = get_users_sharing_documents_with_cache_key(instance.user)
-        cache.delete(cache_key)
+    cache_key = get_users_sharing_documents_with_cache_key(instance.user_id)
+    cache.delete(cache_key)
 
 
 @receiver(signals.post_delete, sender=models.DocumentAccess)
@@ -46,6 +45,5 @@ def document_access_post_delete(sender, instance, **kwargs):  # pylint: disable=
     """
     Clear cache for the affected user when document access is deleted.
     """
-    if instance.user:
-        cache_key = get_users_sharing_documents_with_cache_key(instance.user)
-        cache.delete(cache_key)
+    cache_key = get_users_sharing_documents_with_cache_key(instance.user_id)
+    cache.delete(cache_key)

--- a/src/backend/core/tests/test_models_users.py
+++ b/src/backend/core/tests/test_models_users.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
-from django.db import connection
+from django.db import DatabaseError, connection
 from django.test.utils import override_settings
 
 import pytest
@@ -366,3 +366,280 @@ def test_models_users_duplicate_onboarding_sandbox_race_condition():
 
         assert isinstance(user1, models.User)
         assert isinstance(user2, models.User)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_task_user_delete():
+    """test user_delete task with a complete scenario"""
+
+    user_to_delete = factories.UserFactory()
+    other_user = factories.UserFactory()
+
+    # Documents where the user is the sole owner
+    documents_to_delete = factories.DocumentFactory.create_batch(
+        3, creator=user_to_delete, users=[(user_to_delete, models.RoleChoices.OWNER)]
+    )
+    # Documents where the user is not the sole owner
+    documents_to_keep = factories.DocumentFactory.create_batch(
+        4,
+        creator=other_user,
+        users=[
+            (user_to_delete, models.RoleChoices.OWNER),
+            (other_user, models.RoleChoices.OWNER),
+        ],
+    )
+    # descendants of a document to delete should also be removed
+    depth = 5
+    for _ in range(depth + 1):
+        documents_to_delete.append(
+            factories.DocumentFactory(parent=documents_to_delete[-1])
+        )
+
+    # Documents created by the user to delete and should be set to null
+    documents_creator_set_to_null = factories.DocumentFactory.create_batch(
+        3, creator=user_to_delete
+    )
+
+    # Non creator nor owner document but with accesses to delete
+    for role in models.RoleChoices.values:
+        if role == models.RoleChoices.OWNER.value:
+            continue
+
+        factories.DocumentFactory(users=[(user_to_delete, role)])
+
+    # create 3 link traces
+    #
+    factories.DocumentFactory.create_batch(3, link_traces=[user_to_delete, other_user])
+    # Create other link traces for the other user
+    #
+    factories.DocumentFactory.create_batch(3, link_traces=[other_user])
+
+    # Threads created by the user to delete should be set to null
+    threads_owned_by_user_to_delete = factories.ThreadFactory.create_batch(
+        2, creator=user_to_delete
+    )
+    # Threads created by the other user should not change
+    threads_owned_by_other_user = factories.ThreadFactory.create_batch(
+        2, creator=other_user
+    )
+
+    # create comments for both users in all existing threads
+    comments = []
+    for thread in threads_owned_by_user_to_delete + threads_owned_by_other_user:
+        comments.append(factories.CommentFactory(thread=thread, user=user_to_delete))
+        comments.append(factories.CommentFactory(thread=thread, user=other_user))
+
+    assert models.DocumentAccess.objects.filter(user=user_to_delete).count() == 11
+    assert models.Document.objects.all().count() == 30
+    assert models.LinkTrace.objects.all().count() == 9
+    assert models.Thread.objects.all().count() == 4
+    assert models.Comment.objects.all().count() == 8
+    assert len(documents_to_delete) == 9
+
+    user_to_delete.delete()
+
+    for document in documents_to_delete:
+        assert models.Document.objects.filter(id=document.id).exists() is False
+
+    for document in documents_to_keep:
+        assert models.Document.objects.filter(id=document.id).exists()
+
+    for document in documents_creator_set_to_null:
+        document.refresh_from_db()
+        assert document.creator is None
+
+    assert models.DocumentAccess.objects.filter(user_id=user_to_delete.id).count() == 0
+    assert (
+        models.Document.objects.all().count() == 21
+    )  # models.Document.objects.all().count() - len(documents_to_delete)
+    assert models.LinkTrace.objects.all().count() == 6
+
+    # Number of threads and comments should not have changed
+    assert models.Thread.objects.all().count() == 4
+    assert models.Comment.objects.all().count() == 8
+
+    for thread in threads_owned_by_user_to_delete:
+        thread.refresh_from_db()
+        assert thread.creator is None
+
+        assert (
+            models.Comment.objects.filter(thread=thread, user__isnull=True).count() == 1
+        )
+        assert (
+            models.Comment.objects.filter(thread=thread, user=other_user).count() == 1
+        )
+
+    for thread in threads_owned_by_other_user:
+        thread.refresh_from_db()
+        assert thread.creator == other_user
+        assert (
+            models.Comment.objects.filter(thread=thread, user__isnull=True).count() == 1
+        )
+        assert (
+            models.Comment.objects.filter(thread=thread, user=other_user).count() == 1
+        )
+
+    assert models.User.objects.filter(id=user_to_delete.id).exists() is False
+
+
+@pytest.mark.django_db(transaction=True)
+def test_tasks_user_delete_nothing_to_delete():
+    """Delete a user not having creating data yet."""
+
+    user_to_delete = factories.UserFactory()
+    other_user = factories.UserFactory()
+
+    factories.DocumentFactory.create_batch(
+        4,
+        creator=other_user,
+        users=[
+            (other_user, models.RoleChoices.OWNER),
+        ],
+    )
+
+    # Create other link traces for the other user
+    #
+    factories.DocumentFactory.create_batch(3, link_traces=[other_user])
+
+    threads_owned_by_other_user = factories.ThreadFactory.create_batch(
+        2, creator=other_user
+    )
+
+    # create comments for bot users in all existing threads
+    comments = []
+    for thread in threads_owned_by_other_user:
+        comments.append(factories.CommentFactory(thread=thread, user=other_user))
+
+    assert models.DocumentAccess.objects.count() == 4
+    assert models.Document.objects.all().count() == 9
+    assert models.LinkTrace.objects.all().count() == 3
+    assert models.Thread.objects.all().count() == 2
+    assert models.Comment.objects.all().count() == 2
+
+    user_to_delete.delete()
+
+    assert models.DocumentAccess.objects.count() == 4
+    assert models.Document.objects.all().count() == 9
+    assert models.LinkTrace.objects.all().count() == 3
+    assert models.Thread.objects.all().count() == 2
+    assert models.Comment.objects.all().count() == 2
+    assert models.User.objects.filter(id=user_to_delete.id).exists() is False
+
+
+@pytest.mark.django_db(transaction=True)
+def test_tasks_user_delete_only_owner_but_not_creator():
+    """Test delete a user who is sole owner of a document but not the creator should work."""
+
+    user_to_delete = factories.UserFactory()
+    other_user = factories.UserFactory()
+
+    document_to_delete = factories.DocumentFactory(
+        creator=other_user, users=[(user_to_delete, models.RoleChoices.OWNER)]
+    )
+
+    document_to_keep = factories.DocumentFactory(
+        creator=other_user,
+        users=[
+            (other_user, models.RoleChoices.OWNER),
+            (user_to_delete, models.RoleChoices.OWNER),
+        ],
+    )
+
+    assert models.DocumentAccess.objects.filter(user=user_to_delete).count() == 2
+    assert models.Document.objects.all().count() == 2
+
+    user_to_delete.delete()
+
+    assert models.DocumentAccess.objects.filter(user_id=user_to_delete.id).count() == 0
+    assert models.Document.objects.all().count() == 1
+
+    assert models.Document.objects.filter(id=document_to_delete.id).exists() is False
+    assert models.Document.objects.filter(id=document_to_keep.id).exists() is True
+
+    assert models.User.objects.filter(id=user_to_delete.id).exists() is False
+
+
+@pytest.mark.django_db(transaction=True)
+def test_tasks_user_delete_error_during_deletion_should_rollback_deletion(monkeypatch):
+    """Test transaction is correctly working by forcing an error during user deletion."""
+
+    user_to_delete = factories.UserFactory()
+    other_user = factories.UserFactory()
+
+    # Documents where the user is the sole owner
+    documents_to_delete = factories.DocumentFactory.create_batch(
+        3, creator=user_to_delete, users=[(user_to_delete, models.RoleChoices.OWNER)]
+    )
+    # Documents where the user is not the sole owner
+    factories.DocumentFactory.create_batch(
+        4,
+        creator=other_user,
+        users=[
+            (user_to_delete, models.RoleChoices.OWNER),
+            (other_user, models.RoleChoices.OWNER),
+        ],
+    )
+    # descendants of a document to delete should also be removed
+    depth = 5
+    for _ in range(depth + 1):
+        documents_to_delete.append(
+            factories.DocumentFactory(parent=documents_to_delete[-1])
+        )
+
+    # Documents created by the user to delete and should be set to null
+    factories.DocumentFactory.create_batch(3, creator=user_to_delete)
+
+    # Non creator nor owner document but with accesses to delete
+    for role in models.RoleChoices.values:
+        if role == models.RoleChoices.OWNER.value:
+            continue
+
+        factories.DocumentFactory(users=[(user_to_delete, role)])
+
+    # create 3 link traces
+    #
+    factories.DocumentFactory.create_batch(3, link_traces=[user_to_delete, other_user])
+    # Create other link traces for the other user
+    #
+    factories.DocumentFactory.create_batch(3, link_traces=[other_user])
+
+    # Threads created by the user to delete should be set to null
+    threads_owned_by_user_to_delete = factories.ThreadFactory.create_batch(
+        2, creator=user_to_delete
+    )
+    # Threads created by the other user should not change
+    threads_owned_by_other_user = factories.ThreadFactory.create_batch(
+        2, creator=other_user
+    )
+
+    # create comments for bot users in all existing threads
+    comments = []
+    for thread in threads_owned_by_user_to_delete + threads_owned_by_other_user:
+        comments.append(factories.CommentFactory(thread=thread, user=user_to_delete))
+        comments.append(factories.CommentFactory(thread=thread, user=other_user))
+
+    assert models.DocumentAccess.objects.filter(user=user_to_delete).count() == 11
+    assert models.Document.objects.all().count() == 30
+    assert models.LinkTrace.objects.all().count() == 9
+    assert models.Thread.objects.all().count() == 4
+    assert models.Comment.objects.all().count() == 8
+    assert len(documents_to_delete) == 9
+
+    def mock_clear_user_created_documents(self):
+        raise DatabaseError()
+
+    monkeypatch.setattr(
+        models.User, "_clear_user_created_documents", mock_clear_user_created_documents
+    )
+
+    with pytest.raises(DatabaseError):
+        user_to_delete.delete()
+
+    assert models.DocumentAccess.objects.filter(user=user_to_delete).count() == 11
+    assert models.Document.objects.all().count() == 30
+    assert models.LinkTrace.objects.all().count() == 9
+    assert models.Thread.objects.all().count() == 4
+    assert models.Comment.objects.all().count() == 8
+    assert len(documents_to_delete) == 9
+
+    assert models.User.objects.filter(id=user_to_delete.id).exists() is True

--- a/src/backend/core/tests/test_utils.py
+++ b/src/backend/core/tests/test_utils.py
@@ -130,10 +130,10 @@ def test_utils_users_sharing_documents_with_cache_miss():
     factories.UserDocumentAccessFactory(user=user2, document=doc1)
     factories.UserDocumentAccessFactory(user=user3, document=doc2)
 
-    cache_key = get_users_sharing_documents_with_cache_key(user1)
+    cache_key = get_users_sharing_documents_with_cache_key(user1.id)
     cache.delete(cache_key)
 
-    result = users_sharing_documents_with(user1)
+    result = users_sharing_documents_with(user1.id)
 
     assert user2.id in result
 
@@ -150,12 +150,12 @@ def test_utils_users_sharing_documents_with_cache_hit():
     factories.UserDocumentAccessFactory(user=user1, document=doc1)
     factories.UserDocumentAccessFactory(user=user2, document=doc1)
 
-    cache_key = get_users_sharing_documents_with_cache_key(user1)
+    cache_key = get_users_sharing_documents_with_cache_key(user1.id)
 
     test_cached_data = {user2.id: "2025-02-10"}
     cache.set(cache_key, test_cached_data, 86400)
 
-    result = users_sharing_documents_with(user1)
+    result = users_sharing_documents_with(user1.id)
     assert result == test_cached_data
 
 
@@ -167,7 +167,7 @@ def test_utils_users_sharing_documents_with_cache_invalidation_on_create():
     doc1 = factories.DocumentFactory()
 
     # Pre-populate cache
-    cache_key = get_users_sharing_documents_with_cache_key(user1)
+    cache_key = get_users_sharing_documents_with_cache_key(user1.id)
     cache.set(cache_key, {}, 86400)
 
     # Verify cache exists
@@ -193,7 +193,7 @@ def test_utils_users_sharing_documents_with_cache_invalidation_on_delete():
 
     doc_access = factories.UserDocumentAccessFactory(user=user1, document=doc1)
 
-    cache_key = get_users_sharing_documents_with_cache_key(user1)
+    cache_key = get_users_sharing_documents_with_cache_key(user1.id)
     cache.set(cache_key, {user2.id: "2025-02-10"}, 86400)
 
     assert cache.get(cache_key) is not None
@@ -207,10 +207,10 @@ def test_utils_users_sharing_documents_with_empty_result():
     """Test when user is not sharing any documents."""
     user1 = factories.UserFactory()
 
-    cache_key = get_users_sharing_documents_with_cache_key(user1)
+    cache_key = get_users_sharing_documents_with_cache_key(user1.id)
     cache.delete(cache_key)
 
-    result = users_sharing_documents_with(user1)
+    result = users_sharing_documents_with(user1.id)
 
     assert result == {}
 

--- a/src/backend/core/tests/test_utils_users_sharing_documents_with.py
+++ b/src/backend/core/tests/test_utils_users_sharing_documents_with.py
@@ -55,7 +55,7 @@ def test_utils_users_sharing_documents_with():
     doc_3_pierre_2.created_at = yesterday
     doc_3_pierre_2.save()
 
-    shared_map = users_sharing_documents_with(user)
+    shared_map = users_sharing_documents_with(user.id)
 
     assert shared_map == {
         pierre_1.id: last_week,

--- a/src/backend/core/utils/users.py
+++ b/src/backend/core/utils/users.py
@@ -12,35 +12,35 @@ from core import models
 logger = logging.getLogger(__name__)
 
 
-def get_users_sharing_documents_with_cache_key(user):
+def get_users_sharing_documents_with_cache_key(user_id):
     """Generate a unique cache key for each user."""
-    return f"users_sharing_documents_with_{user.id}"
+    return f"users_sharing_documents_with_{user_id}"
 
 
-def users_sharing_documents_with(user):
+def users_sharing_documents_with(user_id):
     """
     Returns a map of users sharing documents with the given user,
     sorted by last shared date.
     """
     start_time = time.time()
-    cache_key = get_users_sharing_documents_with_cache_key(user)
+    cache_key = get_users_sharing_documents_with_cache_key(user_id)
     cached_result = cache.get(cache_key)
 
     if cached_result is not None:
         elapsed = time.time() - start_time
         logger.info(
             "users_sharing_documents_with cache hit for user %s (took %.3fs)",
-            user.id,
+            user_id,
             elapsed,
         )
         return cached_result
 
-    user_docs_qs = models.DocumentAccess.objects.filter(user=user).values_list(
+    user_docs_qs = models.DocumentAccess.objects.filter(user__id=user_id).values_list(
         "document_id", flat=True
     )
     shared_qs = (
-        models.DocumentAccess.objects.filter(document_id__in=Subquery(user_docs_qs))
-        .exclude(user=user)
+        models.DocumentAccess.objects.filter(document__id__in=Subquery(user_docs_qs))
+        .exclude(user__id=user_id)
         .values("user")
         .annotate(last_shared=db.Max("created_at"))
     )
@@ -49,7 +49,7 @@ def users_sharing_documents_with(user):
     elapsed = time.time() - start_time
     logger.info(
         "users_sharing_documents_with cache miss for user %s (took %.3fs)",
-        user.id,
+        user_id,
         elapsed,
     )
     return result


### PR DESCRIPTION
## Purpose

Deleting a user is not possible when it has created docs because the
on_delete on the Document class id RESTRICT and we don't want to change
it. We decided to have a specific workflow for correctly delete a user.
The document where the user is the sole owner must be deleted, the other
only the owner access must be deleted. For the remaining Documents where
the user is the creator, we set it to `null`, then the user can be
delete, remaining relations are deleted in cascade.


## Proposal

* [x] ♻️(backend) use user_id instead of user relation in sharing module
* [x] ✨(backend) specific user delete method to delete its relations
* [x] ♻️(backend) change how a user is deleted in the admin

Fix #1110 