### PR TITLE
🛂 use jwt token for converter services

### DIFF
--- a/documentation/examples/helm/impress.values.yaml
+++ b/documentation/examples/helm/impress.values.yaml
@@ -135,7 +135,6 @@ yProvider:
     COLLABORATION_LOGGING: true
     COLLABORATION_SERVER_ORIGIN: https://docs.127.0.0.1.nip.io
     COLLABORATION_SERVER_SECRET: my-secret
-    Y_PROVIDER_API_KEY: my-secret
 
 ingress:
   enabled: true

--- a/documentation/format_conversion.md
+++ b/documentation/format_conversion.md
@@ -8,20 +8,23 @@ To make it work, some configuration should be made and another service enabled i
 
 The first configuration to make is related to converting a docs in multiple format. This will be used by the `formatted-content` endpoint (`/api/v1.0/documents/{document_id}/formatted-content/?content_format=(json|html|markdown)`).
 This service is also used by the `create-for-owner` endpoint and in the import of markdown file.
-To configure it, use this environment variables in the Django service:
+To configure it, use this environment variable in the Django service:
 
 ```yaml
 Y_PROVIDER_API_BASE_URL: http://{y-provider-service}:443/api/
-Y_PROVIDER_API_KEY: a-shared-private-key-with-y-provider
 ```
 
 For the `Y_PROVIDER_API_BASE_URL`, it can be the FQDN of your docs instance if you have configured a reverse proxy in front of the y-provider service and created a route to the `/api` for this service. It can also be the internal `y-provider` service url if Django can access it directly. In the case you deploy in a Kubernetes cluster, you can use the `y-provider` service url. We prefer the usage of internal url.
 
-You also have to add an environment variable in your `y-provider` configuration, to share the same `Y_PROVIDER_API_KEY`:
+Requests to the y-provider service are authenticated with a short-lived admin JWT that Django signs itself (see `core.services.jwt_services.JWTService`), instead of a shared secret. The y-provider service verifies the signature against the public key Django publishes on its JWKS endpoint (`/api/v1.0/jwks`), so there is nothing to configure on the Django side beyond `JWT_PRIVATE_KEY` (see the JWT section of [env.md](env.md)).
+
+On the `y-provider` side, point it at the Django backend so it can fetch the JWKS:
 
 ```yaml
-Y_PROVIDER_API_KEY: a-shared-private-key-with-y-provider
+COLLABORATION_BACKEND_BASE_URL: http://{django-service}:8000
 ```
+
+The JWKS url defaults to `{COLLABORATION_BACKEND_BASE_URL}/api/v1.0/jwks`; override it with `JWKS_URL` if Django is not reachable at that base url from the y-provider service.
 
 ### Splitting conversion service
 

--- a/src/backend/core/services/converter_services.py
+++ b/src/backend/core/services/converter_services.py
@@ -13,6 +13,11 @@ from core.services.jwt_services import JWTService
 
 logger = logging.getLogger(__name__)
 
+# Audience of the admin token y-provider expects. Scoping the token to it
+# prevents an admin JWT issued for another backend service from being
+# replayed against y-provider.
+Y_CONVERTER_AUDIENCE = "y-converter"
+
 
 class ConversionError(Exception):
     """Base exception for conversion-related errors."""
@@ -110,7 +115,8 @@ class YdocConverter:
     @property
     def auth_header(self):
         """Build microservice authentication header."""
-        return f"Bearer {JWTService().get_admin_token()}"
+        token = JWTService().get_admin_token({"aud": Y_CONVERTER_AUDIENCE})
+        return f"Bearer {token}"
 
     def _request(self, url, data, content_type, accept):
         """Make a request to the Y-Provider API."""

--- a/src/backend/core/services/converter_services.py
+++ b/src/backend/core/services/converter_services.py
@@ -9,6 +9,7 @@ from django.conf import settings
 import requests
 
 from core.services import mime_types
