### PR TITLE
🔧(dev) make the dev stack domain-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to
 - 🐛(frontend) fix removed item in the tree #2420
 - 🐛(frontend) fix service worker causing reload on tab focus #2454
 - 🐛(backend) update restore ability for inherited deletion #2148
+- 🔧(dev) make the dev stack domain-agnostic #2498
 - 🐛(frontend) stop force index redirect when delete doc #2490
 
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ create-env-local-files:
 	@touch env.d/development/crowdin.local
 	@touch env.d/development/common.local
 	@touch env.d/development/postgresql.local
+	@touch env.d/development/kc_auth.local
 	@touch env.d/development/kc_postgresql.local
 .PHONY: create-env-local-files
 

--- a/compose.yml
+++ b/compose.yml
@@ -231,11 +231,13 @@ services:
     image: quay.io/keycloak/keycloak:26.3
     volumes:
       - ./docker/auth/realm.json:/opt/keycloak/data/import/realm.json
+    env_file:
+      - env.d/development/kc_auth
+      - env.d/development/kc_auth.local
     command:
       - start-dev
       - --features=preview
       - --import-realm
-      - --hostname=http://localhost:8083
       - --hostname-strict=false
       - --health-enabled=true
       - --metrics-enabled=true
@@ -249,16 +251,6 @@ services:
       interval: 1s
       timeout: 2s
       retries: 300
-    environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
-      KC_DB: postgres
-      KC_DB_URL_HOST: kc_postgresql
-      KC_DB_URL_DATABASE: keycloak
-      KC_DB_PASSWORD: pass
-      KC_DB_USERNAME: impress
-      KC_DB_SCHEMA: public
-      PROXY_ADDRESS_FORWARDING: "true"
     ports:
       - "8080:8080"
     depends_on:

--- a/docker/auth/realm.json
+++ b/docker/auth/realm.json
@@ -687,19 +687,8 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "secret": "ThisIsAnExampleKeyForDevPurposeOnly",
-      "redirectUris": [
-        "http://localhost:8070/*",
-        "http://localhost:8071/*",
-        "http://localhost:3200/*",
-        "http://localhost:8088/*",
-        "http://localhost:3000/*"
-      ],
-      "webOrigins": [
-        "http://localhost:3200",
-        "http://localhost:8088",
-        "http://localhost:8070",
-        "http://localhost:3000"
-      ],
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
       "notBefore": 0,
       "bearerOnly": false,
       "consentRequired": false,

--- a/docker/files/etc/nginx/conf.d/default.conf
+++ b/docker/files/etc/nginx/conf.d/default.conf
@@ -39,7 +39,7 @@ server {
 
     location / {
         proxy_pass http://keycloak:8080;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 

--- a/env.d/development/kc_auth
+++ b/env.d/development/kc_auth
@@ -1,0 +1,12 @@
+# Keycloak
+
+KC_HOSTNAME=http://localhost:8083
+KEYCLOAK_ADMIN: admin
+KEYCLOAK_ADMIN_PASSWORD: admin
+KC_DB: postgres
+KC_DB_URL_HOST: kc_postgresql
+KC_DB_URL_DATABASE: keycloak
+KC_DB_PASSWORD: pass
+KC_DB_USERNAME: impress
+KC_DB_SCHEMA: public
+PROXY_ADDRESS_FORWARDING: "true"

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -1247,7 +1247,11 @@ class Development(Base):
 
     ALLOWED_HOSTS = ["*"]
     CORS_ALLOW_ALL_ORIGINS = True
-    CSRF_TRUSTED_ORIGINS = ["http://localhost:8072", "http://localhost:3000"]
+    CSRF_TRUSTED_ORIGINS = values.ListValue(
+        ["http://localhost:8072", "http://localhost:3000"],
+        environ_name="DJANGO_CSRF_TRUSTED_ORIGINS",
+        environ_prefix=None,
+    )
     CORS_ALLOW_HEADERS = (
         *default_headers,
         "if-none-match",


### PR DESCRIPTION
## Purpose

Trying the dev app on mobile phone was not easily possible because of hardcoded variables.
Keycloak's hostname, its client's redirect/web origins, and Django's CSRF trusted origins were hardcoded to localhost, so the dev stack was only reachable from that exact origin.
It is now possible to run the dev stack on any domains depending what is configured in the env files.

## Demo


https://github.com/user-attachments/assets/edfffbd9-a74b-47fd-9aac-a5f1a7eae211


