### PR TITLE
♿️(frontend) announce search loading state for screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Changed
 
 - ♻️(backend) reset collaboration connection in cascade for all children #2507
+- ♿️(frontend) announce search loading state for screen readers #2526
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to
 ### Changed
 
 - ♻️(backend) reset collaboration connection in cascade for all children #2507
+- ♿️(frontend) announce search loading state for screen readers #2526
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchContent.tsx
@@ -1,6 +1,6 @@
 import { announce } from '@react-aria/live-announcer';
 import { t } from 'i18next';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { InView } from 'react-intersection-observer';
 
 import { Box } from '@/components/';
@@ -115,10 +115,17 @@ export const DocSearchContent = ({
     onResults,
   ]);
 
+  const prevLoadingRef = useRef(false);
+
   useEffect(() => {
-    if (loading && (search || isSearchNotMandatory)) {
+    if (
+      loading &&
+      !prevLoadingRef.current &&
+      (search || isSearchNotMandatory)
+    ) {
       announce(t('Loading documents...'), 'polite');
     }
+    prevLoadingRef.current = loading;
   }, [loading, search, isSearchNotMandatory]);
 
   useEffect(() => {

--- a/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchContent.tsx
@@ -65,6 +65,9 @@ export const DocSearchContent = ({
 
   useEffect(() => {
     if (loading) {
+      if (search || isSearchNotMandatory) {
+        announce(t('Loading documents...'), 'polite');
+      }
       return;
     }
 

--- a/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchContent.tsx
@@ -1,6 +1,6 @@
 import { announce } from '@react-aria/live-announcer';
 import { t } from 'i18next';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { InView } from 'react-intersection-observer';
 
 import { Box } from '@/components/';
@@ -65,6 +65,9 @@ export const DocSearchContent = ({
 
   useEffect(() => {
     if (loading) {
+      if (search || isSearchNotMandatory) {
+        announce(t('Loading documents...'), 'polite');
+      }
       return;
     }
 
@@ -114,19 +117,6 @@ export const DocSearchContent = ({
     fetchNextPage,
     onResults,
   ]);
-
-  const prevLoadingRef = useRef(false);
-
-  useEffect(() => {
-    if (
-      loading &&
-      !prevLoadingRef.current &&
-      (search || isSearchNotMandatory)
-    ) {
-      announce(t('Loading documents...'), 'polite');
-    }
-    prevLoadingRef.current = loading;
-  }, [loading, search, isSearchNotMandatory]);
 
   useEffect(() => {
     onLoadingChange?.(loading);

--- a/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-search/components/DocSearchContent.tsx
@@ -116,6 +116,12 @@ export const DocSearchContent = ({
   ]);
 
   useEffect(() => {
+    if (loading && (search || isSearchNotMandatory)) {
+      announce(t('Loading documents...'), 'polite');
+    }
+  }, [loading, search, isSearchNotMandatory]);
+
+  useEffect(() => {
     onLoadingChange?.(loading);
   }, [loading, onLoadingChange]);
 


### PR DESCRIPTION
## Purpose

Fix an accessibility issue where the "Loading documents..." message during document search is not conveyed by screen readers. Blind users receive no feedback that their input was registered while results are loading (RGAA criterion 7.1).

## Proposal

* [x] Announce "Loading documents..." via `@react-aria/live-announcer` when search loading starts in `DocSearchContent`
* [x] Cover all document search entry points: main search modal, move document modal, and editor interlinking
* [x] Keep existing result announcements after loading completes