+from core.services.jwt_services import JWTService
 
 logger = logging.getLogger(__name__)
 
@@ -109,8 +110,7 @@ class YdocConverter:
     @property
     def auth_header(self):
         """Build microservice authentication header."""
-        # Note: Yprovider microservice accepts only raw token, which is not recommended
-        return f"Bearer {settings.Y_PROVIDER_API_KEY}"
+        return f"Bearer {JWTService().get_admin_token()}"
 
     def _request(self, url, data, content_type, accept):
         """Make a request to the Y-Provider API."""

--- a/src/backend/core/tests/test_api_jwks.py
+++ b/src/backend/core/tests/test_api_jwks.py
@@ -6,11 +6,10 @@ from django.urls import resolve
 
 import jwt
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from rest_framework.test import APIClient
 
 from core.services.jwt_services import JWTService
+from core.tests.utils.jwt import generate_key_pair
 from core.tests.utils.urls import reload_urls
 
 pytestmark = pytest.mark.django_db
@@ -18,23 +17,9 @@ pytestmark = pytest.mark.django_db
 # Private members of a RSA JWK, none of them may ever leak in the JWKS
 PRIVATE_JWK_MEMBERS = {"d", "p", "q", "dp", "dq", "qi", "oth"}
 
-
-def generate_private_key():
-    """Generate a PEM encoded RSA private key."""
-    return (
-        rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        .private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-        .decode("utf-8")
-    )
-
-
 # Generating RSA keys is expensive, do it once for the whole module
-PRIVATE_KEY = generate_private_key()
-OTHER_PRIVATE_KEY = generate_private_key()
+PRIVATE_KEY, _ = generate_key_pair()
+OTHER_PRIVATE_KEY, _ = generate_key_pair()
 
 
 @pytest.fixture(name="jwt_settings")

--- a/src/backend/core/tests/test_services_converter_services.py
+++ b/src/backend/core/tests/test_services_converter_services.py
@@ -3,6 +3,7 @@
 from base64 import b64decode
 from unittest.mock import MagicMock, patch
 
+import jwt
 import pytest
 import requests
 
@@ -12,13 +13,28 @@ from core.services.converter_services import (
     ValidationError,
     YdocConverter,
 )
+from core.tests.utils.jwt import generate_key_pair
+
+# Generating an RSA key is expensive, do it once for the whole module
+PRIVATE_KEY, PUBLIC_KEY = generate_key_pair()
 
 
-def test_auth_header(settings):
-    """Test authentication header generation."""
-    settings.Y_PROVIDER_API_KEY = "test-key"
+@pytest.fixture(autouse=True)
+def jwt_settings(settings):
+    """Setup valid settings for the JWT service used to sign the auth header."""
+    settings.JWT_PRIVATE_KEY = PRIVATE_KEY
+    settings.JWT_TOKEN_LIFETIME = 3600
+
+
+def test_auth_header():
+    """The auth header carries an admin JWT signed with the configured key."""
     converter = YdocConverter()
-    assert converter.auth_header == "Bearer test-key"
+
+    scheme, token = converter.auth_header.split(" ")
+
+    assert scheme == "Bearer"
+    payload = jwt.decode(token, PUBLIC_KEY, algorithms=["RS256"])
+    assert payload["admin"] is True
 
 
 def test_convert_empty_text():
@@ -63,12 +79,12 @@ def test_convert_full_integration(mock_post, settings):
     """Test full integration with all settings."""
 
     settings.Y_PROVIDER_API_BASE_URL = "http://test.com/"
-    settings.Y_PROVIDER_API_KEY = "test-key"
     settings.CONVERSION_API_ENDPOINT = "conversion-endpoint"
     settings.CONVERSION_API_TIMEOUT = 5
     settings.CONVERSION_API_CONTENT_FIELD = "content"
 
     converter = YdocConverter()
