### PR TITLE
🔒️(backend) force SVG attachments to download to prevent stored XSS

### DIFF
--- a/src/backend/impress/settings.py
+++ b/src/backend/impress/settings.py
@@ -213,6 +213,8 @@ class Base(Configuration):
         "application/x-msi",
         "application/java-archive",
         "application/octet-stream",
+        # Vector Graphics (SVG can embed executable scripts/event handlers)
+        "image/svg+xml",
         # Dynamic Web Pages
         "application/x-httpd-php",
         "application/x-asp",


### PR DESCRIPTION
## Summary

Add `image/svg+xml` to `DOCUMENT_UNSAFE_MIME_TYPES` so uploaded SVG attachments are flagged `is_unsafe=true` and served with `Content-Disposition: attachment` (forced download), consistent with the existing handling of other active-content types (HTML, PHP, etc.) in that list.

## Context (updated after review)

The original description claimed a reproducible stored XSS. That was wrong - as @maboukerfa pointed out, all 3 reference deployment paths apply `Content-Security-Policy: default-src 'none'` to `/media/` at the proxy layer (dev nginx config, production nginx template, and the Helm chart's `ingressMedia` annotation), which blocks script execution in inline-served SVGs. The severity claim is withdrawn.

## Why the change may still be worth it (defense-in-depth)

- The protection lives entirely in the proxy layer. The Helm path applies it via `nginx.ingress.kubernetes.io/configuration-snippet`, and ingress-nginx ships with `allow-snippet-annotations: false` by default since v1.9, so on a cluster with default admission settings the annotation is not applied. Other ingress classes (Traefik, ALB, etc.) ignore it entirely.
- `DOCUMENT_UNSAFE_MIME_TYPES` already enforces the same policy for other active-content types at the application layer regardless of proxy config. This change makes SVG consistent with that policy, so the app stays safe even when a deployment's proxy layer differs from the reference configs.

## Behaviour change

SVG uploads are stored with the `-unsafe` suffix and download instead of rendering inline. Raster images (png, jpeg, gif, webp) are unaffected.