### PR TITLE
🐛(backend) fix duplicating a document that has no content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(frontend) fix clipped formatting toolbar in new comment composer #2585
+- 🐛(backend) fix duplicating a document that has no content
 - 📄(frontend) allowed partially export when MIT #2551
 
 ## [v5.5.0] - 2026-08-24

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1371,7 +1371,7 @@ class DocumentViewSet(
         user_role = document_to_duplicate.get_role(user)
         is_owner_or_admin = user_role in models.PRIVILEGED_ROLES
 
-        base64_yjs_content = document_to_duplicate.content
+        base64_yjs_content = document_to_duplicate.content or ""
 
         # Duplicate the document instance
         link_kwargs = (

--- a/src/backend/core/tests/documents/test_api_documents_duplicate.py
+++ b/src/backend/core/tests/documents/test_api_documents_duplicate.py
@@ -862,3 +862,35 @@ def test_api_documents_duplicate_with_descendants_complex_tree():
     dup_grandchildren2 = dup_child2.get_children()
     assert dup_grandchildren2.count() == 1
     assert dup_grandchildren2.first().title == "Copy of GrandChild 3"
+
+
+def test_api_documents_duplicate_document_without_content():
+    """
+    A document that was never edited has no content in object storage. Duplicating it
+    should succeed and produce an empty duplicate.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    # Create through the API so nothing is ever written to object storage
+    with mock.patch("core.api.viewsets.posthog_capture"):
+        response = client.post(
+            "/api/v1.0/documents/", {"title": "never edited"}, format="json"
+        )
+
+    assert response.status_code == 201
+    document = models.Document.objects.get(id=response.json()["id"])
+    assert document.content is None
+
+    with mock.patch("core.api.viewsets.posthog_capture"):
+        response = client.post(f"/api/v1.0/documents/{document.id!s}/duplicate/")
+
+    assert response.status_code == 201
+
+    duplicated_document = models.Document.objects.get(id=response.json()["id"])
+    assert duplicated_document.title == "Copy of never edited"
+    assert duplicated_document.content is None
+    assert duplicated_document.creator == user
+    assert duplicated_document.duplicated_from == document
+    assert duplicated_document.attachments == []


### PR DESCRIPTION
## Purpose

Document.content reads from object storage and returns None when nothing was ever written there. That None, raised "content should be a string.", so the duplicate endpoint answered a 500. 

```Bash
1. Create a document (no content is ever written to object storage)

curl -s -X POST "$DOCS_HOST/api/v1.0/documents/" \
  -b "docs_sessionid=$SESSION_ID; csrftoken=$CSRF_TOKEN" \
  -H "x-csrftoken: $CSRF_TOKEN" \
  -H "referer: $DOCS_HOST/" \
  -H 'content-type: application/json' \
  --data-raw '{"title":"never edited"}'

2. Duplicate it → 500 before the fix, 201 after

curl -s -X POST "$DOCS_HOST/api/v1.0/documents/$DOC_ID/duplicate/" \
  -b "docs_sessionid=$SESSION_ID; csrftoken=$CSRF_TOKEN" \
  -H "x-csrftoken: $CSRF_TOKEN" \
  -H "referer: $DOCS_HOST/docs/$DOC_ID/" \
  -H 'content-type: application/json' \
  --data-raw '{"with_accesses":false,"with_descendants":false}'
```
- Response
```json
{
  "error": true,
  "code": 500,
  "message": "Internal Server Error",
  "description": "The server met an unexpected condition"
}
```