### PR TITLE
🐛(backend) hide restore action for inherited deletion

### DIFF
--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1400,7 +1400,7 @@ class Document(MP_Node, BaseModel):
             "leave": can_leave,
             "move": is_owner_or_admin and not is_deleted,
             "partial_update": can_update,
-            "restore": is_owner,
+            "restore": is_owner and bool(self.deleted_at),
             "retrieve": retrieve,
             "media_auth": can_get,
             "link_select_options": link_select_options,

--- a/src/backend/core/tests/documents/test_api_documents_restore.py
+++ b/src/backend/core/tests/documents/test_api_documents_restore.py
@@ -110,24 +110,6 @@ def test_api_documents_restore_authenticated_owner_ancestor_deleted():
     assert grand_parent_deleted_at > document_deleted_at
 
 
-def test_api_documents_restore_ability_false_when_only_ancestor_deleted():
-    """The restore ability should be false when only an ancestor is deleted."""
-    user = factories.UserFactory()
-    client = APIClient()
-    client.force_login(user)
-
-    parent = factories.DocumentFactory()
-    document = factories.DocumentFactory(parent=parent)
-    factories.UserDocumentAccessFactory(document=document, user=user, role="owner")
-
-    parent.soft_delete()
-
-    response = client.get(f"/api/v1.0/documents/{document.id!s}/")
-
-    assert response.status_code == 200
-    assert response.json()["abilities"]["restore"] is False
-
-
 def test_api_documents_restore_authenticated_owner_expired():
     """It should not be possible to restore a document beyond the allowed time limit."""
     user = factories.UserFactory()

--- a/src/backend/core/tests/documents/test_api_documents_restore.py
+++ b/src/backend/core/tests/documents/test_api_documents_restore.py
@@ -110,6 +110,24 @@ def test_api_documents_restore_authenticated_owner_ancestor_deleted():
     assert grand_parent_deleted_at > document_deleted_at
 
 
+def test_api_documents_restore_ability_false_when_only_ancestor_deleted():
+    """The restore ability should be false when only an ancestor is deleted."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    parent = factories.DocumentFactory()
+    document = factories.DocumentFactory(parent=parent)
+    factories.UserDocumentAccessFactory(document=document, user=user, role="owner")
+
+    parent.soft_delete()
+
+    response = client.get(f"/api/v1.0/documents/{document.id!s}/")
+
+    assert response.status_code == 200
+    assert response.json()["abilities"]["restore"] is False
+
+
 def test_api_documents_restore_authenticated_owner_expired():
     """It should not be possible to restore a document beyond the allowed time limit."""
     user = factories.UserFactory()

--- a/src/backend/core/tests/test_models_documents.py
+++ b/src/backend/core/tests/test_models_documents.py
@@ -458,7 +458,7 @@ def test_models_documents_get_abilities_owner(django_assert_num_queries):
         "media_check": True,
         "move": True,
         "partial_update": True,
-        "restore": True,
+        "restore": False,
         "retrieve": True,
         "tree": True,
         "update": True,
@@ -513,6 +513,20 @@ def test_models_documents_get_abilities_owner(django_assert_num_queries):
         "versions_retrieve": False,
         "search": False,
     }
+
+
+def test_models_documents_get_abilities_restore_false_when_only_ancestor_deleted():
+    """The restore ability should be false when only an ancestor is deleted."""
+    user = factories.UserFactory()
+    parent = factories.DocumentFactory()
+    document = factories.DocumentFactory(parent=parent, users=[(user, "owner")])
+
+    parent.soft_delete()
+    document.refresh_from_db()
+
+    assert document.deleted_at is None
+    assert document.ancestors_deleted_at == parent.deleted_at
+    assert document.get_abilities(user)["restore"] is False
 
 
 @override_settings(


### PR DESCRIPTION
## Purpose

Fix #2127.

When a parent document is soft-deleted, child documents inherit the deleted state through `ancestors_deleted_at`. However, child documents still exposed the `restore` ability even when the child document itself was not directly deleted.

This could make the frontend show a restore action for a child document that cannot be restored independently.

## Proposal

* Expose the `restore` ability only when the document itself has `deleted_at` set.
* Add a backend test covering the case where only an ancestor document is deleted.

## External contributions

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added corresponding tests for new features or bug fixes (if applicable)

*Skip the checkbox below 👇 if you're fixing an issue or adding documentation*
* [ ] Before submitting a PR for a new feature I made sure to contact the product manager

### CI requirements

* [ ] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [ ] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [ ] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer