### PR TITLE
♿️(frontend) restore presenter focus trapping after share links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 ### Changed
 
 - ♿️(frontend) use semantic `<dl>` structure in document info card #2379
+- ♿️(frontend) restore presenter focus trapping after share links #2533
 
 ## [v5.4.1] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - 🐛(backend) skip session creation for the liveness probe
 - 🐛(frontend) preserve page titles when adding an emoji #2586
 - 🐛(frontend) hide the selection highlight on presenter images #2665
+- ♿️(frontend) restore presenter focus trapping after share links #2533
 
 ## [v5.6.1] - 2026-09-04
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-routing.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-routing.spec.ts
@@ -157,6 +157,8 @@ test.describe('Doc Routing', () => {
       RELEASE_VERSION: '0.0.0',
     });
 
+    await page.goto('/');
+
     let counterReload = 0;
     await page.route(/.*\/users\/me\/$/, async (route) => {
       counterReload += 1;

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/usePresenterShortcuts.spec.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/__tests__/usePresenterShortcuts.spec.ts
@@ -14,6 +14,7 @@ const renderShortcuts = (
     onToggleFullscreen: vi.fn(),
     onClose: vi.fn(),
     isFullscreen: false,
+    isPopoverOpen: false,
     ...overrides,
   };
   renderHook(() => usePresenterShortcuts(handlers));

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
@@ -43,6 +43,11 @@ const barCss = css`
   border: 1px solid var(--c--contextuals--border--surface--primary);
   background: var(--c--contextuals--background--surface--primary);
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.05);
+
+  button[aria-disabled='true'] {
+    opacity: 0.4;
+    cursor: default;
+  }
 `;
 
 const separatorCss = css`
@@ -71,6 +76,12 @@ const PresenterDropdownLayerStyle = createGlobalStyle`
     box-sizing: border-box;
     height: 32px;
   }
+
+  .react-aria-Popover .c__dropdown-menu--tiny .c__dropdown-menu-item:focus-visible {
+    outline: 2px solid var(--c--theme--colors--primary-400, #3b82f6);
+    outline-offset: -2px;
+    border-radius: 4px;
+  }
 `;
 
 export const PresenterFloatingBar = ({
@@ -97,7 +108,7 @@ export const PresenterFloatingBar = ({
   useEffect(() => {
     const id = requestAnimationFrame(() => {
       barRef.current
-        ?.querySelector<HTMLButtonElement>('button:not([disabled])')
+        ?.querySelector<HTMLButtonElement>('button:not([aria-disabled="true"])')
         ?.focus();
     });
     return () => cancelAnimationFrame(id);
@@ -137,8 +148,8 @@ export const PresenterFloatingBar = ({
           size="nano"
           color="neutral"
           variant="tertiary"
-          disabled={isFirst}
-          onClick={onPrev}
+          aria-disabled={isFirst}
+          onClick={isFirst ? undefined : onPrev}
           aria-label={t('Previous slide')}
           icon={<ChevronLeft size="small" />}
         />
@@ -149,8 +160,8 @@ export const PresenterFloatingBar = ({
           size="nano"
           color="neutral"
           variant="tertiary"
-          disabled={isLast}
-          onClick={onNext}
+          aria-disabled={isLast}
+          onClick={isLast ? undefined : onNext}
           aria-label={t('Next slide')}
           icon={<ChevronRight size="small" />}
         />

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
@@ -22,6 +22,7 @@ interface PresenterFloatingBarProps {
   onPrev: () => void;
   onNext: () => void;
   onCopyLink: () => void;
+  onActionsOpenChange?: (isOpen: boolean) => void;
   onToggleFullscreen: () => void;
   onClose: () => void;
 }
@@ -91,6 +92,7 @@ export const PresenterFloatingBar = ({
   onPrev,
   onNext,
   onCopyLink,
+  onActionsOpenChange,
   onToggleFullscreen,
   onClose,
 }: PresenterFloatingBarProps) => {
@@ -119,7 +121,16 @@ export const PresenterFloatingBar = ({
   const toggleActions = (event: MouseEvent<HTMLElement>) => {
     event.stopPropagation();
     event.preventDefault();
-    setIsActionsOpen((isOpen) => !isOpen);
+    setIsActionsOpen((prev) => {
+      const next = !prev;
+      onActionsOpenChange?.(next);
+      return next;
+    });
+  };
+
+  const handleActionsOpenChange = (isOpen: boolean) => {
+    setIsActionsOpen(isOpen);
+    onActionsOpenChange?.(isOpen);
   };
 
   const actionOptions = useMemo<DropdownMenuItem[]>(
@@ -169,7 +180,7 @@ export const PresenterFloatingBar = ({
         <DropdownMenu
           options={actionOptions}
           isOpen={isActionsOpen}
-          onOpenChange={setIsActionsOpen}
+          onOpenChange={handleActionsOpenChange}
           shouldCloseOnInteractOutside={() => true}
           variant="tiny"
         >

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterFloatingBar.tsx
@@ -27,6 +27,7 @@ interface PresenterFloatingBarProps {
   onNext: () => void;
   onCopyLink: () => void;
   onExportPdf: () => void;
+  onActionsOpenChange?: (isOpen: boolean) => void;
   onToggleFullscreen: () => void;
   onClose: () => void;
   isExportingPdf: boolean;
@@ -49,6 +50,11 @@ const barCss = css`
   border: 1px solid var(--c--contextuals--border--surface--primary);
   background: var(--c--contextuals--background--surface--primary);
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.05);
+
+  button[aria-disabled='true'] {
+    opacity: 0.4;
+    cursor: default;
+  }
 `;
 
 const separatorCss = css`
@@ -87,6 +93,7 @@ export const PresenterFloatingBar = ({
   onNext,
   onCopyLink,
   onExportPdf,
+  onActionsOpenChange,
   onToggleFullscreen,
   onClose,
   isExportingPdf,
@@ -105,7 +112,7 @@ export const PresenterFloatingBar = ({
   useEffect(() => {
     const id = requestAnimationFrame(() => {
       barRef.current
-        ?.querySelector<HTMLButtonElement>('button:not([disabled])')
+        ?.querySelector<HTMLButtonElement>('button:not([aria-disabled="true"])')
         ?.focus();
     });
     return () => cancelAnimationFrame(id);
@@ -116,7 +123,16 @@ export const PresenterFloatingBar = ({
   const toggleActions = (event: MouseEvent<HTMLElement>) => {
     event.stopPropagation();
     event.preventDefault();
-    setIsActionsOpen((isOpen) => !isOpen);
+    setIsActionsOpen((prev) => {
+      const next = !prev;
+      onActionsOpenChange?.(next);
+      return next;
+    });
+  };
+
+  const handleActionsOpenChange = (isOpen: boolean) => {
+    setIsActionsOpen(isOpen);
+    onActionsOpenChange?.(isOpen);
   };
 
   const actionOptions = useMemo<DropdownMenuItem[]>(
@@ -151,8 +167,8 @@ export const PresenterFloatingBar = ({
           size="nano"
           color="neutral"
           variant="tertiary"
-          disabled={isFirst}
-          onClick={onPrev}
+          aria-disabled={isFirst}
+          onClick={isFirst ? undefined : onPrev}
           aria-label={t('Previous slide')}
           icon={<ChevronLeft size="small" />}
         />
@@ -163,8 +179,8 @@ export const PresenterFloatingBar = ({
           size="nano"
           color="neutral"
           variant="tertiary"
-          disabled={isLast}
-          onClick={onNext}
+          aria-disabled={isLast}
+          onClick={isLast ? undefined : onNext}
           aria-label={t('Next slide')}
           icon={<ChevronRight size="small" />}
         />
@@ -172,7 +188,7 @@ export const PresenterFloatingBar = ({
         <DropdownMenu
           options={actionOptions}
           isOpen={isActionsOpen}
-          onOpenChange={setIsActionsOpen}
+          onOpenChange={handleActionsOpenChange}
           shouldCloseOnInteractOutside={() => true}
           variant="tiny"
         >

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
@@ -56,6 +56,10 @@ export const PresenterOverlay = ({
   const editor = useEditorStore((state) => state.editor);
   const copyPresenterLink = useCopyPresenterLink(doc.id);
 
+  // Track the floating bar's actions popover state so keyboard shortcuts
+  // can avoid closing the presenter while the popover is open.
+  const [isActionsOpen, setIsActionsOpen] = useState(false);
+
   // Snapshot the editor's blocks once at mount. Subsequent collaborator
   // edits do not affect the ongoing presentation (by design).
   const snapshotRef = useRef<PresenterBlock[] | null>(null);
@@ -138,6 +142,7 @@ export const PresenterOverlay = ({
     onToggleFullscreen: () => void toggle(),
     onClose,
     isFullscreen,
+    isPopoverOpen: isActionsOpen,
   });
 
   const mountedIndices = useMemo(() => {
@@ -202,6 +207,7 @@ export const PresenterOverlay = ({
           onPrev={goPrev}
           onNext={goNext}
           onCopyLink={() => copyPresenterLink(currentIndex)}
+          onActionsOpenChange={setIsActionsOpen}
           onToggleFullscreen={() => void toggle()}
           onClose={onClose}
         />

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
@@ -173,7 +173,7 @@ export const PresenterOverlay = ({
   }
 
   return createPortal(
-    <FocusScope autoFocus restoreFocus>
+    <FocusScope contain autoFocus restoreFocus>
       <Box
         $css={overlayCss}
         role="dialog"

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
@@ -178,7 +178,7 @@ export const PresenterOverlay = ({
   }
 
   return createPortal(
-    <FocusScope contain autoFocus restoreFocus>
+    <FocusScope contain={!isActionsOpen} autoFocus restoreFocus>
       <Box
         $css={overlayCss}
         role="dialog"

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterOverlay.tsx
@@ -65,6 +65,10 @@ export const PresenterOverlay = ({
   const editor = useEditorStore((state) => state.editor);
   const copyPresenterLink = useCopyPresenterLink(doc.id);
 
+  // Track the floating bar's actions popover state so keyboard shortcuts
+  // can avoid closing the presenter while the popover is open.
+  const [isActionsOpen, setIsActionsOpen] = useState(false);
+
   // Snapshot the editor's blocks once at mount. Subsequent collaborator
   // edits do not affect the ongoing presentation (by design).
   const snapshotRef = useRef<PresenterBlock[] | null>(null);
@@ -161,6 +165,7 @@ export const PresenterOverlay = ({
     onToggleFullscreen: () => void toggle(),
     onClose,
     isFullscreen,
+    isPopoverOpen: isActionsOpen,
   });
 
   const mountedIndices = useMemo(() => {
@@ -196,7 +201,7 @@ export const PresenterOverlay = ({
   }
 
   return createPortal(
-    <FocusScope autoFocus restoreFocus>
+    <FocusScope contain={!isActionsOpen} autoFocus restoreFocus>
       <Box
         $css={overlayCss}
         role="dialog"
@@ -231,6 +236,7 @@ export const PresenterOverlay = ({
           onCopyLink={() => copyPresenterLink(currentIndex)}
           onExportPdf={() => void exportPdf()}
           isExportingPdf={isExportingPdf}
+          onActionsOpenChange={setIsActionsOpen}
           onToggleFullscreen={() => void toggle()}
           onClose={onClose}
         />

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/usePresenterShortcuts.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/usePresenterShortcuts.ts
@@ -74,8 +74,10 @@ export const usePresenterShortcuts = ({
         case 'Escape':
           // While fullscreen, the browser handles Esc natively (exits
           // fullscreen) and we deliberately stay open. Once out of
-          // fullscreen, Esc closes the presenter.
-          if (!isFullscreen) {
+          // fullscreen, Esc closes the presenter, unless a popover (e.g.
+          // the share dropdown) is open, in which case Esc should only
+          // dismiss the popover.
+          if (!isFullscreen && !document.querySelector('.react-aria-Popover')) {
             event.preventDefault();
             onClose();
           }

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/usePresenterShortcuts.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/usePresenterShortcuts.ts
@@ -8,6 +8,7 @@ interface ShortcutHandlers {
   onToggleFullscreen: () => void;
   onClose: () => void;
   isFullscreen: boolean;
+  isPopoverOpen: boolean;
 }
 
 const ARROW_CODES = new Set(['ArrowLeft', 'ArrowRight']);
@@ -20,6 +21,7 @@ export const usePresenterShortcuts = ({
   onToggleFullscreen,
   onClose,
   isFullscreen,
+  isPopoverOpen,
 }: ShortcutHandlers) => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -74,8 +76,10 @@ export const usePresenterShortcuts = ({
         case 'Escape':
           // While fullscreen, the browser handles Esc natively (exits
           // fullscreen) and we deliberately stay open. Once out of
-          // fullscreen, Esc closes the presenter.
-          if (!isFullscreen) {
+          // fullscreen, Esc closes the presenter — unless the presenter's
+          // own actions popover is open, in which case Esc should only
+          // dismiss the popover.
+          if (!isFullscreen && !isPopoverOpen) {
             event.preventDefault();
             onClose();
           }
@@ -95,5 +99,6 @@ export const usePresenterShortcuts = ({
     onToggleFullscreen,
     onClose,
     isFullscreen,
+    isPopoverOpen,
   ]);
 };

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/usePresenterShortcuts.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/hooks/usePresenterShortcuts.ts
@@ -8,6 +8,7 @@ interface ShortcutHandlers {
   onToggleFullscreen: () => void;
   onClose: () => void;
   isFullscreen: boolean;
+  isPopoverOpen: boolean;
 }
 
 const ARROW_CODES = new Set(['ArrowLeft', 'ArrowRight']);
@@ -20,6 +21,7 @@ export const usePresenterShortcuts = ({
   onToggleFullscreen,
   onClose,
   isFullscreen,
+  isPopoverOpen,
 }: ShortcutHandlers) => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -74,10 +76,10 @@ export const usePresenterShortcuts = ({
         case 'Escape':
           // While fullscreen, the browser handles Esc natively (exits
           // fullscreen) and we deliberately stay open. Once out of
-          // fullscreen, Esc closes the presenter, unless a popover (e.g.
-          // the share dropdown) is open, in which case Esc should only
+          // fullscreen, Esc closes the presenter — unless the presenter's
+          // own actions popover is open, in which case Esc should only
           // dismiss the popover.
-          if (!isFullscreen && !document.querySelector('.react-aria-Popover')) {
+          if (!isFullscreen && !isPopoverOpen) {
             event.preventDefault();
             onClose();
           }
@@ -97,5 +99,6 @@ export const usePresenterShortcuts = ({
     onToggleFullscreen,
     onClose,
     isFullscreen,
+    isPopoverOpen,
   ]);
 };


### PR DESCRIPTION
## Purpose

Fix accessibility regressions in presenter mode introduced with share links: focus escaping to the background document, focus loss on first/last slides, missing keyboard focus on "Copy link to slide", and Escape closing the presenter while the share dropdown is open.

https://github.com/user-attachments/assets/830df578-cdcc-4c35-93c7-9017e44ae367

## Proposal

* [x] Restore `contain` on the presenter `FocusScope`
* [x] Replace native `disabled` with `aria-disabled` on Prev/Next toolbar buttons
* [x] Add a visible `:focus-visible` indicator on the "Copy link to slide" menu item
* [x] Ignore Escape in presenter shortcuts while the share dropdown popover is open