### PR TITLE
♿️(frontend) hide mobile left panel from screen readers when collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to
 
 - 🐛(frontend) fix removed item in the tree #2420
 
+### Changed
+
+- ♿️(frontend) hide mobile left panel from screen readers when collapsed #2450
 
 ## [v5.3.0] - 2026-06-19
 

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanel.tsx
@@ -93,6 +93,7 @@ const LeftPanelMobile = () => {
       <Box
         $hasTransition
         $height="100vh"
+        inert={!isPanelOpenMobile}
         $css={css`
           z-index: 999;
           width: 100dvw;


### PR DESCRIPTION
## Purpose

Fix side panel content exposed to screen readers when collapsed on **mobile** only. Desktop was already handled.

## Proposal

* [x] Add `inert={!isPanelOpenMobile}` on the mobile left panel
