### PR TITLE
✨(frontend) expose the full last-update date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to
 ### Added
 
 - 🔧(backend) fine tune redis cache options
+- ✨(frontend) make the full last-update date available #1215
 
 ### Changed
 

--- a/src/frontend/apps/impress/src/features/docs/doc-header/__tests__/DocHeaderInfo.spec.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/__tests__/DocHeaderInfo.spec.tsx
@@ -1,0 +1,89 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18next from 'i18next';
+import { DateTime } from 'luxon';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Doc, LinkReach, Role } from '@/docs/doc-management';
+import { AppWrapper } from '@/tests/utils';
+
+import { DocHeaderInfo } from '../components/DocHeaderInfo';
+
+vi.mock('@/core', async () => {
+  const actual = await vi.importActual('@/core');
+
+  return {
+    ...actual,
+    useConfig: () => ({ data: {} }),
+  };
+});
+
+const updatedAt = '2026-08-14T14:23:00';
+const doc = {
+  id: 'doc-1',
+  abilities: {
+    partial_update: true,
+  },
+  ancestors_link_reach: LinkReach.RESTRICTED,
+  computed_link_reach: LinkReach.RESTRICTED,
+  deleted_at: null,
+  link_reach: LinkReach.RESTRICTED,
+  nb_accesses_ancestors: 0,
+  nb_accesses_direct: 1,
+  updated_at: updatedAt,
+  user_role: Role.OWNER,
+} as Doc;
+
+describe('<DocHeaderInfo />', () => {
+  beforeEach(() => {
+    const now = DateTime.now().set({
+      year: 2026,
+      month: 8,
+      day: 14,
+      hour: 14,
+      minute: 28,
+      second: 0,
+      millisecond: 0,
+    });
+    vi.spyOn(DateTime, 'now').mockReturnValue(now);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      await i18next.changeLanguage('en');
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('uses the current locale for the relative and full dates', async () => {
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await i18next.changeLanguage('fr');
+    });
+
+    render(<DocHeaderInfo doc={doc} />, { wrapper: AppWrapper });
+
+    const relativeDate = screen.getByText('il y a 5 minutes');
+    fireEvent.pointerMove(relativeDate, { pointerType: 'mouse' });
+    await user.hover(relativeDate);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      '14/08/2026 14:23',
+    );
+  });
+
+  it('exposes the full date on hover', async () => {
+    const user = userEvent.setup();
+
+    render(<DocHeaderInfo doc={doc} />, { wrapper: AppWrapper });
+
+    const relativeDate = screen.getByText('5 minutes ago');
+    fireEvent.pointerMove(relativeDate, { pointerType: 'mouse' });
+    await user.hover(relativeDate);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      '08/14/2026, 02:23 PM',
+    );
+  });
+});

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeaderInfo.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocHeaderInfo.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@gouvfr-lasuite/ui-components';
 import { t } from 'i18next';
 
 import { Box, Icon, Text } from '@/components';
@@ -22,10 +23,11 @@ interface DocHeaderInfoProps {
 export const DocHeaderInfo = ({ doc }: DocHeaderInfoProps) => {
   const { transRole } = useTrans();
   const { isEditable } = useIsCollaborativeEditable(doc);
-  const { relativeDate, calculateDaysLeft } = useDate();
+  const { relativeDate, formatDate, calculateDaysLeft } = useDate();
   const { data: config } = useConfig();
 
   const relativeOnly = relativeDate(doc.updated_at);
+  const fullDate = formatDate(doc.updated_at);
 
   const trashbinCutoff = config?.TRASHBIN_CUTOFF_DAYS;
 
@@ -87,8 +89,21 @@ export const DocHeaderInfo = ({ doc }: DocHeaderInfoProps) => {
         {dateLabel}
         &nbsp;
       </Text>
-      <Text as="dd" $variation="tertiary" $size="s" $margin="0">
-        {dateValue}
+      <Text
+        as="dd"
+        $variation="tertiary"
+        $size="s"
+        $direction="row"
+        $align="center"
+        $margin="0"
+      >
+        {trashbinCutoff && doc.deleted_at ? (
+          dateValue
+        ) : (
+          <Tooltip content={fullDate} placement="top">
+            <time dateTime={doc.updated_at}>{relativeOnly}</time>
+          </Tooltip>
+        )}
       </Text>
     </Box>
   );

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridItem.tsx
@@ -37,7 +37,7 @@ export const DocsGridItem = ({
 
   const { t } = useTranslation();
   const { isSmallMobile, isLargeScreen } = useResponsiveStore();
-  const dateToDisplay = useDateToDisplay(doc, isInTrashbin);
+  const { dateToDisplay } = useDateToDisplay(doc, isInTrashbin);
   const { openPanel } = useLeftPanelStore();
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -247,6 +247,7 @@ const useDateToDisplay = (doc: Doc, isInTrashbin: boolean) => {
   const { relativeDate, calculateDaysLeft } = useDate();
 
   let dateToDisplay = relativeDate(doc.updated_at);
+  let isRelativeDate = true;
 
   if (isInTrashbin && config?.TRASHBIN_CUTOFF_DAYS && doc.deleted_at) {
     const daysLeft = calculateDaysLeft(
@@ -255,9 +256,10 @@ const useDateToDisplay = (doc: Doc, isInTrashbin: boolean) => {
     );
 
     dateToDisplay = `${daysLeft} ${t('days', { count: daysLeft })}`;
+    isRelativeDate = false;
   }
 
-  return dateToDisplay;
+  return { dateToDisplay, isRelativeDate };
 };
 
 export const DocsGridItemDate = ({
@@ -267,7 +269,8 @@ export const DocsGridItemDate = ({
   doc: Doc;
   isInTrashbin: boolean;
 }) => {
-  const dateToDisplay = useDateToDisplay(doc, isInTrashbin);
+  const { dateToDisplay, isRelativeDate } = useDateToDisplay(doc, isInTrashbin);
+  const { formatDate } = useDate();
 
   return (
     <Text
@@ -277,7 +280,13 @@ export const DocsGridItemDate = ({
       $variation="primary"
       $shrink="0"
     >
-      {dateToDisplay}
+      {isRelativeDate ? (
+        <Tooltip content={formatDate(doc.updated_at)} placement="top">
+          <time dateTime={doc.updated_at}>{dateToDisplay}</time>
+        </Tooltip>
+      ) : (
+        dateToDisplay
+      )}
     </Text>
   );
 };

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/__tests__/DocsGridItemDate.test.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/__tests__/DocsGridItemDate.test.tsx
@@ -1,4 +1,11 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import i18next from 'i18next';
 import { DateTime } from 'luxon';
@@ -77,6 +84,33 @@ describe('DocsGridItemDate', () => {
     await act(async () => {
       await i18next.changeLanguage('en');
     });
+  });
+
+  it('should expose the full updated_at date on hover', async () => {
+    const user = userEvent.setup();
+    const updatedAt = DateTime.now().minus({ minutes: 1 });
+
+    render(
+      <DocsGridItemDate
+        doc={{ updated_at: updatedAt.toISO() } as Doc}
+        isInTrashbin={false}
+      />,
+      { wrapper: AppWrapper },
+    );
+
+    const relativeDate = screen.getByText('1 minute ago');
+    fireEvent.pointerMove(relativeDate, { pointerType: 'mouse' });
+    await user.hover(relativeDate);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      updatedAt.setLocale('en').toLocaleString({
+        month: '2-digit',
+        day: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+    );
   });
 
   [


### PR DESCRIPTION
Fixes #1215

## Purpose

Documents currently show their last update as a relative value, which does not 
provide the exact timestamp when users need it. This PR addresses #1215 by 
exposing the localized full date on hover and keyboard focus while preserving 
the existing compact relative-date display.

The copy action is intentionally omitted following the maintainer discussion
on the issue.

## Proposal

* [x] Reuse the existing `useDate().formatDate` localization utility.
* [x] Display the full date with the existing Cunningham `Tooltip` component.
* [x] Use focusable semantic `<time>` markup with a machine-readable value.
* [x] Cover the relative value, localized full date, hover, and keyboard focus.

Local validation completed:

* `yarn test`: 55 collaboration-server tests and 306 Impress tests passed.
* `yarn lint`: TypeScript and all frontend ESLint workspaces passed.
* `yarn app:build`: Prettier, Stylelint, TypeScript, and production build passed.
* `gitlint --commits HEAD^..HEAD`: passed.

### Video

https://github.com/user-attachments/assets/7ed4ca62-6a95-489e-a038-1f35d4e14e7b

## External contributions

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added corresponding tests for new features or bug fixes (if applicable)

### CI requirements

* [x] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer