### PR TITLE
🐛(backend) fix scoped full-text search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) fix full-text search scoped to a document
 - 🐛(frontend) refresh pins after document deletion and restoration
 - 🐛(frontend) redirect homepage to login when homepage feat is disabled #2521
 - 🐛(backend) ignore CSPs for API docs in development

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1550,8 +1550,8 @@ class DocumentViewSet(
         document_id = params.validated_data.get("document")
         if document_id:
             try:
-                path = models.Document.objects.get(pk=document_id).values_list(
-                    "path", flat=True
+                path = models.Document.objects.values_list("path", flat=True).get(
+                    pk=document_id
                 )
             except models.Document.DoesNotExist as exc:
                 raise drf.exceptions.NotFound("Document not found.") from exc

--- a/src/backend/core/tests/documents/test_api_documents_search.py
+++ b/src/backend/core/tests/documents/test_api_documents_search.py
@@ -612,3 +612,20 @@ def test_api_documents_search_success(indexer_settings):
     assert results == [
         {"id": document["id"], "title": document["title"], "path": document["path"]}
     ]
+
+
+@mock.patch("core.services.search_indexers.FindDocumentIndexer.search_query")
+def test_api_documents_search_success_scoped(search_query, indexer_settings):
+    """A document-scoped indexer search should use the document path."""
+    indexer_settings.SEARCH_URL = "http://find/api/v1.0/search"
+    search_query.return_value = []
+    document = factories.DocumentFactory()
+
+    response = APIClient().get(
+        "/api/v1.0/documents/search/",
+        data={"q": "alpha", "document": document.id},
+    )
+
+    assert response.status_code == 200
+    assert search_query.call_count == 1
+    assert search_query.call_args.kwargs["data"]["path"] == document.path


### PR DESCRIPTION
Fixes #2589

## Purpose

Scoped full-text searches fail before reaching the search indexer, preventing
users from searching within a document and its subdocuments.

## Proposal

* [x] Resolve the scoped document path before querying the search indexer
* [x] Add regression coverage for document-scoped full-text search

The full backend suite passes with 2,214 tests passed and 1 skipped. Ruff,
Pylint, and gitlint also pass.

## External contributions

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added corresponding tests for new features or bug fixes

### CI requirements

* [x] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

* [x] I used AI assistance to produce part or all of this contribution
* [x] I have read, reviewed, understood and can explain the code I am submitting
* [x] I can jump in a call or a chat to explain my work to a maintainer