### PR TITLE
🐛(frontend) stop force index redirect when delete doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to
 - 🐛(frontend) fix removed item in the tree #2420
 - 🐛(frontend) fix service worker causing reload on tab focus #2454
 - 🐛(backend) update restore ability for inherited deletion #2148
+- 🐛(frontend) stop force index redirect when delete doc #2490
 
 ### Removed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-management/components/ModalRemoveDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/components/ModalRemoveDoc.tsx
@@ -6,7 +6,6 @@ import {
   VariantType,
   useToastProvider,
 } from '@gouvfr-lasuite/cunningham-react';
-import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -36,7 +35,6 @@ export const ModalRemoveDoc = ({
   const { t } = useTranslation();
   const { data: config } = useConfig();
   const trashBinCutoffDays = config?.TRASHBIN_CUTOFF_DAYS || 30;
-  const { push } = useRouter();
   const { hasChildren } = useDocUtils(doc);
   const cancelButtonRef = useRef<ButtonElement>(null);
 
@@ -50,8 +48,6 @@ export const ModalRemoveDoc = ({
       onSuccess: () => {
         if (onSuccess) {
           onSuccess(doc);
-        } else {
-          void push('/');
         }
 
         onClose();


### PR DESCRIPTION
## Purpose

Depends the state, after deleted a doc, we were automatically redirecting to the index page, which is not always the desired behavior. This change stops the automatic redirect after deleting a document, allowing for more flexible navigation based on user context.
