### PR TITLE
🔧(helm) mount custom cacert in yprovider deployment

### DIFF
--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -174,6 +174,22 @@ yProvider:
     COLLABORATION_SERVER_ORIGIN: https://docs.127.0.0.1.nip.io
     COLLABORATION_SERVER_SECRET: my-secret
     Y_PROVIDER_API_KEY: my-secret
+    NODE_EXTRA_CA_CERTS: /cert/cacert.pem
+
+  # Extra volume mounts to manage our local custom CA and avoid to set ssl_verify: false
+  extraVolumeMounts:
+    - name: certs
+      mountPath: /cert/cacert.pem
+      subPath: cacert.pem
+
+  # Extra volumes to manage our local custom CA and avoid to set ssl_verify: false
+  extraVolumes:
+    - name: certs
+      configMap:
+        name: certifi
+        items:
+        - key: cacert.pem
+          path: cacert.pem
 
 docSpec:
   enabled: true


### PR DESCRIPTION
## Purpose

In the yprovider deployment we now need to mount the cacert containing the certificates generated by mkcert. Then, we have to declare the environment variable NODE_EXTRA_CA_CERTS with the path where this cacert is mounted. With this new config we don't have tls issue anymore.

## Proposal

* [x] 🔧(helm) mount custom cacert in yprovider deployment