### PR TITLE
📝(doc) add email.eu to the list of public instances

### DIFF
--- a/documentation/instances.md
+++ b/documentation/instances.md
@@ -43,9 +43,9 @@ If you run a public instance and would like it listed here, feel free to open a 
 ### email.eu
 
 **Organization:** Email.eu  
-**Type:** Sovereign business workspace  
-**Access:** Account required  
-<https://email.eu/>
+**Type:** Demo instance  
+**Access:** Open, no account needed  
+<https://email-eu.wiki.email.eu/docs/f23cd0ac-87d6-4b8e-8b55-5a15c814a4b6/>
 
 ### notes.liiib.re
 

--- a/documentation/instances.md
+++ b/documentation/instances.md
@@ -40,6 +40,13 @@ If you run a public instance and would like it listed here, feel free to open a 
 **Type:** Demo instance  
 <https://docs.demo.mosacloud.eu/>
 
+### email.eu
+
+**Organization:** Email.eu  
+**Type:** Sovereign business workspace  
+**Access:** Account required  
+<https://email.eu/>
+
 ### notes.liiib.re
 
 **Organization:** lasuite.coop  


### PR DESCRIPTION
Adds [email.eu](https://email.eu/) to the public instances page.

Email.eu is a sovereign EU business workspace that runs La Suite Docs. This mirrors the [existing entry in La Suite Meet](https://github.com/suitenumerique/meet/blob/main/README.md#known-instances).

Thanks for the great work! 🙏