### PR TITLE
✨(frontend) add dark / light / system colour-mode switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 - ♿️(frontend) restore skip to content link after header redesign #2510
 - 🌐(i18n) rename cn_CN to zh_CN, add eo_PL and zh_TW locales #2486
+- ✨(frontend) add dark / light / system colour-mode switcher #2519
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/components/FloatingBar.tsx
+++ b/src/frontend/apps/impress/src/components/FloatingBar.tsx
@@ -19,7 +19,11 @@ const FLOATING_STYLES = css`
     position: absolute;
     inset: 0;
     z-index: -1;
-    background: linear-gradient(180deg, #fff 0%, rgba(255, 255, 255, 0) 100%);
+    background: linear-gradient(
+      180deg,
+      var(--c--contextuals--background--surface--primary) 0%,
+      transparent 100%
+    );
     backdrop-filter: blur(1px);
     -webkit-backdrop-filter: blur(1px);
     mask-image: linear-gradient(180deg, black 50%, transparent 100%);

--- a/src/frontend/apps/impress/src/components/ThemeSwitch.tsx
+++ b/src/frontend/apps/impress/src/components/ThemeSwitch.tsx
@@ -1,0 +1,65 @@
+import { useTranslation } from 'react-i18next';
+import { css } from 'styled-components';
+
+import { ThemeMode, useCunninghamTheme } from '@/cunningham';
+
+import { Box } from './Box';
+import { Icon } from './Icon';
+import { DropdownMenu } from './dropdown-menu/DropdownMenu';
+
+const MODE_ICON: Record<ThemeMode, string> = {
+  light: 'light_mode',
+  dark: 'dark_mode',
+  system: 'brightness_auto',
+};
+
+/**
+ * Colour-mode switcher: light / dark / follow-system. Reads and updates the
+ * persisted `themeMode` in the Cunningham theme store.
+ */
+export const ThemeSwitch = () => {
+  const { t } = useTranslation();
+  const { themeMode, setThemeMode } = useCunninghamTheme();
+
+  const modes: { mode: ThemeMode; label: string }[] = [
+    { mode: 'light', label: t('Light') },
+    { mode: 'dark', label: t('Dark') },
+    { mode: 'system', label: t('System') },
+  ];
+
+  const options = modes.map(({ mode, label }) => ({
+    label,
+    icon: <Icon iconName={MODE_ICON[mode]} $size="sm" aria-hidden />,
+    value: mode,
+    isSelected: themeMode === mode,
+    callback: () => setThemeMode(mode),
+  }));
+
+  return (
+    <DropdownMenu
+      options={options}
+      selectedValues={[themeMode]}
+      label={t('Change theme')}
+      buttonCss={css`
+        transition: all var(--c--globals--transitions--duration)
+          var(--c--globals--transitions--ease-out) !important;
+        border-radius: var(--c--globals--spacings--st);
+        padding: 0.5rem 0.6rem;
+        & .material-icons {
+          color: var(
+            --c--contextuals--content--palette--brand--primary
+          ) !important;
+        }
+      `}
+    >
+      <Box
+        className="--docs--theme-switch"
+        $direction="row"
+        $align="center"
+        aria-label={t('Change theme')}
+      >
+        <Icon iconName={MODE_ICON[themeMode]} $color="inherit" $size="xl" />
+      </Box>
+    </DropdownMenu>
+  );
+};

--- a/src/frontend/apps/impress/src/components/ThemeSwitch.tsx
+++ b/src/frontend/apps/impress/src/components/ThemeSwitch.tsx
@@ -38,7 +38,6 @@ export const ThemeSwitch = () => {
   return (
     <DropdownMenu
       options={options}
-      selectedValues={[themeMode]}
       label={t('Change theme')}
       buttonCss={css`
         transition: all var(--c--globals--transitions--duration)
