### PR TITLE
🐛(backend) ignore CSPs for API docs in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(frontend) redirect homepage to login when homepage feat is disabled #2521
+- 🐛(backend) ignore CSPs for API docs in development
 
 ### Changed
 

--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -1283,6 +1283,10 @@ class Development(Base):
     def __init__(self):
         # pylint: disable=invalid-name
         self.INSTALLED_APPS += ["django_extensions", "drf_spectacular_sidecar"]
+        self.CONTENT_SECURITY_POLICY["EXCLUDE_URL_PREFIXES"] += [
+            f"/api/{self.API_VERSION}/swagger",
+            f"/api/{self.API_VERSION}/redoc",
+        ]
 
 
 class Test(Base):


### PR DESCRIPTION
## Purpose

With Content Security Policies activated, swagger (and redoc) auto-generated API documentation is no longer accessible even locally.

## Proposal

- [x] ignore `/api/v1.0/(swagger|redoc)` URL prefixes from CSP in development
