### PR TITLE
♿️(frontend) limit share modal opening announcement for screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Changed
 
 - ♻️(backend) reset collaboration connection in cascade for all children #2507
+- ♿️(frontend) limit share modal opening announcement for screen readers #2452
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to
 ### Changed
 
 - ♻️(backend) reset collaboration connection in cascade for all children #2507
+- ♿️(frontend) limit share modal opening announcement for screen readers #2452
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
@@ -40,7 +40,8 @@ import {
 import { QuickSearchGroupMember } from './DocShareMember';
 import { DocShareModalFooter } from './DocShareModalFooter';
 
-const DEBOUNCE_MS = 300;
+const SEARCH_QUERY_DEBOUNCE_MS = 300;
+const ACCESSIBILITY_REEXPOSURE_DELAY_MS = 300;
 
 const ShareModalStyle = createGlobalStyle`
   .--docs--doc-share-modal [cmdk-item] {
@@ -122,7 +123,7 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
 
   const onFilter = useDebouncedCallback((str: string) => {
     setUserQuery(str);
-  }, DEBOUNCE_MS);
+  }, SEARCH_QUERY_DEBOUNCE_MS);
 
   const onRemoveUser = (row: User) => {
     setSelectedUsers((prevState) => {
@@ -176,7 +177,7 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
 
     const id = window.setTimeout(() => {
       setIsContentAccessible(true);
-    }, DEBOUNCE_MS);
+    }, ACCESSIBILITY_REEXPOSURE_DELAY_MS);
 
     return () => window.clearTimeout(id);
   }, [canShare]);

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
@@ -168,8 +168,11 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
   // accessibility tree during the opening announcement, then restore it.
   useEffect(() => {
     if (canShare) {
+      setIsContentAccessible(true);
       return;
     }
+
+    setIsContentAccessible(false);
 
     const id = window.setTimeout(() => {
       setIsContentAccessible(true);

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
@@ -40,6 +40,8 @@ import {
 import { QuickSearchGroupMember } from './DocShareMember';
 import { DocShareModalFooter } from './DocShareModalFooter';
 
+const DEBOUNCE_MS = 300;
+
 const ShareModalStyle = createGlobalStyle`
   .--docs--doc-share-modal [cmdk-item] {
     cursor: auto;
@@ -84,6 +86,7 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
 
   const [listHeight, setListHeight] = useState<string>('400px');
   const canShare = doc.abilities.accesses_manage && isRootDoc;
+  const [isContentAccessible, setIsContentAccessible] = useState(canShare);
   const canViewAccesses = doc.abilities.accesses_view;
   const showMemberSection = inputValue === '' && selectedUsers.length === 0;
   const showFooter = selectedUsers.length === 0 && !inputValue;
@@ -119,7 +122,7 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
 
   const onFilter = useDebouncedCallback((str: string) => {
     setUserQuery(str);
-  }, 300);
+  }, DEBOUNCE_MS);
 
   const onRemoveUser = (row: User) => {
     setSelectedUsers((prevState) => {
@@ -161,6 +164,20 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
   const showInheritedShareContent =
     inheritedAccesses.length > 0 && showMemberSection && !isRootDoc;
 
+  // When the search input is hidden, keep the modal content out of the
+  // accessibility tree during the opening announcement, then restore it.
+  useEffect(() => {
+    if (canShare) {
+      return;
+    }
+
+    const id = window.setTimeout(() => {
+      setIsContentAccessible(true);
+    }, DEBOUNCE_MS);
+
+    return () => window.clearTimeout(id);
+  }, [canShare]);
+
   // Invalidate relevant queries to ensure fresh data on modal open
   useEffect(() => {
     [
@@ -197,6 +214,7 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
               {t('Share the document')}
             </Text>
             <ButtonCloseModal
+              autoFocus={!canShare}
               aria-label={t('Close the share modal')}
               onClick={onClose}
             />
@@ -206,6 +224,7 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
       >
         <ShareModalStyle />
         <Box
+          aria-hidden={isContentAccessible ? undefined : true}
           $height="auto"
           $maxHeight={canViewAccesses ? modalContentHeight : 'none'}
           $overflow="hidden"

--- a/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/components/DocShareModal.tsx
@@ -227,6 +227,9 @@ export const DocShareModal = ({ doc, onClose, isRootDoc = true }: Props) => {
         hideCloseButton
       >
         <ShareModalStyle />
+        {/* aria-hidden is temporary (300ms) to prevent NVDA from reading
+            the entire modal body on open when the search input is absent.
+            autoFocus alone on the close button is not enough. */}
         <Box
           aria-hidden={isContentAccessible ? undefined : true}
           $height="auto"


### PR DESCRIPTION
## Purpose

Limit the screen reader announcement when opening the share modal without the search input.

## Proposal

* [x] Autofocus the close button when the search input is hidden