### PR TITLE
🐛(frontend) redirect home page to login when homepage feature is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to
 - ♿️(frontend) restore skip to content link after header redesign #2510
 - 🌐(i18n) rename cn_CN to zh_CN, add eo_PL and zh_TW locales #2486
 
+### Fixed
+
+- 🐛(frontend) redirect homepage to login when homepage feat is disabled #2521
+
 ## [v5.4.1] - 2026-07-09
 
 ### Changed

--- a/src/frontend/apps/e2e/__tests__/app-impress/home.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/home.spec.ts
@@ -178,4 +178,34 @@ test.describe('Home page', () => {
       page.locator(`${process.env.SIGN_IN_EL_LOGIN_PAGE}`).getByText('impress'),
     ).toBeVisible();
   });
+
+  test('it redirects a direct /home link to login when the homepage feature is disabled', async ({
+    page,
+  }) => {
+    await overrideConfig(page, {
+      FRONTEND_HOMEPAGE_FEATURE_ENABLED: false,
+    });
+
+    await page.goto('/home/');
+
+    // Keyclock login page
+    await expect(
+      page.locator(`${process.env.SIGN_IN_EL_LOGIN_PAGE}`).getByText('impress'),
+    ).toBeVisible();
+  });
+
+  test('it shows the homepage for a direct /home link when the homepage feature is enabled', async ({
+    page,
+  }) => {
+    await overrideConfig(page, {
+      FRONTEND_HOMEPAGE_FEATURE_ENABLED: true,
+    });
+
+    await page.goto('/home/');
+
+    // Homepage content, not the login page
+    await expect(
+      page.locator('h2').getByText('Govs ❤️ Open Source.'),
+    ).toBeVisible();
+  });
 });

--- a/src/frontend/apps/impress/src/pages/home/index.tsx
+++ b/src/frontend/apps/impress/src/pages/home/index.tsx
@@ -4,14 +4,18 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Loading } from '@/components';
-import { useAuth } from '@/features/auth';
+import { useConfig } from '@/core';
+import { gotoLogin, useAuth } from '@/features/auth';
 import { HomeContent } from '@/features/home';
 import { NextPageWithLayout } from '@/types/next';
 
 const Page: NextPageWithLayout = () => {
   const { t } = useTranslation();
-  const { authenticated } = useAuth();
+  const { authenticated, isAuthLoading } = useAuth();
+  const { data: config, isFetched: isConfigFetched } = useConfig();
   const { replace } = useRouter();
+  const homepageDisabled =
+    isConfigFetched && !config?.FRONTEND_HOMEPAGE_FEATURE_ENABLED;
 
   /**
    * If the user is authenticated we redirect him to the index page (grid).
@@ -24,7 +28,21 @@ const Page: NextPageWithLayout = () => {
     void replace('/');
   }, [authenticated, replace]);
 
-  if (authenticated) {
+  /**
+   * If the homepage feature is disabled, the homepage should not be reachable
+   * even from a direct link, so we redirect the user to the login page — the
+   * same behavior as visiting `/` (see the `Auth` component). We wait for the
+   * config to be fetched so a pending flag is not mistaken for a disabled one.
+   */
+  useEffect(() => {
+    if (isAuthLoading || authenticated || !homepageDisabled) {
+      return;
+    }
+
+    gotoLogin(false);
+  }, [isAuthLoading, authenticated, homepageDisabled]);
+
+  if (isAuthLoading || authenticated || !isConfigFetched || homepageDisabled) {
     return <Loading $height="100vh" $width="100vw" />;
   }
 


### PR DESCRIPTION
## Purpose

`FRONTEND_HOMEPAGE_FEATURE_ENABLED=false` is supposed to disable the homepage: the `Auth` guard sends anonymous visitors on `/` straight to the login page instead of `/home`. But the `/home` page itself doesn't check the flag, so anyone following a direct link to `/home/` still gets the full stock homepage. Since the auth guard only forces login on `/` and `/docs` (`/home` is an "allowed" path), nothing stops it from rendering.

We noticed this on our own instance (we run Docs with a custom skin as part of a sovereign EU business workspace): with the flag off, every entry point correctly leads to our SSO login, except a deep link to `/home/`, which still shows the default homepage.

## Proposal

* [x] When `FRONTEND_HOMEPAGE_FEATURE_ENABLED` is `false`, `/home` now redirects anonymous visitors to the login page (`gotoLogin(false)` — no point returning to `/home` after login), mirroring the `Auth` component's behavior for `/`
* [x] e2e test: with the flag overridden to `false`, a direct visit to `/home/` lands on the login page (sibling of the existing flag test)

## External contributions

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added corresponding tests for new features or bug fixes (if applicable)

*Skip the checkbox below 👇 if you're fixing an issue or adding documentation*
* [ ] Before submitting a PR for a new feature I made sure to contact the product manager

### CI requirements

* [x] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [ ] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhqB4SHsHCuMfprwLEN3rR
