### PR TITLE
🚚(global) move favorite documents API endpoint to `/documents/favorites/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 ### Changed
 
 - ♿️(frontend) use semantic `<dl>` structure in document info card #2379
+- 🚚(global) move favorite documents API endpoint to `/documents/favorites/`
 
 ## [v5.4.1] - 2026-07-09
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -484,7 +484,7 @@ class DocumentViewSet(
     8. **Favorite**: Get list of favorite documents for a user. Mark or unmark
         a document as favorite.
         Examples:
-        - GET /documents/favorite_list/
+        - GET /documents/favorites/
         - POST, DELETE /documents/{id}/favorite/
 
     9. **Create for Owner**: Create a document via server-to-server on behalf of a user.
@@ -836,6 +836,7 @@ class DocumentViewSet(
         detail=False,
         methods=["get"],
         permission_classes=[permissions.IsAuthenticated],
+        url_path="favorites",
     )
     def favorite_list(self, request, *args, **kwargs):
         """Get list of favorite documents for the current user."""

--- a/src/backend/core/tests/documents/test_api_documents_favorite_list.py
+++ b/src/backend/core/tests/documents/test_api_documents_favorite_list.py
@@ -16,7 +16,7 @@ def test_api_document_favorite_list_anonymous():
     """Anonymous users should receive a 401 error."""
     client = APIClient()
 
-    response = client.get("/api/v1.0/documents/favorite_list/")
+    response = client.get("/api/v1.0/documents/favorites/")
 
     assert response.status_code == 401
 
@@ -27,7 +27,7 @@ def test_api_document_favorite_list_authenticated_no_favorite():
     client = APIClient()
     client.force_login(user)
 
-    response = client.get("/api/v1.0/documents/favorite_list/")
+    response = client.get("/api/v1.0/documents/favorites/")
 
     assert response.status_code == 200
     assert response.json() == {
@@ -53,7 +53,7 @@ def test_api_document_favorite_list_authenticated_with_favorite():
         user=user, role=models.RoleChoices.READER, document__favorited_by=[user]
     ).document
 
-    response = client.get("/api/v1.0/documents/favorite_list/")
+    response = client.get("/api/v1.0/documents/favorites/")
 
     assert response.status_code == 200
     assert response.json() == {
@@ -107,7 +107,7 @@ def test_api_document_favorite_list_with_favorite_children():
     other_root = factories.DocumentFactory(creator=user, users=[user])
     factories.DocumentFactory.create_batch(2, parent=other_root)
 
-    response = client.get("/api/v1.0/documents/favorite_list/")
+    response = client.get("/api/v1.0/documents/favorites/")
 
     assert response.status_code == 200
     assert response.json()["count"] == 3
@@ -149,7 +149,7 @@ def test_api_document_favorite_list_sorted_by_updated_at():
         updated_at=now + timedelta(seconds=3)
     )
 
-    response = client.get("/api/v1.0/documents/favorite_list/")
+    response = client.get("/api/v1.0/documents/favorites/")
 
     assert response.status_code == 200
     assert response.json()["count"] == 3
@@ -176,7 +176,7 @@ def test_api_document_favorite_list_with_deleted_child():
 
     child1.delete()
 
-    response = client.get("/api/v1.0/documents/favorite_list/")
+    response = client.get("/api/v1.0/documents/favorites/")
 
     assert response.status_code == 200
     assert response.json()["count"] == 2

--- a/src/backend/core/tests/external_api/test_external_api_documents_favorite.py
+++ b/src/backend/core/tests/external_api/test_external_api_documents_favorite.py
@@ -35,7 +35,7 @@ def test_external_api_documents_favorites_list_allowed(
         document__favorited_by=[user_specific_sub],
     ).document
 
-    response = client.get("/external_api/v1.0/documents/favorite_list/")
+    response = client.get("/external_api/v1.0/documents/favorites/")
 
     assert response.status_code == 200
     data = response.json()

--- a/src/frontend/apps/impress/src/features/docs/doc-management/api/useDocsFavorite.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/api/useDocsFavorite.tsx
@@ -26,7 +26,7 @@ export const getDocsFavorite = async (
   }
 
   const response = await fetchAPI(
-    `documents/favorite_list/?${searchParams.toString()}`,
+    `documents/favorites/?${searchParams.toString()}`,
   );
 
   if (!response.ok) {


### PR DESCRIPTION
## Purpose

Current favorite documents listing endpoint path is `/documents/favorite_list/`. To respect current API semantic (_e.g._ `/documents/{id}/favorite/`), we think we can make a shorter version of the endpoint path without being less explicit 😜

## Proposal

- [x] 🚚(global) move favorite documents API endpoint to `/documents/favorites/`
