### PR TITLE
♿️(frontend) remove redundant aria-label on table of contents links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - ♻️(frontend) new create button for docs #2423
 - ♿️(frontend) align search modal field label with placeholder #2384
 - 🚚(frontend) move Waffle to bottom left #2455
+- ♿️(frontend) remove redundant aria-label on table of contents links #2459
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-table-content/components/Heading.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-table-content/components/Heading.tsx
@@ -85,7 +85,6 @@ export const Heading = ({
           border-radius: var(--c--globals--spacings--st);
         }
       `}
-      aria-label={text}
       aria-current={isHighlight ? 'true' : undefined}
     >
       <Text


### PR DESCRIPTION
## Purpose

Remove redundant `aria-label` on TOC links ([2390](https://github.com/suitenumerique/docs/pull/2390) follow-up). Visible link text is already an explicit accessible name.

## Proposal

* [x] Remove `aria-label` from TOC `Heading` anchors
