### PR TITLE
🔊(y-provider) capture convert handler errors in Sentry

### DIFF
--- a/src/frontend/servers/y-provider/src/handlers/convertHandler.ts
+++ b/src/frontend/servers/y-provider/src/handlers/convertHandler.ts
@@ -5,6 +5,7 @@ import {
   YjsThreadStore,
 } from '@blocknote/core/comments';
 import { ServerBlockNoteEditor } from '@blocknote/server-util';
+import * as Sentry from '@sentry/node';
 import { Request, Response } from 'express';
 import * as Y from 'yjs';
 
@@ -191,6 +192,14 @@ export const convertHandler = async (
       .setHeader('content-type', accept)
       .send(await writer.write(blocks ?? []));
   } catch (e) {
+    Sentry.captureException(e, {
+      tags: { handler: 'convert' },
+      extra: {
+        contentType,
+        accept,
+        bodyBytes: req.body?.length ?? 0,
+      },
+    });
     logger('conversion failed:', e);
     res.status(500).json({ error: 'An error occurred' });
   }


### PR DESCRIPTION
The y-provider `/api/convert` handler catches every writer/reader exception and returns a generic `{"error":"An error occurred"}` 500. The real JS exception is silently dropped: `logger()` only prints to stdout when `COLLABORATION_LOGGING=true`, and Sentry's `setupExpressErrorHandler` only sees unhandled errors — never this one.

Result: Sentry issues `DOCS-4ZY` / `DOCS-4ZZ` / `DOCS-6DK` all fire on every 500, but none of them carry the underlying JS stack, making root-cause diagnosis impossible from Python alone.

This patch adds `Sentry.captureException` in the outer catch with `handler:convert` tag and `contentType` / `accept` / `bodyBytes` extras. Behavior otherwise unchanged.

All 55 y-provider tests pass. LSP and eslint clean.

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer