### PR TITLE
🐛(frontend) refresh pins after document deletion and restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(frontend) refresh pins after document deletion and restoration
 - 🐛(frontend) redirect homepage to login when homepage feat is disabled #2521
 - 🐛(backend) ignore CSPs for API docs in development
 - 🐛(frontend) export images embedded with a relative url #2573

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
@@ -146,6 +146,13 @@ test.describe('Document grid item options', () => {
 
     await expect(page.getByText(docTitle)).toBeVisible();
     const row = await getGridRow(page, docTitle);
+
+    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
+    await page.getByRole('menuitem', { name: 'Pin' }).click();
+
+    const leftPanelFavorites = page.getByTestId('left-panel-favorites');
+    await expect(leftPanelFavorites.getByText(docTitle)).toBeVisible();
+
     await row.getByRole('button', { name: /Open the menu of actions/ }).click();
 
     await page.getByRole('menuitem', { name: 'Delete' }).click();
@@ -164,7 +171,10 @@ test.describe('Document grid item options', () => {
       page.getByText('The document has been deleted.'),
     ).toBeVisible();
 
-    await expect(page.getByText(docTitle)).toBeHidden();
+    await expect(
+      page.getByLabel('Documents grid').getByText(docTitle),
+    ).toBeHidden();
+    await expect(leftPanelFavorites.getByText(docTitle)).toBeHidden();
   });
 
   test('it checks the leave feature', async ({ page, browserName }) => {

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-trashbin.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-trashbin.spec.ts
@@ -38,9 +38,14 @@ test.describe('Doc Trashbin', () => {
     await expect(row1.getByText(title1)).toBeHidden();
 
     const row2 = await getGridRow(page, title2);
+    await clickInGridMenu(page, row2, 'Pin');
+    const leftPanelFavorites = page.getByTestId('left-panel-favorites');
+    await expect(leftPanelFavorites.getByText(title2)).toBeVisible();
+
     await clickInGridMenu(page, row2, 'Delete');
     await page.getByRole('button', { name: 'Delete document' }).click();
     await expect(row2.getByText(title2)).toBeHidden();
+    await expect(leftPanelFavorites.getByText(title2)).toBeHidden();
 
     await page.getByRole('link', { name: 'Trashbin' }).click();
 
@@ -81,6 +86,7 @@ test.describe('Doc Trashbin', () => {
     await clickInGridMenu(page, row2, 'Restore');
 
     await expect(row2.getByText(title2)).toBeHidden();
+    await expect(leftPanelFavorites.getByText(title2)).toBeVisible();
     await page.getByRole('link', { name: 'All docs' }).click();
     const row2Restored = await getGridRow(page, title2);
     await expect(row2Restored.getByText(title2)).toBeVisible();
@@ -127,11 +133,19 @@ test.describe('Doc Trashbin', () => {
     await navigateToPageFromTree({ page, title: subDocName });
     await verifyDocName(page, subDocName);
 
+    await clickInEditorMenu(page, 'Pin');
+    await page.getByRole('button', { name: 'Back to homepage' }).click();
+    const leftPanelFavorites = page.getByTestId('left-panel-favorites');
+    await expect(leftPanelFavorites.getByText(subDocName)).toBeVisible();
+    await leftPanelFavorites.getByText(subDocName).click();
+    await verifyDocName(page, subDocName);
+
     await clickInEditorMenu(page, 'Delete');
     await page.getByRole('button', { name: 'Delete document' }).click();
     await verifyDocName(page, topParent);
 
     await page.getByRole('button', { name: 'Back to homepage' }).click();
+    await expect(leftPanelFavorites.getByText(subDocName)).toBeHidden();
     await page.getByRole('link', { name: 'Trashbin' }).click();
 
     let row;
@@ -179,5 +193,7 @@ test.describe('Doc Trashbin', () => {
     );
     await expect(page.getByRole('button', { name: 'Share' })).toBeEnabled();
     await expect(docTree.getByText(topParent)).toBeVisible();
+    await page.getByRole('button', { name: 'Back to homepage' }).click();
+    await expect(leftPanelFavorites.getByText(subDocName)).toBeVisible();
   });
 });

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertRestore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertRestore.tsx
@@ -12,6 +12,7 @@ import {
   Doc,
   KEY_DOC,
   KEY_LIST_DOC,
+  KEY_LIST_FAVORITE_DOC,
   useRestoreDoc,
 } from '@/docs/doc-management';
 import { KEY_LIST_DOC_TRASHBIN } from '@/docs/docs-grid';
@@ -22,7 +23,12 @@ export const AlertRestore = ({ doc }: { doc: Doc }) => {
   const treeContext = useTreeContext<Doc>();
   const { spacingsTokens } = useCunninghamTheme();
   const { mutate: restoreDoc, error } = useRestoreDoc({
-    listInvalidQueries: [KEY_LIST_DOC, KEY_LIST_DOC_TRASHBIN, KEY_DOC],
+    listInvalidQueries: [
+      KEY_LIST_DOC,
+      KEY_LIST_DOC_TRASHBIN,
+      KEY_DOC,
+      KEY_LIST_FAVORITE_DOC,
+    ],
     options: {
       onSuccess: (_data) => {
         // It will force the tree to be reloaded

--- a/src/frontend/apps/impress/src/features/docs/doc-management/components/ModalRemoveDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/components/ModalRemoveDoc.tsx
@@ -14,7 +14,7 @@ import { useConfig } from '@/core';
 import { KEY_LIST_DOC_TRASHBIN } from '@/docs/docs-grid';
 import { useKeyboardAction } from '@/hooks';
 
-import { KEY_DOC } from '../api';
+import { KEY_DOC, KEY_LIST_FAVORITE_DOC } from '../api';
 import { KEY_LIST_DOC } from '../api/useDocs';
 import { useRemoveDoc } from '../api/useRemoveDoc';
 import { useDocUtils } from '../hooks';
@@ -43,7 +43,12 @@ export const ModalRemoveDoc = ({
     isError,
     error,
   } = useRemoveDoc({
-    listInvalidQueries: [KEY_LIST_DOC, KEY_LIST_DOC_TRASHBIN, KEY_DOC],
+    listInvalidQueries: [
+      KEY_LIST_DOC,
+      KEY_LIST_DOC_TRASHBIN,
+      KEY_DOC,
+      KEY_LIST_FAVORITE_DOC,
+    ],
     options: {
       onSuccess: () => {
         if (onSuccess) {

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridTrashbinActions.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridTrashbinActions.tsx
@@ -9,6 +9,7 @@ import { DropdownMenu, DropdownMenuOption, Icon } from '@/components';
 import {
   Doc,
   KEY_LIST_DOC,
+  KEY_LIST_FAVORITE_DOC,
   useRestoreDoc,
   useTrans,
 } from '@/docs/doc-management';
@@ -26,7 +27,11 @@ export const DocsGridTrashbinActions = ({
   const { untitledDocument } = useTrans();
   const { toast } = useToastProvider();
   const { mutate: restoreDoc, error } = useRestoreDoc({
-    listInvalidQueries: [KEY_LIST_DOC, KEY_LIST_DOC_TRASHBIN],
+    listInvalidQueries: [
+      KEY_LIST_DOC,
+      KEY_LIST_DOC_TRASHBIN,
+      KEY_LIST_FAVORITE_DOC,
+    ],
     options: {
       onSuccess: (_data) => {
         toast(t('The document has been restored.'), VariantType.SUCCESS, {


### PR DESCRIPTION
Fixes #2567

Favorite relationships persist across soft deletion, but the sidebar keeps a stale cached favorites list until the page is reloaded. Invalidate the favorites query after deletion and restoration so deleted documents disappear immediately and retained pins reappear when documents are restored.

## Purpose

Deleting a pinned document removes it from the document grid but can leave it visible in the sidebar until the page is refreshed.

The favorite relationship also remains persisted after soft deletion, causing the pin to reappear if the document is restored.

## Proposal

- Refresh the favorites query after deletion so the pinned document disappears from the sidebar immediately.
- Keep the favorite relationship while the document is in the trashbin.
- Refresh the favorites query after restoration so the pin reappears without a page reload.
- Add Playwright coverage for deleting and restoring pinned documents from both the document grid and document page.

## Testing

Automated checks completed:

- [x] Prettier on the affected frontend and E2E files
- [x] ESLint on the affected frontend and E2E files
- [x] TypeScript type checking
- [x] Full Playwright suite
- [x] Full CI suite

Manual verification (see video below):

1. Pin a document and confirm it appears in the left sidebar.
2. Delete the document.
3. Confirm it disappears from both the grid and sidebar without refreshing.
4. Restore it from the trashbin.
5. Confirm the document is restored and its pin reappears in the sidebar.

## Screenshots or recording

No visual design changes.

https://github.com/user-attachments/assets/c6ef1567-66f7-44ed-a136-b1a82f948de2

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] I have added corresponding regression coverage.
- [x] All CI checks are passing.
- [x] The commit is signed and signed off.
- [x] A changelog entry was added or the `noChangeLog` label was applied.

## AI assistance

- [x] AI assistance was used for this contribution.
- [x] I have reviewed, understood, and can explain all submitted changes.