### PR TITLE
💄(frontend) use the same highlight color for cells and moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Changed
 
 - ♿️(frontend) use semantic `<dl>` structure in document info card #2379
+- 💄(frontend) use the same highlight color for cells and moves #2575
 
 ### Fixed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/components/BlockNoteEditor.tsx
@@ -196,6 +196,9 @@ export const BlockNoteEditor = ({ doc, provider }: BlockNoteEditorProps) => {
         },
         showCursorLabels: showCursorLabels as 'always' | 'activity',
       },
+      dropCursor: {
+        color: 'var(--c--contextuals--background--semantic--brand--tertiary)',
+      },
       dictionary: {
         ...localesBN[langLocalesBN as keyof typeof localesBN],
         ...(localesBNMultiColumn && {

--- a/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-editor/styles.tsx
@@ -150,6 +150,19 @@ export const DocsEditorStyle = createGlobalStyle`
     }
 
     /**
+    * Tables
+    */
+    .ProseMirror .selectedCell:after {
+      background: var(--c--contextuals--background--semantic--brand--tertiary);
+      mix-blend-mode: multiply;
+    }
+    .bn-table-drop-cursor, .ProseMirror .column-resize-handle {
+      background-color: var(
+        --c--contextuals--background--semantic--brand--tertiary
+      );
+    }
+
+    /**
     * Divider
     */
     .bn-block-content[data-content-type='divider'] {


### PR DESCRIPTION
## Purpose

Fixes #2080

Three different colors are used to highlight things in the editor, none of them from the palette:

| what | where it comes from | color |
| --- | --- | --- |
| selected table cells | `.ProseMirror .selectedCell:after` (`@blocknote/core` style.css) | `#c8c8ff66`, i.e. `#e9e9ff` over white |
| drop cursor of a moved block | `dropCursor.color` default in the `DropCursor` extension | `#ddeeff` |
| drop indicator of a moved table row/column | `.bn-table-drop-cursor` | `#adf` |

The first two are the ones compared in the issue screenshot.

Following @robin-lecomte's answer, all three now use `var(--c--contextuals--background--semantic--brand--tertiary)` (`brand-050`, `#eef1fa`).

## Proposal

* [x] set `dropCursor.color` on the main editor to the brand token, the option `@YousefED` mentions in TypeCellOS/BlockNote#2569 is exposed by `useCreateBlockNote`, so no `!important` on the inline style the extension writes
* [x] override `.selectedCell:after` and `.bn-table-drop-cursor` with the same token in `doc-editor/styles.tsx`

The cell overlay is drawn on top of the cell content (`position: absolute; inset: 0; z-index: 2`), which is why BlockNote uses a translucent color. An opaque token there hides the text, so the overlay gets `mix-blend-mode: multiply`: over the white cell it renders exactly `#eef1fa`, and the content stays readable. This is the same treatment already used for the comment marks in `doc-comments/styles.tsx`.

Two points worth a look from a design standpoint, both a one line change if you want them different:

* `brand-050` on white gives a 1.06:1 contrast ratio for the drop cursor, against 1.13:1 for the current `#ddeeff`, so the indicator of a moved block becomes slightly fainter than it is today. `--c--contextuals--background--semantic--brand--secondary` (`#dde2f5`) would keep it closer to the current visibility while staying in the palette.
* I included `.bn-table-drop-cursor` (moving a table row or column) since it is the same "move" indicator inside the very table the issue is about, and leaving it at `#adf` would keep a third color around. Happy to drop it from the PR if you would rather keep the scope to the two colors of the screenshot.

## Testing

No automated test: the change is a color override with no behaviour attached, and the editor has no visual regression setup. Checked manually that the token resolves through the inline style the drop cursor extension sets (`element.style.backgroundColor = "var(--c--contextuals--background--semantic--brand--tertiary)"` computes to `rgb(238, 241, 250)`), and that the blended overlay keeps the cell content readable.

`tsc --noEmit`, `eslint` and `prettier --check` are clean, `doc-editor` unit tests pass (21).

## External contributions

### General requirements

* [x] I have read and followed the contributing guidelines
* [x] I have read and agreed to the Code of Conduct
* [x] I have added corresponding tests for new features or bug fixes (if applicable)

### CI requirements

* [x] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer
