### PR TITLE
✨(frontend) reset side panel state between documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to
 ### Changed
 
 - ♿️(frontend) use anchor links for interlinking sub-documents #2391
+- ✨(frontend) reset side panel state between documents #2583
+- ♿️(frontend) announce search loading state for screen readers #2526
+
 
 ## [v5.5.0] - 2026-08-24
 
@@ -44,7 +47,6 @@ and this project adheres to
 ### Changed
 
 - ♻️(backend) reset collaboration connection in cascade for all children #2507
-- ♿️(frontend) announce search loading state for screen readers #2526
 
 ### Fixed
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-comments.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-comments.spec.ts
@@ -13,6 +13,7 @@ import {
   updateShareLink,
 } from './utils-share';
 import { logOut } from './utils-signin';
+import { createRootSubPage } from './utils-sub-pages';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
@@ -518,6 +519,27 @@ test.describe('Doc Comments Side Panel', () => {
       .getByRole('button', { name: 'Filter comments' })
       .click();
     await page.getByRole('menuitem', { name: 'Resolved' }).click();
+    await expect(
+      elCommentsSidePanel.getByText('This is a comment'),
+    ).toBeVisible();
+
+    // Closing the panel resets the filter to open comments
+    await page
+      .getByRole('button', { name: 'Close the comments sidebar' })
+      .click();
+    await expect(elCommentsSidePanel).toBeHidden();
+    await page
+      .getByRole('button', { name: 'Show the comments sidebar' })
+      .click();
+    await expect(
+      elCommentsSidePanel.getByText('This is a comment'),
+    ).toBeHidden();
+
+    // Select resolved comments again to continue working with the thread
+    await elCommentsSidePanel
+      .getByRole('button', { name: 'Filter comments' })
+      .click();
+    await page.getByRole('menuitem', { name: 'Resolved' }).click();
     await elCommentsSidePanel.getByText('This is a comment').click();
     await expect(editor.getByText('Hello World')).toHaveClass(
       'bn-thread-mark-selected',
@@ -583,5 +605,35 @@ test.describe('Doc Comments Side Panel', () => {
     await expect(
       page.getByRole('button', { name: 'Show the comments sidebar' }),
     ).toBeFocused();
+  });
+
+  test('it closes the comments side panel when switching documents', async ({
+    page,
+    browserName,
+  }) => {
+    await createDoc(page, 'comment-doc-panel-switch', browserName, 1);
+
+    const editor = await writeInEditor({ page, text: 'Hello World' });
+    await editor.getByText('Hello').selectText();
+    await page.getByRole('button', { name: 'Add comment' }).click();
+
+    const thread = page.locator('.bn-thread');
+    await thread.getByRole('paragraph').first().fill('This is a comment');
+    await thread.locator('[data-test="save"]').click();
+
+    await page
+      .getByRole('button', { name: 'Show the comments sidebar' })
+      .click();
+    const elCommentsSidePanel = page.getByLabel('Comments side panel');
+    await expect(elCommentsSidePanel).toBeVisible();
+
+    const { name: childDocName } = await createRootSubPage(
+      page,
+      browserName,
+      'comment-doc-panel-switch-child',
+    );
+
+    await verifyDocName(page, childDocName);
+    await expect(elCommentsSidePanel).toBeHidden();
   });
 });

--- a/src/frontend/apps/impress/src/features/docs/doc-comments/components/CommentSideBar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-comments/components/CommentSideBar.tsx
@@ -23,10 +23,17 @@ interface CommentSideBarProps {
 
 export const CommentSideBar = ({ onClose }: CommentSideBarProps) => {
   const { t } = useTranslation();
-  const { setThreadsSidebarTarget, filter, setFilter } =
+  const { setThreadsSidebarTarget, filter, setFilter, resetFilter } =
     useCommentSidebarStore();
   const portalRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
+
+  /** Reset the filter when the comment sidebar is closed */
+  useEffect(() => {
+    return () => {
+      resetFilter();
+    };
+  }, [resetFilter]);
 
   useEffect(() => {
     if (portalRef.current) {

--- a/src/frontend/apps/impress/src/features/docs/doc-comments/stores/useCommentSidebarStore.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-comments/stores/useCommentSidebarStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 interface CommentSidebarStore {
   filter: 'open' | 'resolved';
+  resetFilter: () => void;
   setFilter: (filter: 'open' | 'resolved') => void;
   setThreadsSidebarTarget: (el: HTMLElement | null) => void;
   threadsSidebarTarget: HTMLElement | null;
@@ -9,6 +10,7 @@ interface CommentSidebarStore {
 
 export const useCommentSidebarStore = create<CommentSidebarStore>((set) => ({
   filter: 'open',
+  resetFilter: () => set({ filter: 'open' }),
   setFilter: (filter) => set(() => ({ filter })),
   setThreadsSidebarTarget: (threadsSidebarTarget) => {
     set(() => ({ threadsSidebarTarget }));

--- a/src/frontend/apps/impress/src/features/right-panel/components/RightPanel.tsx
+++ b/src/frontend/apps/impress/src/features/right-panel/components/RightPanel.tsx
@@ -23,6 +23,13 @@ export const RightPanel = () => {
     isReady && provider && provider?.configuration.name === doc?.id;
   const { restoreFocus } = useFocusStore();
 
+  /** Side panel must be explicitly opened for each document. */
+  useEffect(() => {
+    return () => {
+      setIsPanelOpen(false);
+    };
+  }, [doc?.id, setIsPanelOpen]);
+
   /**
    * Keep rendering the last active panel during the close animation,
    * so the content doesn't vanish before the panel finishes sliding out.


### PR DESCRIPTION
Fixes #2439

Reset the comment filter to open whenever the side panel closes, and close the active panel when navigating to another document. This prevents panel state from leaking across sessions and documents.

## Purpose

The comment filter currently remains set to **Resolved** after the side panel is closed. The side panel can also remain open when navigating to another document, carrying state from the previous document into the new context.

Resetting the filter to **Open** when the panel closes and requiring users to reopen the panel after switching documents provides consistent and predictable behavior.

## Proposal

* [x] Reset the comment filter to **Open** whenever the side panel closes
* [x] Close the active side panel when navigating to another document
* [x] Add E2E coverage for closing, reopening, and switching documents
* [x] Add an entry under `## [Unreleased]` in the changelog

Local validation passed for Prettier, ESLint, frontend TypeScript, E2E TypeScript, and Playwright test discovery. The Vitest suite reported 299 passing tests and 4 unrelated local failures involving `localStorage` availability and trash-bin date assertions. The full E2E suite was not run.

## Screenshots or recording

No visual design changes.

https://github.com/user-attachments/assets/e6c0690b-b60b-440f-a4ea-c850795ebd94

## External contributions

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added corresponding tests for new features or bug fixes (if applicable)

### CI requirements

* [ ] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer