### PR TITLE
✨(backend) conditional email notification in server to server api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 - ♿️(frontend) restore skip to content link after header redesign #2510
 - 🌐(i18n) rename cn_CN to zh_CN, add eo_PL and zh_TW locales #2486
+- ✨(backend) conditional email notification in server to server api #2554
 
 ### Fixed
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -453,6 +453,7 @@ class ServerCreateDocumentSerializer(serializers.Serializer):
     language = serializers.ChoiceField(
         required=False, choices=lazy(lambda: settings.LANGUAGES, tuple)()
     )
+    send_notification_email = serializers.BooleanField(required=False, default=True)
     # Invitation
     message = serializers.CharField(required=False)
     subject = serializers.CharField(required=False)
@@ -520,7 +521,8 @@ class ServerCreateDocumentSerializer(serializers.Serializer):
         document.content = document_content
         document.save()
 
-        self._send_email_notification(document, validated_data, email, language)
+        if validated_data.get("send_notification_email", True):
+            self._send_email_notification(document, validated_data, email, language)
         return document
 
     def _send_email_notification(self, document, validated_data, email, language):

--- a/src/backend/core/tests/documents/test_api_documents_create_for_owner.py
+++ b/src/backend/core/tests/documents/test_api_documents_create_for_owner.py
@@ -312,6 +312,33 @@ def test_api_documents_create_for_owner_new_user(mock_convert_md):
     assert document.creator == user
 
 
+@override_settings(SERVER_TO_SERVER_API_TOKENS=["DummyToken"])
+def test_api_documents_create_for_owner_without_notification_email(mock_convert_md):
+    """The caller can disable the notification email when creating the document."""
+    data = {
+        "title": "My Document",
+        "content": "Document content",
+        "sub": "123",
+        "email": "john.doe@example.com",
+        "send_notification_email": False,
+    }
+
+    response = APIClient().post(
+        "/api/v1.0/documents/create-for-owner/",
+        data,
+        format="json",
+        HTTP_AUTHORIZATION="Bearer DummyToken",
+    )
+
+    assert response.status_code == 201
+    assert mock_convert_md.called is True
+    assert Document.objects.exists()
+    assert Invitation.objects.filter(
+        email="john.doe@example.com", role="owner"
+    ).exists()
+    assert len(mail.outbox) == 0
+
+
 @override_settings(
     SERVER_TO_SERVER_API_TOKENS=["DummyToken"],
     OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION=True,


### PR DESCRIPTION
## Purpose

Add `send_notification_email` flag (defaults to True) on the `ServerCreateDocumentSerializer` so that we can bypass sending the email notification when creating a document with the server to server API.

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added corresponding tests for new features or bug fixes (if applicable)

*Skip the checkbox below 👇 if you're fixing an issue or adding documentation*
* [x] Before submitting a PR for a new feature I made sure to contact the product manager

### CI requirements

* [x] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

*Skip the checkboxes below 👇 If you didn't use AI for your contribution*

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer
