### PR TITLE
🐛(y-provider) send X-Forwarded-Proto on internal backend calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(y-provider) send X-Forwarded-Proto on internal backend calls #2541
 - 🐛(frontend) redirect homepage to login when homepage feat is disabled #2521
 
 ### Changed

--- a/src/frontend/servers/y-provider/__tests__/collaborationBackend.test.ts
+++ b/src/frontend/servers/y-provider/__tests__/collaborationBackend.test.ts
@@ -63,4 +63,29 @@ describe('CollaborationBackend', () => {
 
     axiosGetSpy.mockRestore();
   });
+
+  test('always sends X-Forwarded-Proto: https regardless of the incoming header', async () => {
+    const axiosGetSpy = vi.spyOn(axios, 'get').mockResolvedValue({
+      status: 200,
+      data: { id: 'test-user-id', email: 'test@example.com' },
+    });
+
+    const { fetchCurrentUser } = await import('@/api/collaborationBackend');
+
+    await fetchCurrentUser({
+      cookie: 'test-cookie',
+      'x-forwarded-proto': 'http',
+    });
+
+    expect(axiosGetSpy).toHaveBeenCalledWith(
+      'http://app-dev:8000/api/v1.0/users/me/',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Forwarded-Proto': 'https',
+        }),
+      }),
+    );
+
+    axiosGetSpy.mockRestore();
+  });
 });

--- a/src/frontend/servers/y-provider/src/api/collaborationBackend.ts
+++ b/src/frontend/servers/y-provider/src/api/collaborationBackend.ts
@@ -52,6 +52,19 @@ interface Doc {
   };
 }
 
+/**
+ * In production the backend sets SECURE_SSL_REDIRECT and only trusts
+ * X-Forwarded-Proto to tell whether TLS was terminated upstream. This call is
+ * internal, so when COLLABORATION_BACKEND_BASE_URL points at the backend
+ * directly it never crosses the reverse proxy: nothing sets the header, Django
+ * answers a 301 to https://<host>:<port>, and the client then speaks TLS to a
+ * port that serves plain HTTP.
+ *
+ * Always send https: it is the safe default given the current Production
+ * settings. Relaying the client's own X-Forwarded-Proto would let a client
+ * that sends X-Forwarded-Proto: http on its WebSocket upgrade force a 301 and
+ * break its own connection — a vector this fix has no reason to introduce.
+ */
 async function fetch<T>(
   path: string,
   requestHeaders: IncomingHttpHeaders,
@@ -63,6 +76,7 @@ async function fetch<T>(
         cookie: requestHeaders['cookie'],
         origin: requestHeaders['origin'],
         'X-Y-Provider-Key': Y_PROVIDER_API_KEY,
+        'X-Forwarded-Proto': 'https',
       },
     },
   );


### PR DESCRIPTION
## Purpose

Fixes #2541.

On a self-hosted deployment where `COLLABORATION_BACKEND_BASE_URL` points at the backend directly (internal docker network, e.g. `http://docs-backend:8000`), **collaboration can never connect**. Every `onConnect` fails with `[onConnect] Backend error: Unauthorized`, whatever the credentials.

The cause is not authentication, it is `SECURE_SSL_REDIRECT`:

1. `Production.SECURE_SSL_REDIRECT = True` is hardcoded in `src/backend/impress/settings.py` and cannot be driven by an environment variable.
2. Django only learns that TLS was terminated in front of it through `SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")`.
3. The y-provider call to the backend is internal: it does not cross the reverse proxy, so nothing sets that header. Django answers `301` to `https://<host>:8000`, and the client follows it — speaking TLS to a port that serves plain HTTP (`wrong version number`).

Reproduced from inside the y-provider container (v5.4.1):

```
$ wget -S --spider http://docs-backend:8000/api/v1.0/config/
  HTTP/1.1 301 Moved Permanently
  Location: https://docs-backend:8000/api/v1.0/config/
  error:0A00010B:SSL routines:tls_validate_record_header:wrong version number

$ wget -S --spider --header="X-Forwarded-Proto: https" http://docs-backend:8000/api/v1.0/config/
  HTTP/1.1 200 OK
```

The backend log showed 46 × `301 Moved Permanently` on `/api/v1.0/documents/<id>/` within the last 200 lines, all from the y-provider container IP.

## Proposal

* [x] `collaborationBackend.ts` always sends `X-Forwarded-Proto: https`, next to the `cookie` and `origin` headers it already relays.

  `https` is hardcoded rather than relayed from the incoming request. An ingress configured with `use-forwarded-headers: true` — required as soon as a load-balancer sits upstream — passes the client's own header through unchanged. A client that sends `X-Forwarded-Proto: http` on its WebSocket upgrade would therefore cause Django to answer a 301, axios would follow the redirect to a plain-HTTP port, and the connection would break. That is a vector this fix has no reason to introduce. Since `SECURE_PROXY_SSL_HEADER` is only declared in the `Production` class where `SECURE_SSL_REDIRECT = True` already makes a plain-HTTP deployment unreachable, `https` is the safe default given the current Production settings.

* [x] Test suite updated: the two cases that tested relay behaviour are removed; one test checks that `X-Forwarded-Proto: https` is always sent to the backend even when the incoming request carries `X-Forwarded-Proto: http`.
* [x] Changelog entry.

Ran locally on this branch: `yarn COLLABORATION_SERVER run test` (6 files, 56 tests passing), `run lint`, `run build`.

### Why not fix this on the backend instead?

A maintainer might reasonably suggest extending `SECURE_REDIRECT_EXEMPT` (`src/backend/impress/settings.py`) with the internal API prefixes called by the y-provider, rather than touching the y-provider itself. That approach is legitimate and would fix the problem at its source in Python.

The trade-off is maintenance surface: every internal path that could be called before the reverse proxy sets the header would need to be listed and kept in sync as the API evolves. The y-provider fix applies unconditionally for any topology where `COLLABORATION_BACKEND_BASE_URL` points at the backend directly.

It is worth noting that the topology recommended by the official Helm chart (`documentation/examples/helm/impress.values.yaml`, where `COLLABORATION_BACKEND_BASE_URL` is set to the public HTTPS URL) does **not** trigger this bug at all — the call goes through the ingress, which sets the header correctly. Routing an in-cluster call out through the public ingress and back in adds unnecessary latency and a dependency on external DNS resolution from inside the cluster; the direct-backend URL is the natural choice for in-cluster deployments, and this fix makes it work without requiring any backend change.

### Alternative considered

Making `SECURE_SSL_REDIRECT` configurable through an environment variable would also work, but it weakens a security default for every deployment in order to fix an internal call. Sending `https` unconditionally keeps the production posture untouched.

## External contributions

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added corresponding tests for new features or bug fixes (if applicable)

### CI requirements

* [x] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer
