### PR TITLE
🐛(keycloak) fix database env variables in the self-hosting example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 - 🐛(backend) ignore CSPs for API docs in development
 - 🐛(frontend) export images embedded with a relative url #2573
 - 🐛(y-provider) fix sentry init #2579
+- 🐛(keycloak) fix database env variables in the self-hosting example #2572
 - 🐛(helm) show the database error while jobs wait for it to be ready #2578
 
 ## [v5.4.1] - 2026-07-09

--- a/env.d/production.dist/kc_postgresql
+++ b/env.d/production.dist/kc_postgresql
@@ -7,7 +7,7 @@ PGDATA=/var/lib/postgresql/data/pgdata
 # Keycloak postgresql configuration
 KC_DB=postgres
 KC_DB_SCHEMA=public
-KC_DB_HOST=postgresql
-KC_DB_NAME=${POSTGRES_DB}
-KC_DB_USER=${POSTGRES_USER}
+KC_DB_URL_HOST=kc_postgresql
+KC_DB_URL_DATABASE=${POSTGRES_DB}
+KC_DB_USERNAME=${POSTGRES_USER}
 KC_DB_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
## Purpose

Fixes #1322

The Keycloak self-hosting example cannot connect to its database. `env.d/production.dist/kc_postgresql` is loaded into both the `kc_postgresql` and the `keycloak` containers of [`documentation/examples/compose/keycloak/compose.yaml`](https://github.com/suitenumerique/docs/blob/main/documentation/examples/compose/keycloak/compose.yaml), but the `KC_DB_*` variables it defines are not the ones the Quarkus distribution of Keycloak reads.

Unknown `KC_*` variables are silently ignored, so Keycloak falls back to its default JDBC URL (`jdbc:postgresql://localhost/keycloak`) and the container fails to start.

## Proposal

* [x] `KC_DB_HOST` → `KC_DB_URL_HOST` (maps to `--db-url-host`)
* [x] `KC_DB_NAME` → `KC_DB_URL_DATABASE` (maps to `--db-url-database`)
* [x] `KC_DB_USER` → `KC_DB_USERNAME` (maps to `--db-username`)
* [x] fix the host value: it pointed to `postgresql`, but the service is named `kc_postgresql` in the example compose file

The three names now match the ones already used in `env.d/development/kc_auth`, so the development and production examples are consistent.

Reference: [Keycloak — all configuration](https://www.keycloak.org/server/all-config) (`db-url-host`, `db-url-database`, `db-username`).

Note: the reporter suggested `KC_DB_URL`, but that option expects a *full* JDBC URL and would ignore the other `db-url-*` settings. `KC_DB_URL_HOST` is the correct one here since the rest of the URL is composed from `KC_DB_URL_DATABASE`.

## External contributions

### General requirements

* [x] I have read and followed the contributing guidelines
* [x] I have read and agreed to the Code of Conduct
* [ ] I have added corresponding tests for new features or bug fixes (if applicable) — N/A, configuration example only

### CI requirements

* [x] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer
