### PR TITLE
🛂(backend) remove unused default authentication backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to
 - 🐛(frontend) fix service worker causing reload on tab focus #2454
 - 🐛(backend) update restore ability for inherited deletion #2148
 
+### Removed
+
+- 🔥(backend) remove unused default authentication backend
+
 ## [v5.3.0] - 2026-06-19
 
 ### Added

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -10,11 +10,15 @@ from lasuite.marketing.tasks import create_or_update_contact
 from lasuite.oidc_login.backends import (
     OIDCAuthenticationBackend as LaSuiteOIDCAuthenticationBackend,
 )
+from rest_framework.authentication import (
+    SessionAuthentication as BaseSessionAuthentication,
+)
 
 from core.models import DuplicateEmailError
 from core.utils.analytics import PosthogEventName, posthog_capture
 
 logger = logging.getLogger(__name__)
+
 
 # Settings renamed warnings
 if os.environ.get("USER_OIDC_FIELDS_TO_FULLNAME"):
@@ -81,3 +85,19 @@ class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
 
         if user:
             posthog_capture(PosthogEventName.USER_LOGIN, user)
+
+
+class SessionAuthentication(BaseSessionAuthentication):
+    """
+    SessionAuthentication that yields a 401 (instead of 403) for unauthenticated requests.
+
+    DRF chooses between 401 and 403 based on whether the first authentication class returns a
+    truthy `authenticate_header`. The stock `SessionAuthentication` does not implement it
+    (it inherits `BaseAuthentication.authenticate_header`, which returns `None`), so anonymous
+    requests get a misleading 403. Returning a value restores the correct 401, signalling that the
+    client may authenticate and retry.
+    """
+
+    def authenticate_header(self, request):
+        """Return a non-empty challenge so DRF responds with 401 rather than 403."""
+        return "Session"

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -404,8 +404,7 @@ class Base(Configuration):
 
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (
-            "mozilla_django_oidc.contrib.drf.OIDCAuthentication",
-            "rest_framework.authentication.SessionAuthentication",
+            "core.authentication.backends.SessionAuthentication",
         ),
         "DEFAULT_PARSER_CLASSES": [
             "rest_framework.parsers.JSONParser",


### PR DESCRIPTION
## Purpose

The authentication backend
mozilla_django_oidc.contrib.drf.OIDCAuthentication
is present in the default authentication classes for the REST_FRAMEWORK
settings. This backend should not be used by our application and can
lead to the usage of our main api with an access_token instead of the
cookie session.
We need to override the drf SessionAuthentication backend to implement
the authenticate_header method. Without this, a 403 status code is
returned, but it is not valid. It must a be 401

## Proposal

* 🛂(backend) remove unused default authentication backend