@@ -52,12 +51,7 @@ export const ThemeSwitch = () => {
         }
       `}
     >
-      <Box
-        className="--docs--theme-switch"
-        $direction="row"
-        $align="center"
-        aria-label={t('Change theme')}
-      >
+      <Box className="--docs--theme-switch" $direction="row" $align="center">
         <Icon iconName={MODE_ICON[themeMode]} $color="inherit" $size="xl" />
       </Box>
     </DropdownMenu>

--- a/src/frontend/apps/impress/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/frontend/apps/impress/src/components/dropdown-menu/DropdownMenu.tsx
@@ -297,7 +297,7 @@ export const DropdownMenu = ({
                   <Icon
                     iconName="check"
                     $size="20px"
-                    $theme="gray"
+                    $color="var(--c--contextuals--content--semantic--neutral--primary)"
                     aria-hidden="true"
                   />
                 )}

--- a/src/frontend/apps/impress/src/components/index.ts
+++ b/src/frontend/apps/impress/src/components/index.ts
@@ -16,3 +16,4 @@ export * from './separators';
 export * from './SkipToContent';
 export * from './Text';
 export * from './TextErrors';
+export * from './ThemeSwitch';

--- a/src/frontend/apps/impress/src/core/config/ConfigProvider.tsx
+++ b/src/frontend/apps/impress/src/core/config/ConfigProvider.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box } from '@/components';
-import { useCunninghamTheme } from '@/cunningham';
+import { getStoredThemeMode, useCunninghamTheme } from '@/cunningham';
 import { useAuthQuery } from '@/features/auth';
 import {
   useCustomTranslations,
@@ -59,6 +59,16 @@ export const ConfigProvider = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     if (!conf?.FRONTEND_THEME) {
+      return;
+    }
+
+    // Light/dark is driven by the user's colour-mode preference (ThemeProvider),
+    // so a stored mode wins, and we ignore the plain light/dark backend defaults.
+    // Non-default brand themes (e.g. `dsfr`) still come from backend config.
+    if (getStoredThemeMode()) {
+      return;
+    }
+    if (conf.FRONTEND_THEME === 'default' || conf.FRONTEND_THEME === 'dark') {
       return;
     }
 

--- a/src/frontend/apps/impress/src/core/config/ThemeProvider.tsx
+++ b/src/frontend/apps/impress/src/core/config/ThemeProvider.tsx
@@ -9,30 +9,42 @@ const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const { theme, setThemeMode } = useCunninghamTheme();
+  const { theme, setThemeMode, applyThemeMode } = useCunninghamTheme();
   const currentLocale = useLocales();
 
   // Apply the persisted colour-mode on mount. The store starts from a stable
   // default (for SSR/hydration parity); this reconciles it to the user's choice
   // before paint, matching what the _document.tsx inline script already painted.
+  // With no explicit preference we resolve `system` in memory only (no persist),
+  // so a backend brand theme (e.g. `dsfr`) can still be applied by ConfigProvider.
   useIsomorphicLayoutEffect(() => {
-    setThemeMode(getStoredThemeMode() ?? 'system');
-  }, [setThemeMode]);
+    const stored = getStoredThemeMode();
+    if (stored) {
+      setThemeMode(stored);
+    } else {
+      applyThemeMode('system');
+    }
+  }, [setThemeMode, applyThemeMode]);
 
-  // While in `system` mode, follow live changes to the OS colour scheme.
+  // While in `system` mode, follow live changes to the OS colour scheme, but
+  // never override a non-default brand theme applied from backend config.
   useEffect(() => {
     if (typeof window === 'undefined' || !window.matchMedia) {
       return;
     }
     const mql = window.matchMedia('(prefers-color-scheme: dark)');
     const onChange = () => {
-      if (useCunninghamTheme.getState().themeMode === 'system') {
-        setThemeMode('system');
+      const state = useCunninghamTheme.getState();
+      if (
+        state.themeMode === 'system' &&
+        (state.theme === 'default' || state.theme === 'dark')
+      ) {
+        state.applyThemeMode('system');
       }
     };
     mql.addEventListener('change', onChange);
     return () => mql.removeEventListener('change', onChange);
-  }, [setThemeMode]);
+  }, []);
 
   return (
     <CunninghamProvider theme={theme} currentLocale={currentLocale}>

--- a/src/frontend/apps/impress/src/core/config/ThemeProvider.tsx
+++ b/src/frontend/apps/impress/src/core/config/ThemeProvider.tsx
@@ -1,11 +1,38 @@
 import { CunninghamProvider } from '@gouvfr-lasuite/cunningham-react';
+import { useEffect, useLayoutEffect } from 'react';
 
-import { useCunninghamTheme } from '@/cunningham';
+import { getStoredThemeMode, useCunninghamTheme } from '@/cunningham';
 import { useLocales } from '@/i18n/useLocale';
 
+// useLayoutEffect warns during SSR; fall back to useEffect on the server.
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const { theme } = useCunninghamTheme();
+  const { theme, setThemeMode } = useCunninghamTheme();
   const currentLocale = useLocales();
+
+  // Apply the persisted colour-mode on mount. The store starts from a stable
+  // default (for SSR/hydration parity); this reconciles it to the user's choice
+  // before paint, matching what the _document.tsx inline script already painted.
+  useIsomorphicLayoutEffect(() => {
+    setThemeMode(getStoredThemeMode() ?? 'system');
+  }, [setThemeMode]);
+
+  // While in `system` mode, follow live changes to the OS colour scheme.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => {
+      if (useCunninghamTheme.getState().themeMode === 'system') {
+        setThemeMode('system');
+      }
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [setThemeMode]);
 
   return (
     <CunninghamProvider theme={theme} currentLocale={currentLocale}>

--- a/src/frontend/apps/impress/src/cunningham/__tests__/useCunninghamTheme.spec.tsx
+++ b/src/frontend/apps/impress/src/cunningham/__tests__/useCunninghamTheme.spec.tsx
@@ -5,16 +5,19 @@ import {
 } from '../useCunninghamTheme';
 
 const setSystemPrefersDark = (matches: boolean) => {
-  window.matchMedia = ((query: string) => ({
-    matches,
-    media: query,
-    onchange: null,
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    dispatchEvent: () => false,
-  })) as unknown as typeof window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
 };
 
 const installStorageMock = () => {
@@ -86,5 +89,13 @@ describe('useCunninghamTheme colour mode', () => {
   it('getStoredThemeMode ignores invalid stored values', () => {
     window.localStorage.setItem(THEME_MODE_STORAGE_KEY, 'bogus');
     expect(getStoredThemeMode()).toBeNull();
+  });
+
+  it('applyThemeMode resolves the theme without persisting', () => {
+    useCunninghamTheme.getState().applyThemeMode('dark');
+
+    expect(useCunninghamTheme.getState().theme).toBe('dark');
+    expect(useCunninghamTheme.getState().themeMode).toBe('dark');
+    expect(window.localStorage.getItem(THEME_MODE_STORAGE_KEY)).toBeNull();
   });
 });

--- a/src/frontend/apps/impress/src/cunningham/__tests__/useCunninghamTheme.spec.tsx
+++ b/src/frontend/apps/impress/src/cunningham/__tests__/useCunninghamTheme.spec.tsx
@@ -1,4 +1,40 @@
-import { useCunninghamTheme } from '../useCunninghamTheme';
+import {
+  THEME_MODE_STORAGE_KEY,
+  getStoredThemeMode,
+  useCunninghamTheme,
+} from '../useCunninghamTheme';
+
+const setSystemPrefersDark = (matches: boolean) => {
+  window.matchMedia = ((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+};
+
+const installStorageMock = () => {
+  let store: Record<string, string> = {};
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = String(value);
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+    },
+  });
+};
 
 describe('<useCunninghamTheme />', () => {
   it('changing theme update tokens', () => {
@@ -12,5 +48,43 @@ describe('<useCunninghamTheme />', () => {
     expect(
       useCunninghamTheme.getState().currentTokens.globals?.font.families.base,
     ).toBe('Marianne, Inter Variable, Roboto Flex Variable, sans-serif');
+  });
+});
+
+describe('useCunninghamTheme colour mode', () => {
+  beforeEach(() => {
+    installStorageMock();
+    setSystemPrefersDark(false);
+  });
+
+  it('setThemeMode("dark") applies the dark theme and persists it', () => {
+    useCunninghamTheme.getState().setThemeMode('dark');
+
+    expect(useCunninghamTheme.getState().theme).toBe('dark');
+    expect(useCunninghamTheme.getState().themeMode).toBe('dark');
+    expect(window.localStorage.getItem(THEME_MODE_STORAGE_KEY)).toBe('dark');
+    expect(getStoredThemeMode()).toBe('dark');
+  });
+
+  it('setThemeMode("light") applies the default theme', () => {
+    useCunninghamTheme.getState().setThemeMode('light');
+
+    expect(useCunninghamTheme.getState().theme).toBe('default');
+    expect(useCunninghamTheme.getState().themeMode).toBe('light');
+  });
+
+  it('setThemeMode("system") resolves from prefers-color-scheme', () => {
+    setSystemPrefersDark(true);
+    useCunninghamTheme.getState().setThemeMode('system');
+    expect(useCunninghamTheme.getState().theme).toBe('dark');
+
+    setSystemPrefersDark(false);
+    useCunninghamTheme.getState().setThemeMode('system');
+    expect(useCunninghamTheme.getState().theme).toBe('default');
+  });
+
+  it('getStoredThemeMode ignores invalid stored values', () => {
+    window.localStorage.setItem(THEME_MODE_STORAGE_KEY, 'bogus');
+    expect(getStoredThemeMode()).toBeNull();
   });
 });

--- a/src/frontend/apps/impress/src/cunningham/useCunninghamTheme.tsx
+++ b/src/frontend/apps/impress/src/cunningham/useCunninghamTheme.tsx
@@ -12,6 +12,42 @@ type ComponentTokens = Tokens['components'];
 type ContextualTokens = Tokens['contextuals'];
 export type Theme = keyof typeof tokens.themes;
 
+/**
+ * User-facing colour mode. `system` follows the OS `prefers-color-scheme`.
+ * It maps onto the underlying Cunningham theme: light -> `default`, dark -> `dark`.
+ */
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+export const THEME_MODE_STORAGE_KEY = 'doc-theme-mode';
+
+const isThemeMode = (value: unknown): value is ThemeMode =>
+  value === 'light' || value === 'dark' || value === 'system';
+
+/** The persisted colour-mode preference, or null if never set / unavailable. */
+export const getStoredThemeMode = (): ThemeMode | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const value = window.localStorage.getItem(THEME_MODE_STORAGE_KEY);
+    return isThemeMode(value) ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+const systemPrefersDark = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+const resolveTheme = (mode: ThemeMode): Theme => {
+  if (mode === 'system') {
+    return systemPrefersDark() ? 'dark' : 'default';
+  }
+  return mode === 'dark' ? 'dark' : 'default';
+};
+
 interface ThemeStore {
   colorsTokens: Partial<ColorsTokens>;
   componentTokens: ComponentTokens;
@@ -19,6 +55,8 @@ interface ThemeStore {
   currentTokens: Partial<Tokens>;
   fontSizesTokens: Partial<FontSizesTokens>;
   setTheme: (theme: Theme) => void;
+  themeMode: ThemeMode;
+  setThemeMode: (mode: ThemeMode) => void;
   spacingsTokens: Partial<SpacingsTokens>;
   theme: Theme;
   themeTokens: Partial<Tokens['globals']>;
@@ -28,35 +66,42 @@ const getMergedTokens = (theme: Theme) => {
   return merge({}, tokens.themes['default'], tokens.themes[theme]);
 };
 
-const DEFAULT_THEME: Theme = 'default';
-const defaultTokens = getMergedTokens(DEFAULT_THEME);
-
-const initialState: ThemeStore = {
-  colorsTokens: defaultTokens.globals.colors,
-  componentTokens: defaultTokens.components,
-  contextualTokens: defaultTokens.contextuals,
-  currentTokens: tokens.themes[DEFAULT_THEME],
-  fontSizesTokens: defaultTokens.globals.font.sizes,
-  setTheme: () => {},
-  spacingsTokens: defaultTokens.globals.spacings,
-  theme: DEFAULT_THEME,
-  themeTokens: defaultTokens.globals,
+/** All token slices derived from a resolved Cunningham theme. */
+const tokenSlices = (theme: Theme) => {
+  const merged = getMergedTokens(theme);
+  return {
+    colorsTokens: merged.globals.colors,
+    componentTokens: merged.components,
+    contextualTokens: merged.contextuals,
+    currentTokens: tokens.themes[theme] as Partial<Tokens>,
+    fontSizesTokens: merged.globals.font.sizes,
+    spacingsTokens: merged.globals.spacings,
+    theme,
+    themeTokens: merged.globals,
+  };
 };
 
-export const useCunninghamTheme = create<ThemeStore>((set) => ({
-  ...initialState,
-  setTheme: (theme: Theme) => {
-    const newTokens = getMergedTokens(theme);
+// The store initialises to a stable default on both server and client so SSR
+// output and the first client render match. The real preference is read from
+// localStorage and applied on mount by ThemeProvider (and painted pre-hydration
+// by the inline script in _document.tsx), so there is no flash of the wrong theme.
+const DEFAULT_MODE: ThemeMode = 'system';
+const DEFAULT_THEME: Theme = 'default';
 
-    set({
-      colorsTokens: newTokens.globals.colors,
-      componentTokens: newTokens.components,
-      contextualTokens: newTokens.contextuals,
-      currentTokens: tokens.themes[theme] as Partial<Tokens>,
-      fontSizesTokens: newTokens.globals.font.sizes,
-      spacingsTokens: newTokens.globals.spacings,
-      theme,
-      themeTokens: newTokens.globals,
-    });
+export const useCunninghamTheme = create<ThemeStore>((set) => ({
+  ...tokenSlices(DEFAULT_THEME),
+  themeMode: DEFAULT_MODE,
+  setTheme: (theme: Theme) => {
+    set(tokenSlices(theme));
+  },
+  setThemeMode: (mode: ThemeMode) => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(THEME_MODE_STORAGE_KEY, mode);
+      } catch {
+        // ignore write failures (private mode, storage disabled)
+      }
+    }
+    set({ ...tokenSlices(resolveTheme(mode)), themeMode: mode });
   },
 }));

--- a/src/frontend/apps/impress/src/cunningham/useCunninghamTheme.tsx
+++ b/src/frontend/apps/impress/src/cunningham/useCunninghamTheme.tsx
@@ -57,6 +57,7 @@ interface ThemeStore {
   setTheme: (theme: Theme) => void;
   themeMode: ThemeMode;
   setThemeMode: (mode: ThemeMode) => void;
+  applyThemeMode: (mode: ThemeMode) => void;
   spacingsTokens: Partial<SpacingsTokens>;
   theme: Theme;
   themeTokens: Partial<Tokens['globals']>;
@@ -93,6 +94,12 @@ export const useCunninghamTheme = create<ThemeStore>((set) => ({
   themeMode: DEFAULT_MODE,
   setTheme: (theme: Theme) => {
     set(tokenSlices(theme));
+  },
+  // Resolve and apply a mode WITHOUT persisting it. Used for the in-memory
+  // default so an unset preference does not get written to localStorage and
+  // mask a backend brand theme.
+  applyThemeMode: (mode: ThemeMode) => {
+    set({ ...tokenSlices(resolveTheme(mode)), themeMode: mode });
   },
   setThemeMode: (mode: ThemeMode) => {
     if (typeof window !== 'undefined') {

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -91,7 +91,8 @@ interface BlockNoteEditorProps {
 export const BlockNoteEditor = ({ doc, provider }: BlockNoteEditorProps) => {
   const { user } = useAuth();
   const { setEditor } = useEditorStore();
-  const { themeTokens } = useCunninghamTheme();
+  const { themeTokens, theme } = useCunninghamTheme();
+  const editorTheme = theme === 'dark' ? 'dark' : 'light';
   const refEditorContainer = useRef<HTMLDivElement>(null);
   useSaveDoc(doc.id, provider.document);
 
@@ -292,7 +293,7 @@ export const BlockNoteEditor = ({ doc, provider }: BlockNoteEditorProps) => {
         editor={editor}
         formattingToolbar={false}
         slashMenu={false}
-        theme="light"
+        theme={editorTheme}
         comments={false}
         aria-label={t('Document editor')}
         // To not clipped the floating part in the editor area
@@ -331,6 +332,8 @@ export const BlockNoteReader = ({
 }: BlockNoteReaderProps) => {
   const { user } = useAuth();
   const { setEditor } = useEditorStore();
+  const { theme } = useCunninghamTheme();
+  const editorTheme = theme === 'dark' ? 'dark' : 'light';
   const { threadStore } = useComments(docId, false, user);
   const editor = useCreateBlockNote(
     {
@@ -381,7 +384,7 @@ export const BlockNoteReader = ({
         className="--docs--main-editor"
         editor={editor}
         editable={false}
-        theme="light"
+        theme={editorTheme}
         formattingToolbar={false}
         slashMenu={false}
         comments={false}

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -8,6 +8,9 @@ export const DocsEditorStyle = createGlobalStyle`
   * Token Blocknote
   */
   .bn-root[data-color-scheme] {
+    /* Let the editor share the page background instead of BlockNote's own
+       (Mantine) light/dark surface, so the canvas matches the app in any theme. */
+    --bn-colors-editor-background: transparent;
     --bn-colors-editor-text: var(
       --c--contextuals--content--semantic--neutral--primary
     );

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -8,9 +8,6 @@ export const DocsEditorStyle = createGlobalStyle`
   * Token Blocknote
   */
   .bn-root[data-color-scheme] {
-    /* Let the editor share the page background instead of BlockNote's own
-       (Mantine) light/dark surface, so the canvas matches the app in any theme. */
-    --bn-colors-editor-background: transparent;
     --bn-colors-editor-text: var(
       --c--contextuals--content--semantic--neutral--primary
     );
@@ -24,8 +21,11 @@ export const DocsEditorStyle = createGlobalStyle`
   }
 
   .bn-root {
+    /* Editor shares the page background rather than BlockNote's Mantine
+       surface, so the canvas matches the app background in any theme. */
     .bn-editor {
       height: 100%;
+      background-color: transparent;
     }
 
     .mantine-Menu-itemLabel,

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -278,7 +278,11 @@ export const DocsEditorStyle = createGlobalStyle`
     }
 
     & .bn-inline-content code {
-      background-color: gainsboro;
+      /* Was a hardcoded gainsboro, which left near-white text on a
+         near-white chip once the content tokens switched to the dark ramp. */
+      background-color: var(
+        --c--contextuals--background--palette--gray--tertiary
+      );
       padding: 2px;
       border-radius: 4px;
     }

--- a/src/frontend/apps/impress/src/features/home/components/HomeHeader.tsx
+++ b/src/frontend/apps/impress/src/features/home/components/HomeHeader.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 
-import { Box } from '@/components';
+import { Box, ThemeSwitch } from '@/components';
 import { Title } from '@/components/Title';
 import { Waffle } from '@/components/Waffle';
 import { useConfig } from '@/core';
@@ -77,6 +77,7 @@ export const HomeHeader = () => {
         $gap={!isSmallMobile ? '1rem' : undefined}
         $align="center"
       >
+        <ThemeSwitch />
         <LanguagePickerLegacy />
         <Waffle />
       </Box>

--- a/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFooter.tsx
+++ b/src/frontend/apps/impress/src/features/left-panel/components/LeftPanelFooter.tsx
@@ -1,7 +1,7 @@
 import { UserMenu } from '@gouvfr-lasuite/ui-kit';
 import { useTranslation } from 'react-i18next';
 
-import { Box, SeparatedSection } from '@/components';
+import { Box, SeparatedSection, ThemeSwitch } from '@/components';
 import { Waffle } from '@/components/Waffle';
 import { ButtonLogin } from '@/features/auth';
 import { useAuth } from '@/features/auth/hooks/useAuth';
@@ -35,7 +35,10 @@ export const LeftPanelFooter = () => {
           <Waffle />
           <ButtonLogin />
         </Box>
-        <HelpMenu />
+        <Box $direction="row" $align="center" $gap="0.2rem">
+          <ThemeSwitch />
+          <HelpMenu />
+        </Box>
       </Box>
     </SeparatedSection>
   );

--- a/src/frontend/apps/impress/src/features/skeletons/components/Skeleton.tsx
+++ b/src/frontend/apps/impress/src/features/skeletons/components/Skeleton.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { css, keyframes } from 'styled-components';
 
 import { Box } from '@/components';
-import { useCunninghamTheme } from '@/cunningham';
 import { useSkeletonStore } from '@/features/skeletons';
 
 const FADE_DURATION_MS = 250;
@@ -18,7 +17,6 @@ const fadeOut = keyframes`
 
 export const Skeleton = ({ children }: PropsWithChildren) => {
   const { isSkeletonVisible } = useSkeletonStore();
-  const { colorsTokens } = useCunninghamTheme();
   const [isVisible, setIsVisible] = useState(isSkeletonVisible);
   const [isFadingOut, setIsFadingOut] = useState(true);
   const timeoutVisibleRef = useRef<NodeJS.Timeout | null>(null);
@@ -54,7 +52,7 @@ export const Skeleton = ({ children }: PropsWithChildren) => {
       $align="center"
       $width="100%"
       $height="100%"
-      $background={colorsTokens['gray-000']}
+      $background="var(--c--contextuals--background--surface--primary)"
       $css={css`
         position: absolute;
         inset: 0;

--- a/src/frontend/apps/impress/src/pages/_document.tsx
+++ b/src/frontend/apps/impress/src/pages/_document.tsx
@@ -6,13 +6,14 @@ import Document, {
   NextScript,
 } from 'next/document';
 
+import { THEME_MODE_STORAGE_KEY } from '../cunningham/useCunninghamTheme';
 import { fallbackLng } from '../i18n/config';
 
 // Runs before hydration to set the Cunningham theme class on <html>, so the
-// correct colour scheme paints on first frame (no flash). Mirrors the logic in
-// useCunninghamTheme (storage key + light->`default`, dark->`dark`). Keep in sync.
+// correct colour scheme paints on first frame (no flash). Mirrors the mode
+// resolution in useCunninghamTheme (light->`default`, dark->`dark`).
 const THEME_INIT_SCRIPT = `(function(){try{
-var m=localStorage.getItem('doc-theme-mode')||'system';
+var m=localStorage.getItem('${THEME_MODE_STORAGE_KEY}')||'system';
 var dark=m==='dark'||(m==='system'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);
 var t=dark?'dark':'default';
 var r=document.documentElement;

--- a/src/frontend/apps/impress/src/pages/_document.tsx
+++ b/src/frontend/apps/impress/src/pages/_document.tsx
@@ -8,6 +8,18 @@ import Document, {
 
 import { fallbackLng } from '../i18n/config';
 
+// Runs before hydration to set the Cunningham theme class on <html>, so the
+// correct colour scheme paints on first frame (no flash). Mirrors the logic in
+// useCunninghamTheme (storage key + light->`default`, dark->`dark`). Keep in sync.
+const THEME_INIT_SCRIPT = `(function(){try{
+var m=localStorage.getItem('doc-theme-mode')||'system';
+var dark=m==='dark'||(m==='system'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);
+var t=dark?'dark':'default';
+var r=document.documentElement;
+r.classList.forEach(function(c){if(c.indexOf('cunningham-theme--')===0){r.classList.remove(c);}});
+r.classList.add('cunningham-theme--'+t);
+}catch(e){}})();`;
+
 class MyDocument extends Document<{ locale: string }> {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx);
@@ -19,8 +31,10 @@ class MyDocument extends Document<{ locale: string }> {
 
   render() {
     return (
-      <Html lang={this.props.locale}>
-        <Head />
+      <Html lang={this.props.locale} suppressHydrationWarning>
+        <Head>
+          <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/src/frontend/apps/impress/src/pages/globals.css
+++ b/src/frontend/apps/impress/src/pages/globals.css
@@ -9,6 +9,11 @@ body {
   margin: 0;
   padding: 0;
   overflow: hidden;
+
+  /* Nothing else paints the page canvas, so in dark mode the browser default
+     white showed through under the dark text ramp. The theme class sits on
+     <html>, so the token resolves per theme. */
+  background-color: var(--c--contextuals--background--surface--primary);
 }
 
 /* stylelint-disable-next-line selector-id-pattern */


### PR DESCRIPTION
## Purpose

Docs already ships a `dark` Cunningham token set, but there is no way for a user to select it and no following of the OS colour scheme. This adds an in-app dark / light / system colour-mode switcher, which is one of the recurring asks around theming.

## Proposal

* [x] Add a `themeMode` (`light` / `dark` / `system`) to the theme store, persisted to `localStorage`
* [x] In `system` mode, resolve and follow the OS `prefers-color-scheme` live
* [x] Pre-hydration inline script in `_document` sets the theme class on `<html>` so the correct scheme paints on first frame (no flash), with `suppressHydrationWarning`
* [x] A user's explicit mode preference takes precedence over the plain light/dark `FRONTEND_THEME` backend default (non-default brand themes like `dsfr` still apply)
* [x] A `ThemeSwitch` control in the left-panel footer (app) and the home header (landing page)
* [x] Unit tests for the theme-mode store logic

The store maps the mode onto the existing Cunningham themes (`light` -> `default`, `dark` -> `dark`), so no new tokens are introduced.

## External contributions

Thank you for your contribution! 🎉

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added corresponding tests for new features or bug fixes (if applicable)

### CI requirements

* [x] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [ ] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer
