### PR TITLE
🐛(frontend) fix service worker causing reload on tab focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(frontend) fix removed item in the tree #2420
+- 🐛(frontend) fix service worker causing reload on tab focus #2454
 
 ## [v5.3.0] - 2026-06-19
 

--- a/src/frontend/apps/impress/src/features/service-worker/hooks/useSWRegister.tsx
+++ b/src/frontend/apps/impress/src/features/service-worker/hooks/useSWRegister.tsx
@@ -34,22 +34,33 @@ export const useSWRegister = () => {
         console.error('Service worker registration failed:', err);
       });
 
+    const SW_RELOAD_KEY = 'sw-reloaded';
     let refreshing = false;
     const onControllerChange = () => {
       if (!hadControllerAtStart || refreshing) {
         return;
       }
 
+      if (sessionStorage.getItem(SW_RELOAD_KEY) === '1') {
+        sessionStorage.removeItem(SW_RELOAD_KEY);
+        return;
+      }
+
       refreshing = true;
 
-      if (document.visibilityState === 'visible') {
+      const doReload = () => {
+        sessionStorage.setItem(SW_RELOAD_KEY, '1');
         window.location.reload();
+      };
+
+      if (document.visibilityState === 'visible') {
+        doReload();
         return;
       }
 
       const onVisible = () => {
         if (document.visibilityState === 'visible') {
-          window.location.reload();
+          doReload();
         }
       };
 


### PR DESCRIPTION
## Purpose

During rolling deploys, multiple replicas serve different builds of service-worker.js (each build has a random buildId baked in).
This causes a controllerchange loop: the new SW activates via skipWaiting, the page reloads, then the next request may hit an older replica,triggering another update and another reload — surfacing as a reload every time the tab becomes visible.

We added a sessionStorage guard so a controllerchange triggers at most one automatic reload per session; subsequent flaps between versions are silently ignored, while legitimate updates still cause a single reload automatically.