### PR TITLE
🐛(y-provider) fix sentry init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,16 @@ and this project adheres to
 - 🌐(i18n) rename cn_CN to zh_CN, add eo_PL and zh_TW locales #2486
 - ✨(backend) conditional email notification in server to server api #2554
 
+### Changed
+
+- ♿️(frontend) use semantic `<dl>` structure in document info card #2379
+
 ### Fixed
 
 - 🐛(frontend) redirect homepage to login when homepage feat is disabled #2521
 - 🐛(backend) ignore CSPs for API docs in development
 - 🐛(frontend) export images embedded with a relative url #2573
-
-### Changed
-
-- ♿️(frontend) use semantic `<dl>` structure in document info card #2379
+- 🐛(y-provider) fix sentry init #2579
 
 ## [v5.4.1] - 2026-07-09
 

--- a/src/frontend/servers/y-provider/package.json
+++ b/src/frontend/servers/y-provider/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "cross-env COLLABORATION_LOGGING=true && nodemon --config nodemon.json",
-    "start": "node ./dist/start-server.js",
+    "start": "node --import ./dist/services/sentry.js ./dist/start-server.js",
     "lint": "eslint",
     "test": "vitest"
   },

--- a/src/frontend/servers/y-provider/src/servers/appServer.ts
+++ b/src/frontend/servers/y-provider/src/servers/appServer.ts
@@ -13,8 +13,6 @@ import { corsMiddleware, httpSecurity, wsSecurity } from '@/middlewares';
 import { routes } from '@/routes';
 import { logger } from '@/utils';
 
-import '../services/sentry';
-
 /**
  * init the collaboration server.
  *


### PR DESCRIPTION
## Purpose

Sentry should actually be initialized before the app is created. We now start sentry before starting the app server.

## Demo

Error created locally to check Sentry logs:
<img width="994" height="261" alt="image" src="https://github.com/user-attachments/assets/3841f907-f3a3-4366-a469-9becb1a154b8" />


