### PR TITLE
🐛(frontend) fix clipped formatting toolbar in new comment composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 - ✨(frontend) reset side panel state between documents #2583
 - ♿️(frontend) announce search loading state for screen readers #2526
 
+### Fixed
+
+- 🐛(frontend) fix clipped formatting toolbar in new comment composer #2585
 
 ## [v5.5.0] - 2026-08-24
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-comments.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-comments.spec.ts
@@ -206,7 +206,20 @@ test.describe('Doc Comments', () => {
     await editor.getByText('Hello').selectText();
     await page.getByRole('button', { name: 'Add comment' }).click();
 
-    await thread.getByRole('paragraph').first().fill('This is a new comment');
+    // The composer of a new thread must not clip its formatting toolbar
+    await expect(thread).toHaveCSS('overflow', 'visible');
+
+    // Write the new comment and select it to reveal the formatting toolbar
+    const newComment = thread.getByRole('paragraph').first();
+    await newComment.fill('This is a new comment');
+    await newComment.selectText();
+
+    const boldButton = thread.locator(
+      '.bn-formatting-toolbar button[data-test="bold"]',
+    );
+    await expect(boldButton).toBeVisible();
+    await boldButton.click();
+
     await thread.locator('[data-test="save"]').click();
     await expect(editor.getByText('Hello')).toHaveClass('bn-thread-mark');
 
@@ -217,6 +230,13 @@ test.describe('Doc Comments', () => {
 
     await editor.first().click();
     await editor.getByText('Hello').click();
+
+    // The saved comment keeps the formatting applied in the composer
+    await expect(
+      thread
+        .locator('.bn-editor[contenteditable="false"] strong')
+        .getByText('This is a new comment'),
+    ).toBeVisible();
 
     await thread.getByText('This is a new comment').first().hover();
     await thread.locator('[data-test="moreactions"]').first().click();

--- a/src/frontend/apps/impress/src/features/docs/doc-comments/styles.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-comments/styles.tsx
@@ -255,6 +255,10 @@ export const DocsCommentsStyle = createGlobalStyle<{
         }
       }
 
+      &:has(> .bn-comment-editor + .bn-comment-actions-wrapper) {
+        overflow: visible;
+      }
+
       // Actions button send comment
       .bn-thread-composer .bn-comment-actions-wrapper,
       &:not(.selected) .bn-comment-actions-wrapper {


### PR DESCRIPTION


## Purpose

When you highlighted text in a document and started writing a new comment, the little pop-up menu for styling your text doesn't show up. 

## Proposal

It lets that formatting menu show in full above the new-comment box, so you can bold, italicize, or link text while writing a comment, exactly the way you already could when editing one.

<img width="588" height="329" alt="Screenshot 2026-08-13 at 15 51 54" src="https://github.com/user-attachments/assets/c80fb214-4c16-4128-b931-2144108422b7" />