+    auth_header = converter.auth_header
 
     expected_content = b"converted content"
     mock_response = MagicMock()
@@ -83,7 +99,7 @@ def test_convert_full_integration(mock_post, settings):
         "http://test.com/conversion-endpoint/",
         data="test markdown",
         headers={
-            "Authorization": "Bearer test-key",
+            "Authorization": auth_header,
             "Content-Type": mime_types.MARKDOWN,
             "Accept": mime_types.YJS,
         },
@@ -96,12 +112,12 @@ def test_convert_full_integration(mock_post, settings):
 def test_convert_full_integration_with_specific_headers(mock_post, settings):
     """Test successful conversion with specific content type and accept headers."""
     settings.Y_PROVIDER_API_BASE_URL = "http://test.com/"
-    settings.Y_PROVIDER_API_KEY = "test-key"
     settings.CONVERSION_API_ENDPOINT = "conversion-endpoint"
     settings.CONVERSION_API_TIMEOUT = 5
     settings.CONVERSION_API_SECURE = False
 
     converter = YdocConverter()
+    auth_header = converter.auth_header
 
     expected_response = "# Test Document\n\nThis is test content."
     mock_response = MagicMock()
@@ -116,7 +132,7 @@ def test_convert_full_integration_with_specific_headers(mock_post, settings):
         "http://test.com/conversion-endpoint/",
         data=b"test_content",
         headers={
-            "Authorization": "Bearer test-key",
+            "Authorization": auth_header,
             "Content-Type": mime_types.YJS,
             "Accept": mime_types.MARKDOWN,
         },

--- a/src/backend/core/tests/test_services_converter_services.py
+++ b/src/backend/core/tests/test_services_converter_services.py
@@ -27,14 +27,17 @@ def jwt_settings(settings):
 
 
 def test_auth_header():
-    """The auth header carries an admin JWT signed with the configured key."""
+    """The auth header carries an admin JWT scoped to the y-converter audience."""
     converter = YdocConverter()
 
     scheme, token = converter.auth_header.split(" ")
 
     assert scheme == "Bearer"
-    payload = jwt.decode(token, PUBLIC_KEY, algorithms=["RS256"])
+    payload = jwt.decode(
+        token, PUBLIC_KEY, algorithms=["RS256"], audience="y-converter"
+    )
     assert payload["admin"] is True
+    assert payload["aud"] == "y-converter"
 
 
 def test_convert_empty_text():

--- a/src/backend/core/tests/test_services_jwt_services.py
+++ b/src/backend/core/tests/test_services_jwt_services.py
@@ -10,8 +10,6 @@ from django.core.cache import cache
 
 import jwt
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from freezegun import freeze_time
 
 from core.services.jwt_services import (
@@ -19,26 +17,7 @@ from core.services.jwt_services import (
     JWTService,
     TokenGenerationError,
 )
-
-
-def generate_key_pair():
-    """Generate a PEM encoded RSA key pair to sign and verify test tokens."""
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    private_pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    ).decode("utf-8")
-    public_pem = (
-        private_key.public_key()
-        .public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        .decode("utf-8")
-    )
-    return private_pem, public_pem
-
+from core.tests.utils.jwt import generate_key_pair
 
 # Generating RSA keys is expensive, do it once for the whole module
 PRIVATE_KEY, PUBLIC_KEY = generate_key_pair()

--- a/src/backend/core/tests/utils/jwt.py
+++ b/src/backend/core/tests/utils/jwt.py
@@ -1,0 +1,23 @@
+"""Utils for testing JWT-signed tokens."""
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def generate_key_pair():
+    """Generate a PEM encoded RSA key pair to sign and verify test tokens."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    return private_pem, public_pem

--- a/src/frontend/servers/y-provider/__tests__/convert.test.ts
+++ b/src/frontend/servers/y-provider/__tests__/convert.test.ts
@@ -6,7 +6,7 @@ import {
 import { ServerBlockNoteEditor } from '@blocknote/server-util';
 import { Fragment, Node as PMNode } from 'prosemirror-model';
 import request from 'supertest';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { prosemirrorToYXmlFragment } from 'y-prosemirror';
 import * as Y from 'yjs';
 
@@ -14,17 +14,17 @@ vi.mock('../src/env', async (importOriginal) => {
   return {
     ...(await importOriginal()),
     COLLABORATION_SERVER_ORIGIN: 'http://localhost:3000',
-    Y_PROVIDER_API_KEY: 'yprovider-api-key',
   };
 });
 
 import { docsBlockNoteSchema } from '@/blockSpecs';
 import { initApp } from '@/servers';
 
-import {
-  Y_PROVIDER_API_KEY as apiKey,
-  COLLABORATION_SERVER_ORIGIN as origin,
-} from '../src/env';
+import { JWKS_URL, COLLABORATION_SERVER_ORIGIN as origin } from '../src/env';
+
+import { mockJwksEndpoint, signAdminToken } from './testUtils/adminJwt';
+
+const apiKey = await signAdminToken();
 
 const expectedMarkdown = '# Example document\n\nLorem ipsum dolor sit amet.';
 const expectedHTML =
@@ -141,8 +141,13 @@ const buildYjsUpdateWithComment = (): Buffer => {
 console.error = vi.fn();
 
 describe('Conversion Testing', () => {
+  beforeEach(() => {
+    mockJwksEndpoint(JWKS_URL);
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   test('POST /api/convert with incorrect API key responds with 401', async () => {

--- a/src/frontend/servers/y-provider/__tests__/middlewares.test.ts
+++ b/src/frontend/servers/y-provider/__tests__/middlewares.test.ts
@@ -1,0 +1,114 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { JWKS_URL } = vi.hoisted(() => ({
+  JWKS_URL: 'http://app-dev:8000/api/v1.0/jwks',
+}));
+
+vi.mock('../src/env', async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    JWKS_URL,
+  };
+});
+
+import { httpSecurity } from '@/middlewares';
+
+import {
+  mockJwksEndpoint,
+  signAdminToken,
+  signAdminTokenWithWrongKey,
+  signExpiredAdminToken,
+  signToken,
+} from './testUtils/adminJwt';
+
+const buildApp = () => {
+  const app = express();
+  app.get('/protected', httpSecurity, (req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  return app;
+};
+
+describe('httpSecurity', () => {
+  beforeEach(() => {
+    mockJwksEndpoint(JWKS_URL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects requests without an authorization header', async () => {
+    const response = await request(buildApp()).get('/protected');
+
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({
+      error: 'Unauthorized: No credentials given',
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid admin JWT signed by the Django backend', async () => {
+    const token = await signAdminToken();
+
+    const response = await request(buildApp())
+      .get('/protected')
+      .set('authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    // Verified against the real JWKS document served over the (mocked) network.
+    expect(fetch).toHaveBeenCalledWith(JWKS_URL, expect.anything());
+  });
+
+  it('rejects a token signed with a key that is not in the JWKS', async () => {
+    const token = await signAdminTokenWithWrongKey();
+
+    const response = await request(buildApp())
+      .get('/protected')
+      .set('authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({
+      error: 'Unauthorized: Invalid API Key',
+    });
+  });
+
+  it('rejects an expired admin JWT', async () => {
+    const token = await signExpiredAdminToken();
+
+    const response = await request(buildApp())
+      .get('/protected')
+      .set('authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({
+      error: 'Unauthorized: Invalid API Key',
+    });
+  });
+
+  it('rejects a validly signed JWT missing the admin claim', async () => {
+    const token = await signToken({ sub: 'someone' });
+
+    const response = await request(buildApp())
+      .get('/protected')
+      .set('authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({
+      error: 'Unauthorized: Invalid API Key',
+    });
+  });
+
+  it('rejects a bearer token that is not a valid JWT', async () => {
+    const response = await request(buildApp())
+      .get('/protected')
+      .set('authorization', 'Bearer wrong-token');
+
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({
+      error: 'Unauthorized: Invalid API Key',
+    });
+  });
+});

--- a/src/frontend/servers/y-provider/__tests__/middlewares.test.ts
+++ b/src/frontend/servers/y-provider/__tests__/middlewares.test.ts
@@ -18,6 +18,7 @@ import { httpSecurity } from '@/middlewares';
 import {
   mockJwksEndpoint,
   signAdminToken,
+  signAdminTokenForAudience,
   signAdminTokenWithWrongKey,
   signExpiredAdminToken,
   signToken,
@@ -77,6 +78,19 @@ describe('httpSecurity', () => {
 
   it('rejects an expired admin JWT', async () => {
     const token = await signExpiredAdminToken();
+
+    const response = await request(buildApp())
+      .get('/protected')
+      .set('authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({
+      error: 'Unauthorized: Invalid API Key',
+    });
+  });
+
+  it('rejects a valid admin JWT issued for another audience', async () => {
+    const token = await signAdminTokenForAudience('some-other-service');
 
     const response = await request(buildApp())
       .get('/protected')

--- a/src/frontend/servers/y-provider/__tests__/server.test.ts
+++ b/src/frontend/servers/y-provider/__tests__/server.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest';
-import { describe, expect, it, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 
 import { routes } from '@/routes';
 import { initApp } from '@/servers';
@@ -8,19 +8,25 @@ vi.mock('../src/env', async (importOriginal) => {
   return {
     ...(await importOriginal()),
     COLLABORATION_SERVER_ORIGIN: 'http://localhost:3000',
-    Y_PROVIDER_API_KEY: 'yprovider-api-key',
     CONVERSION_FILE_MAX_SIZE: 500 * 1024, // 500kb
   };
 });
 
-import {
-  Y_PROVIDER_API_KEY as apiKey,
-  COLLABORATION_SERVER_ORIGIN as origin,
-} from '../src/env';
+import { JWKS_URL, COLLABORATION_SERVER_ORIGIN as origin } from '../src/env';
+
+import { mockJwksEndpoint, signAdminToken } from './testUtils/adminJwt';
 
 console.error = vi.fn();
 
 describe('Server Tests', () => {
+  beforeEach(() => {
+    mockJwksEndpoint(JWKS_URL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   test('Ping Pong', async () => {
     const app = initApp();
 
@@ -43,12 +49,13 @@ describe('Server Tests', () => {
 
   it('allows payloads up to 500kb for the CONVERT route', async () => {
     const app = initApp();
+    const apiKey = await signAdminToken();
 
     const largePayload = 'a'.repeat(400 * 1024); // 400kb payload
     const response = await request(app)
       .post(routes.CONVERT)
       .set('origin', origin)
-      .set('authorization', apiKey)
+      .set('authorization', `Bearer ${apiKey}`)
       .set('content-type', 'text/markdown')
       .send(largePayload);
 
@@ -57,12 +64,13 @@ describe('Server Tests', () => {
 
   it('rejects payloads larger than CONVERSION_FILE_MAX_SIZE for the CONVERT route', async () => {
     const app = initApp();
+    const apiKey = await signAdminToken();
 
     const oversizedPayload = 'a'.repeat(501 * 1024); // 501kb payload
     const response = await request(app)
       .post(routes.CONVERT)
       .set('origin', origin)
-      .set('authorization', apiKey)
+      .set('authorization', `Bearer ${apiKey}`)
       .set('content-type', 'text/markdown')
       .send(oversizedPayload);
 

--- a/src/frontend/servers/y-provider/__tests__/testUtils/adminJwt.ts
+++ b/src/frontend/servers/y-provider/__tests__/testUtils/adminJwt.ts
@@ -27,7 +27,12 @@ export const signToken = (claims: Record<string, unknown>) =>
     .setExpirationTime('1h')
     .sign(privateKey);
 
-export const signAdminToken = () => signToken({ admin: true });
+export const signAdminToken = () =>
+  signToken({ admin: true, aud: 'y-converter' });
+
+/** An admin token correctly signed but scoped to another service's audience. */
+export const signAdminTokenForAudience = (aud: string) =>
+  signToken({ admin: true, aud });
 
 /** An admin token signed correctly but already past its expiry. */
 export const signExpiredAdminToken = () =>

--- a/src/frontend/servers/y-provider/__tests__/testUtils/adminJwt.ts
+++ b/src/frontend/servers/y-provider/__tests__/testUtils/adminJwt.ts
@@ -1,0 +1,75 @@
+import {
+  SignJWT,
+  calculateJwkThumbprint,
+  exportJWK,
+  generateKeyPair,
+} from 'jose';
+import { vi } from 'vitest';
+
+import { JWT_ALGORITHM } from '@/middlewares';
+
+const { privateKey, publicKey } = await generateKeyPair(JWT_ALGORITHM, {
+  extractable: true,
+});
+const publicJwk = await exportJWK(publicKey);
+const kid = await calculateJwkThumbprint(publicJwk);
+
+/** JWKS document shaped like the one Django's JWKSView publishes. */
+export const JWKS = {
+  keys: [{ ...publicJwk, kid, alg: JWT_ALGORITHM, use: 'sig' }],
+};
+
+/** Sign a token the way Django's JWTService would, for tests only. */
+export const signToken = (claims: Record<string, unknown>) =>
+  new SignJWT(claims)
+    .setProtectedHeader({ alg: JWT_ALGORITHM, kid })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(privateKey);
+
+export const signAdminToken = () => signToken({ admin: true });
+
+/** An admin token signed correctly but already past its expiry. */
+export const signExpiredAdminToken = () =>
+  new SignJWT({ admin: true })
+    .setProtectedHeader({ alg: JWT_ALGORITHM, kid })
+    .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+    .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+    .sign(privateKey);
+
+// A second, unrelated key pair: never published in the test JWKS, so a token
+// signed with it must fail signature verification.
+const { privateKey: roguePrivateKey } = await generateKeyPair(JWT_ALGORITHM, {
+  extractable: true,
+});
+
+/**
+ * An admin token carrying the real "kid" (so key lookup succeeds) but signed
+ * with a key that isn't the one published in the JWKS.
+ */
+export const signAdminTokenWithWrongKey = () =>
+  new SignJWT({ admin: true })
+    .setProtectedHeader({ alg: JWT_ALGORITHM, kid })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(roguePrivateKey);
+
+/**
+ * Stub global fetch so jose's createRemoteJWKSet resolves our test JWKS
+ * instead of making a real network call to the Django backend. The real
+ * "jose" verification code still runs against a real signed token.
+ */
+export const mockJwksEndpoint = (jwksUrl: string) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string | URL) => {
+      if (input.toString() !== jwksUrl) {
+        throw new Error(`Unexpected fetch to ${input.toString()}`);
+      }
+      return new Response(JSON.stringify(JWKS), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }),
+  );
+};

--- a/src/frontend/servers/y-provider/package.json
+++ b/src/frontend/servers/y-provider/package.json
@@ -23,6 +23,7 @@
     "@tiptap/extensions": "*",
     "cors": "2.8.6",
     "express": "5.2.1",
+    "jose": "6.2.8",
     "yjs": "*"
   },
   "devDependencies": {

--- a/src/frontend/servers/y-provider/src/env.ts
+++ b/src/frontend/servers/y-provider/src/env.ts
@@ -1,9 +1,14 @@
 import { readFileSync } from 'fs';
 
+export const COLLABORATION_BACKEND_BASE_URL =
+  process.env.COLLABORATION_BACKEND_BASE_URL || 'http://app-dev:8000';
 export const COLLABORATION_LOGGING =
   process.env.COLLABORATION_LOGGING || 'false';
 export const COLLABORATION_SERVER_ORIGIN =
   process.env.COLLABORATION_SERVER_ORIGIN || 'http://localhost:3000';
+// TODO(yhub): unused since the yhub migration, mirrors the Django setting of
+// the same name (see impress/settings.py). Kept until CollaborationService is
+// reinstated.
 export const COLLABORATION_SERVER_SECRET = process.env
   .COLLABORATION_SERVER_SECRET_FILE
   ? readFileSync(process.env.COLLABORATION_SERVER_SECRET_FILE, 'utf-8')
@@ -11,8 +16,8 @@ export const COLLABORATION_SERVER_SECRET = process.env
 export const CONVERSION_FILE_MAX_SIZE = process.env.CONVERSION_FILE_MAX_SIZE
   ? Number(process.env.CONVERSION_FILE_MAX_SIZE)
   : 20971520; // 20 MB default
-export const Y_PROVIDER_API_KEY = process.env.Y_PROVIDER_API_KEY_FILE
-  ? readFileSync(process.env.Y_PROVIDER_API_KEY_FILE, 'utf-8')
-  : process.env.Y_PROVIDER_API_KEY || 'yprovider-api-key';
+// JWKS of the Django backend, used to verify the JWT it signs when calling us.
+export const JWKS_URL =
+  process.env.JWKS_URL || `${COLLABORATION_BACKEND_BASE_URL}/api/v1.0/jwks`;
 export const PORT = Number(process.env.PORT || 4444);
 export const SENTRY_DSN = process.env.SENTRY_DSN || '';

--- a/src/frontend/servers/y-provider/src/middlewares.ts
+++ b/src/frontend/servers/y-provider/src/middlewares.ts
@@ -16,14 +16,21 @@ export const corsMiddleware = cors({
 // keeps them until their "kid" no longer matches a token, per jose's own policy.
 const jwks = createRemoteJWKSet(new URL(JWKS_URL));
 
+// Requiring this audience stops a valid admin JWT issued for another service
+// from being replayed against y-provider.
+const Y_CONVERTER_AUDIENCE = 'y-converter';
 export const JWT_ALGORITHM = 'RS256';
 
 /**
- * Verify that the given token is an admin JWT signed by the Django backend.
+ * Verify that the given token is an admin JWT signed by the Django backend
+ * for the y-converter audience.
  */
 const isValidAdminToken = async (token: string): Promise<boolean> => {
   try {
-    const { payload } = await jwtVerify(token, jwks, { algorithms: [JWT_ALGORITHM] });
+    const { payload } = await jwtVerify(token, jwks, {
+      algorithms: [JWT_ALGORITHM],
+      audience: Y_CONVERTER_AUDIENCE,
+    });
     return payload.admin === true;
   } catch {
     return false;

--- a/src/frontend/servers/y-provider/src/middlewares.ts
+++ b/src/frontend/servers/y-provider/src/middlewares.ts
@@ -1,13 +1,9 @@
 import cors from 'cors';
 import { NextFunction, Request, Response } from 'express';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
 
-import {
-  COLLABORATION_SERVER_ORIGIN,
-  COLLABORATION_SERVER_SECRET,
-  Y_PROVIDER_API_KEY,
-} from '@/env';
+import { COLLABORATION_SERVER_ORIGIN, JWKS_URL } from '@/env';
 
-const VALID_API_KEYS = [COLLABORATION_SERVER_SECRET, Y_PROVIDER_API_KEY];
 const allowedOrigins = COLLABORATION_SERVER_ORIGIN.split(',');
 
 export const corsMiddleware = cors({
@@ -16,11 +12,29 @@ export const corsMiddleware = cors({
   credentials: true,
 });
 
-export const httpSecurity = (
+// Cached across requests: fetches the Django backend's public keys lazily and
+// keeps them until their "kid" no longer matches a token, per jose's own policy.
+const jwks = createRemoteJWKSet(new URL(JWKS_URL));
+
+export const JWT_ALGORITHM = 'RS256';
+
+/**
+ * Verify that the given token is an admin JWT signed by the Django backend.
+ */
+const isValidAdminToken = async (token: string): Promise<boolean> => {
+  try {
+    const { payload } = await jwtVerify(token, jwks, { algorithms: [JWT_ALGORITHM] });
+    return payload.admin === true;
+  } catch {
+    return false;
+  }
+};
+
+export const httpSecurity = async (
   req: Request,
   res: Response,
   next: NextFunction,
-): void => {
+): Promise<void> => {
   let apiKey = req.headers['authorization'];
 
   if (!apiKey) {
@@ -32,7 +46,7 @@ export const httpSecurity = (
     apiKey = apiKey.slice('Bearer '.length);
   }
 
-  if (!VALID_API_KEYS.includes(apiKey)) {
+  if (!(await isValidAdminToken(apiKey))) {
     res.status(401).json({ error: 'Unauthorized: Invalid API Key' });
     return;
   }

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -11283,6 +11283,11 @@ jest@30.4.2:
     import-local "^3.2.0"
     jest-cli "30.4.2"
 
+jose@6.2.8:
+  version "6.2.8"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.8.tgz#39c1459fe5eac84eb39b1623b8077dcf9ca6c506"
+  integrity sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -13182,7 +13187,7 @@ react-intersection-observer@10.1.0:
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-10.1.0.tgz#4aedf418c793f2bcf27353263f43553d12afba71"
   integrity sha512-V8HDu3+Llg6OEhOxx8LnUSS0t4VS+1Xk9ZatkI8Jct/H0CwKnqFTCu8NT3q7ghJTghTdIrEMPSWr2dkKPG+gdQ==
 
-"react-is-18@npm:react-is@^18.3.1":
+"react-is-18@npm:react-is@^18.3.1", react-is@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
@@ -13206,11 +13211,6 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-
-react-is@^18.3.1:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
-  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -14247,16 +14247,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14390,14 +14381,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -170,7 +170,6 @@ yProvider:
     COLLABORATION_LOGGING: true
     COLLABORATION_SERVER_ORIGIN: https://docs.127.0.0.1.nip.io
     COLLABORATION_SERVER_SECRET: my-secret
-    Y_PROVIDER_API_KEY: my-secret
     NODE_EXTRA_CA_CERTS: /cert/cacert.pem
 
   # Extra volume mounts to manage our local custom CA and avoid to set ssl_verify: false

--- a/src/helm/env.d/feature/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/feature/values.impress.yaml.gotmpl
@@ -148,7 +148,6 @@ yProvider:
     COLLABORATION_LOGGING: true
     COLLABORATION_SERVER_ORIGIN: https://{{ .Values.feature }}-docs.{{ .Values.domain }}
     COLLABORATION_SERVER_SECRET: my-secret
-    Y_PROVIDER_API_KEY: my-secret
     NODE_OPTIONS: "--max-old-space-size=1024"
 
 docSpec:


### PR DESCRIPTION
## Purpose

This pull request migrates the authentication mechanism between the Django backend and the y-provider service from a shared secret (`Y_PROVIDER_API_KEY`) to short-lived, JWT-signed admin tokens. The Django service now signs tokens with its private key and publishes its public key via a JWKS endpoint, which the y-provider verifies. The change is reflected in both backend and frontend code, as well as in documentation and tests. Additionally, test utilities for JWT key generation and signing are refactored and centralized.

These changes improve security by eliminating long-lived shared secrets and ensure robust, testable authentication between Django and y-provider.