### PR TITLE
♻️(frontend) unified menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - ♿️(frontend) announce search loading state for screen readers #2526
 - ♻️(frontend) change favorite to star #2539
 - 🚚(frontend) add doc move to doc options #2555
+- ♻️(frontend) unified menu #2620
 - ♿(frontend) hide decorative emojis in document titles from SR #2527
 
 ### Fixed

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-ai.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-ai.spec.ts
@@ -273,18 +273,9 @@ if (process.env.IS_INSTANCE !== 'true') {
           title: '',
         });
 
-        const [randomDoc] = await createDoc(
-          page,
-          'doc-editor-ai',
-          browserName,
-          1,
-        );
+        await createDoc(page, 'doc-editor-ai', browserName, 1);
 
-        await verifyDocName(page, randomDoc);
-
-        await page.locator('.bn-block-outer').last().fill('Hello World');
-
-        const editor = page.locator('.ProseMirror');
+        const editor = await writeInEditor({ page, text: 'Hello World' });
         await editor.getByText('Hello').selectText();
 
         if (!ai_transform && !ai_translate) {

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-export.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-export.spec.ts
@@ -269,7 +269,9 @@ test.describe('Doc Export', () => {
     });
 
     await page
-      .getByRole('button', { name: 'Ouvrir les options du document' })
+      .getByRole('button', {
+        name: `Ouvrir les options du document: ${randomDocFrench}`,
+      })
       .click();
     await page.getByRole('menuitem', { name: 'Télécharger' }).click();
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-grid-move.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-grid-move.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import {
+  clickInDocOptionMenu,
   createDoc,
   getGridRow,
   getOtherBrowserName,
@@ -205,9 +206,7 @@ test.describe('Doc grid move', () => {
     await expect(docsGrid.getByText(titleDoc2)).toBeVisible();
 
     const row = await getGridRow(page, titleDoc1);
-    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
-
-    await page.getByRole('menuitem', { name: 'Move into a doc' }).click();
+    await clickInDocOptionMenu(page, row, 'Move into a doc');
 
     await expect(
       page
@@ -295,9 +294,7 @@ test.describe('Doc grid move', () => {
     await expect(docsGrid.getByText(titleDoc2)).toBeVisible();
 
     const row = await getGridRow(page, titleDoc1);
-    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
-
-    await page.getByRole('menuitem', { name: 'Move into a doc' }).click();
+    await clickInDocOptionMenu(page, row, 'Move into a doc');
 
     await expect(
       page
@@ -366,9 +363,7 @@ test.describe('Doc grid move', () => {
 
     // The first user should now be able to move the doc
     await page.reload();
-    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
-
-    await page.getByRole('menuitem', { name: 'Move into a doc' }).click();
+    await clickInDocOptionMenu(page, row, 'Move into a doc');
 
     await expect(
       page

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-grid.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import {
+  clickInDocOptionMenu,
   clickInEditorShareButton,
   createDoc,
   getGridRow,
@@ -103,9 +104,7 @@ test.describe('Document grid item options', () => {
 
     await expect(page.getByText(docTitle)).toBeVisible();
     const row = await getGridRow(page, docTitle);
-    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
-
-    await page.getByRole('menuitem', { name: 'Share' }).click();
+    await clickInDocOptionMenu(page, row, 'Share');
 
     await expect(
       page.getByRole('dialog').getByText('Share the document'),
@@ -121,8 +120,7 @@ test.describe('Document grid item options', () => {
     const row = await getGridRow(page, docTitle);
 
     // Star
-    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
-    await page.getByRole('menuitem', { name: 'Star' }).click();
+    await clickInDocOptionMenu(page, row, 'Star');
 
     // Check is starred
     await expect(row.getByText(/This document is starred/)).toBeVisible();
@@ -133,8 +131,7 @@ test.describe('Document grid item options', () => {
     await expect(page.getByText(docTitle2)).toBeHidden();
 
     // Unstar
-    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
-    await page.getByText('Unstar').click();
+    await clickInDocOptionMenu(page, row, 'Unstar');
     await expect(row).toBeHidden();
 
     // Check is unstarred
@@ -153,8 +150,7 @@ test.describe('Document grid item options', () => {
     await expect(page.getByText(docTitle)).toBeVisible();
     const row = await getGridRow(page, docTitle);
 
-    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
-    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    await clickInDocOptionMenu(page, row, 'Delete');
 
     await expect(
       page.getByRole('heading', { name: 'Delete a doc' }),
@@ -186,9 +182,7 @@ test.describe('Document grid item options', () => {
     ).toBeVisible();
 
     const row = await getGridRow(page, docTitle);
-    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
-
-    await page.getByRole('menuitem', { name: 'Leave' }).click();
+    await clickInDocOptionMenu(page, row, 'Leave');
 
     const modal = page.getByRole('dialog', {
       name: 'Confirmation to leave the document',

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-header.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 
 import {
+  clickInDocOptionMenu,
   clickInEditorMenu,
-  clickInEditorShareButton,
   createDoc,
   getGridRow,
   goToGridDoc,
@@ -527,30 +527,23 @@ test.describe('Doc Header', () => {
     await createDoc(page, `Star doc`, browserName);
 
     // Star
-    await page
-      .getByRole('button', { name: 'Open the document options' })
-      .click();
-    await page.getByRole('menuitem', { name: 'Star' }).click();
+    await clickInEditorMenu(page, 'Star');
     await expect(page.getByText('This document is starred')).toBeVisible();
 
     // UnStar
-    await page
-      .getByRole('button', { name: 'Open the document options' })
-      .click();
-    await page.getByRole('menuitem', { name: 'Unstar' }).click();
+    await clickInEditorMenu(page, 'Unstar');
     await expect(page.getByText('This document is starred')).toBeHidden();
   });
 
   test('it duplicates a document', async ({ page, browserName }) => {
     const [docTitle] = await createDoc(page, `Duplicate doc`, browserName);
 
-    const editor = page.locator('.ProseMirror');
-    await editor.click();
-    await editor.fill('Hello Duplicated World');
+    await writeInEditor({
+      page,
+      text: 'Hello Duplicated World',
+    });
 
-    await page.getByLabel('Open the document options').click();
-
-    await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+    await clickInEditorMenu(page, 'Duplicate');
     await expect(
       page.getByText('Document duplicated successfully!'),
     ).toBeVisible();
@@ -564,10 +557,9 @@ test.describe('Doc Header', () => {
 
     await expect(row.getByText(duplicateTitle)).toBeVisible();
 
-    await row.getByRole('button', { name: /Open the menu of actions/ }).click();
-    await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+    await clickInDocOptionMenu(page, row, 'Duplicate');
     const duplicateDuplicateTitle = 'Copy of ' + duplicateTitle;
-    await page.getByText(duplicateDuplicateTitle).click();
+    await verifyDocName(page, duplicateDuplicateTitle);
     await expect(page.getByText('Hello Duplicated World')).toBeVisible();
   });
 
@@ -586,6 +578,7 @@ test.describe('Doc Header', () => {
 
     const duplicateTitle = 'Copy of ' + childTitle;
     const docTree = page.getByTestId('doc-tree');
+    const currentUrl = page.url();
 
     const child = docTree
       .getByRole('treeitem')
@@ -593,12 +586,9 @@ test.describe('Doc Header', () => {
       .filter({
         hasText: childTitle,
       });
+
     await child.hover();
-    await child.getByRole('button', { name: /More options/ }).click();
-
-    const currentUrl = page.url();
-
-    await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+    await clickInDocOptionMenu(page, child, 'Duplicate');
 
     await expect(page).not.toHaveURL(new RegExp(currentUrl));
 
@@ -607,75 +597,5 @@ test.describe('Doc Header', () => {
     await expect(
       page.getByTestId('doc-tree').getByText(duplicateTitle),
     ).toBeVisible();
-  });
-});
-
-test.describe('Documents Header mobile', () => {
-  test.use({ viewport: { width: 500, height: 1200 } });
-
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/');
-  });
-
-  test('it checks the copy link button is displayed', async ({ page }) => {
-    await mockedDocument(page, {
-      abilities: {
-        destroy: false,
-        link_configuration: true,
-        versions_destroy: true,
-        versions_list: true,
-        versions_retrieve: true,
-        accesses_manage: false,
-        accesses_view: false,
-        update: true,
-        partial_update: true,
-        retrieve: true,
-      },
-    });
-
-    await goToGridDoc(page);
-
-    await page.getByLabel('Open the document options').click();
-    await expect(
-      page.getByRole('menuitem', { name: 'Copy link' }),
-    ).toBeVisible();
-    await page.keyboard.press('Escape');
-    await page.getByRole('button', { name: 'Share' }).click();
-    const shareModal = page.getByRole('dialog', {
-      name: 'Share the document',
-    });
-    await expect(
-      shareModal.getByRole('button', { name: 'Copy link' }),
-    ).toBeVisible();
-  });
-
-  test('it checks the close button on Share modal', async ({ page }) => {
-    await mockedDocument(page, {
-      abilities: {
-        destroy: true, // Means owner
-        link_configuration: true,
-        versions_destroy: true,
-        versions_list: true,
-        versions_retrieve: true,
-        accesses_manage: true,
-        accesses_view: true,
-        update: true,
-        partial_update: true,
-        retrieve: true,
-      },
-    });
-
-    await goToGridDoc(page);
-
-    await clickInEditorShareButton(page);
-
-    const shareModal = page.getByRole('dialog', {
-      name: 'Share the document',
-    });
-    await expect(shareModal).toBeVisible();
-    await page.getByRole('button', { name: 'close' }).click();
-    await expect(
-      page.getByRole('dialog', { name: 'Share the document' }),
-    ).toBeHidden();
   });
 });

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-member-list.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-member-list.spec.ts
@@ -188,6 +188,8 @@ test.describe('Document list members', () => {
     await list.click();
     await expect(currentUserRole).toBeVisible();
 
+    await page.waitForTimeout(300);
+
     await newUserRoles.click();
     await expect(
       page.getByRole('menuitemradio', { name: 'Owner' }),

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-trashbin.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-trashbin.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 
 import {
+  clickInDocOptionMenu,
   clickInEditorMenu,
-  clickInGridMenu,
   createDoc,
   getGridRow,
   verifyDocName,
@@ -34,18 +34,18 @@ test.describe('Doc Trashbin', () => {
 
     // Delete the first document - Is not displayed
     const row1 = await getGridRow(page, title1);
-    await clickInGridMenu(page, row1, 'Delete');
+    await clickInDocOptionMenu(page, row1, 'Delete');
     await page.getByRole('button', { name: 'Delete document' }).click();
     await expect(row1.getByText(title1)).toBeHidden();
 
     // Star the second document - Is displayed in the starred list
     const row2 = await getGridRow(page, title2);
-    await clickInGridMenu(page, row2, 'Star');
+    await clickInDocOptionMenu(page, row2, 'Star');
     await page.getByRole('link', { name: 'Starred', exact: true }).click();
     await expect(row2.getByText(title2)).toBeVisible();
 
     // Delete the second document - It is not displayed in the starred list anymore
-    await clickInGridMenu(page, row2, 'Delete');
+    await clickInDocOptionMenu(page, row2, 'Delete');
     await page.getByRole('button', { name: 'Delete document' }).click();
     await expect(row2.getByText(title2)).toBeHidden();
 
@@ -86,7 +86,7 @@ test.describe('Doc Trashbin', () => {
       }),
     ).toBeDisabled();
 
-    await clickInGridMenu(page, row2, 'Restore');
+    await clickInDocOptionMenu(page, row2, 'Restore');
 
     await expect(row2.getByText(title2)).toBeHidden();
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-tree.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-tree.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import {
+  clickInDocOptionMenu,
   createDoc,
   getOtherBrowserName,
   updateDocTitle,
@@ -247,9 +248,7 @@ test.describe('Doc Tree', () => {
         hasText: docChild,
       });
     await child.hover();
-    const menu = child.getByRole('button', { name: /More options/ });
-    await menu.click();
-    await page.getByText('Move to my docs').click();
+    await clickInDocOptionMenu(page, child, 'Move to my docs');
 
     await verifyDocName(page, docParent);
 
@@ -258,24 +257,17 @@ test.describe('Doc Tree', () => {
   });
 
   test('Only owner can detaches a document', async ({ page, browserName }) => {
-    await createDoc(page, 'doc-tree-detach', browserName, 1);
+    const [docParent] = await createDoc(
+      page,
+      'doc-tree-detach',
+      browserName,
+      1,
+    );
 
     await page.getByRole('button', { name: 'Share' }).click();
 
     const otherBrowserName = getOtherBrowserName(browserName);
     await addNewMember(page, 0, 'Owner', otherBrowserName);
-
-    const list = page.getByTestId('doc-share-quick-search');
-    const currentEmail =
-      process.env[`SIGN_IN_USERNAME_${browserName.toUpperCase()}`] || '';
-    const currentUser = list.getByTestId(
-      `doc-share-member-row-${currentEmail}`,
-    );
-    const currentUserRole = currentUser.getByTestId('doc-role-dropdown');
-    await currentUserRole.click();
-    await page.getByRole('menuitemradio', { name: 'Administrator' }).click();
-    await list.click();
-
     await page.getByRole('button', { name: 'Ok' }).click();
 
     const { name: docChild } = await createRootSubPage(
@@ -283,12 +275,6 @@ test.describe('Doc Tree', () => {
       browserName,
       'doc-tree-detach-child',
     );
-
-    await expect(
-      page
-        .getByLabel('It is the card information about the document.')
-        .getByText('Administrator ·'),
-    ).toBeVisible();
 
     const docTree = page.getByTestId('doc-tree');
     await expect(docTree.getByText(docChild)).toBeVisible();
@@ -299,13 +285,48 @@ test.describe('Doc Tree', () => {
       .filter({
         hasText: docChild,
       });
+
     await child.hover();
-    const menu = child.getByRole('button', { name: /More options/ });
+    const menu = child.getByRole('button', {
+      name: /Open the document options/,
+    });
     await menu.click();
 
     await expect(
       page.getByRole('menuitem', { name: 'Move to my docs' }),
-    ).toHaveAttribute('aria-disabled', 'true');
+    ).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    await docTree.getByText(docParent).click();
+    await verifyDocName(page, docParent);
+
+    // Change the role current user to "Administrator" to test that only the owner can detach a document
+    await page.getByRole('button', { name: 'Share' }).click();
+    const list = page.getByTestId('doc-share-quick-search');
+    const currentEmail =
+      process.env[`SIGN_IN_USERNAME_${browserName.toUpperCase()}`] || '';
+    const currentUser = list.getByTestId(
+      `doc-share-member-row-${currentEmail}`,
+    );
+    const currentUserRole = currentUser.getByTestId('doc-role-dropdown');
+    await currentUserRole.click();
+    await page.getByRole('menuitemradio', { name: 'Administrator' }).click();
+    await list.click();
+    await page.getByRole('button', { name: 'Ok' }).click();
+
+    await expect(
+      page
+        .getByLabel('It is the card information about the document.')
+        .getByText('Administrator ·'),
+    ).toBeVisible();
+
+    await child.hover();
+    await menu.click();
+
+    await expect(
+      page.getByRole('menuitem', { name: 'Move to my docs' }),
+    ).toBeHidden();
   });
 
   test('keyboard navigation with Enter key opens documents', async ({
@@ -371,12 +392,12 @@ test.describe('Doc Tree', () => {
     await rootItem.focus();
     await expect(rootItem).toBeFocused();
 
-    // Press F2 → focus should move to the root actions \"More options\" button
+    // Press F2 → focus should move to the root actions \"Open the document options\" button
     await page.keyboard.press('F2');
 
     const rootActions = rootItem.locator('.doc-tree-root-item-actions');
     const rootMoreOptionsButton = rootActions.getByRole('button', {
-      name: /more options/i,
+      name: /Open the document options/i,
     });
 
     await expect(rootMoreOptionsButton).toBeFocused();
@@ -386,13 +407,7 @@ test.describe('Doc Tree', () => {
     page,
     browserName,
   }) => {
-    const [docParent] = await createDoc(
-      page,
-      'doc-tree-shift-tab',
-      browserName,
-      1,
-    );
-    await verifyDocName(page, docParent);
+    await createDoc(page, 'doc-tree-shift-tab', browserName, 1);
 
     const { name: docChild } = await createRootSubPage(
       page,
@@ -400,6 +415,7 @@ test.describe('Doc Tree', () => {
       'doc-tree-shift-tab-child',
     );
 
+    const docTree = page.getByTestId('doc-tree');
     const selectedSubDoc = await getTreeRow(page, docChild);
     await expect(selectedSubDoc).toHaveAttribute('aria-selected', 'true');
 
@@ -407,7 +423,7 @@ test.describe('Doc Tree', () => {
     await expect(selectedSubDoc).toBeFocused();
 
     await page.keyboard.press('Tab');
-    await expect(page.getByLabel('User menu')).toBeFocused();
+    await expect(page.getByLabel('Open user menu')).toBeFocused();
 
     await page.keyboard.press('Tab');
     await expect(page.getByLabel('Open help menu')).toBeFocused();
@@ -424,7 +440,7 @@ test.describe('Doc Tree', () => {
     await expect(page.getByLabel('User menu')).toBeFocused();
 
     await page.keyboard.press('Shift+Tab');
-    await expect(selectedSubDoc).toBeFocused();
+    await expect(docTree.getByLabel('Root document').first()).toBeFocused();
   });
 
   test('it updates the child icon from the tree', async ({
@@ -441,19 +457,6 @@ test.describe('Doc Tree', () => {
 
     const row = await getTreeRow(page, docChild);
 
-    // Check Remove emoji is not present initially
-    await row.hover();
-    const menu = row.getByRole('button', { name: /More options/ });
-    await menu.click();
-    await expect(
-      page.getByRole('menuitem', { name: 'Remove emoji' }),
-    ).toBeHidden();
-
-    // Close the menu
-    await page.keyboard.press('Escape');
-
-    await page.waitForTimeout(500);
-
     // Update the emoji from the tree
     await row.locator('.--docs--doc-icon').click();
     await page.getByRole('button', { name: '😀' }).first().click();
@@ -465,14 +468,6 @@ test.describe('Doc Tree', () => {
       .locator('.--docs--doc-title')
       .getByRole('button');
     await expect(titleEmojiPicker).toHaveText('😀');
-
-    // Now remove the emoji using the new action
-    await row.hover();
-    await menu.click();
-    await page.getByRole('menuitem', { name: 'Remove emoji' }).click();
-
-    await expect(row.getByText('😀')).toBeHidden();
-    await expect(titleEmojiPicker).toBeHidden();
   });
 
   test('A child inherit from the parent', async ({ page, browserName }) => {

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-tree.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-tree.spec.ts
@@ -329,98 +329,85 @@ test.describe('Doc Tree', () => {
     ).toBeHidden();
   });
 
-  test('keyboard navigation with Enter key opens documents', async ({
+  test('check the accessibility of the doc tree', async ({
     page,
     browserName,
   }) => {
-    // Create a parent document
     const [docParent] = await createDoc(
       page,
-      'doc-tree-keyboard-nav',
+      'doc-tree-accessibility',
       browserName,
       1,
     );
-    await verifyDocName(page, docParent);
 
-    // Create a sub-document
-    const { name: docChild } = await createRootSubPage(
+    const { name: docChild1 } = await createRootSubPage(
       page,
       browserName,
-      'doc-tree-keyboard-child',
+      'doc-tree-accessibility-child-1',
+    );
+
+    const { name: docChild2 } = await createRootSubPage(
+      page,
+      browserName,
+      'doc-tree-accessibility-child-2',
     );
 
     const docTree = page.getByTestId('doc-tree');
-    await expect(docTree).toBeVisible();
+    const rootItem = docTree.getByLabel('Root document').first();
+    const treeRow1 = await getTreeRow(page, docChild1);
+    const treeRow2 = await getTreeRow(page, docChild2);
 
-    // Test keyboard navigation on root document
-    const rootItem = page.getByTestId('doc-tree-root-item');
-    await expect(rootItem).toBeVisible();
-
-    // Focus on the root item and press Enter
-    await rootItem.focus();
+    await docTree.click();
+    await page.keyboard.press('Tab');
     await expect(rootItem).toBeFocused();
-    await page.keyboard.press('Enter');
-
-    // Verify we navigated to the root document
-    await verifyDocName(page, docParent);
-    await expect(page).toHaveURL(/\/docs\/[^/]+\/?$/);
-
-    // Now test keyboard navigation on sub-document
-    await expect(docTree.getByText(docChild)).toBeVisible();
-  });
-
-  test('keyboard navigation with F2 focuses root actions button', async ({
-    page,
-    browserName,
-  }) => {
-    // Create a parent document to initialize the tree
-    const [docParent] = await createDoc(
-      page,
-      'doc-tree-keyboard-f2-root',
-      browserName,
-      1,
-    );
-    await verifyDocName(page, docParent);
-
-    const docTree = page.getByTestId('doc-tree');
-    await expect(docTree).toBeVisible();
-
-    const rootItem = page.getByTestId('doc-tree-root-item');
-    await expect(rootItem).toBeVisible();
-
-    // Focus the root item
-    await rootItem.focus();
-    await expect(rootItem).toBeFocused();
-
-    // Press F2 → focus should move to the root actions \"Open the document options\" button
+    await page.keyboard.press('ArrowDown');
+    await expect(treeRow1).toBeFocused();
     await page.keyboard.press('F2');
+    await expect(
+      treeRow1.getByRole('button', { name: 'Add emoji' }),
+    ).toBeFocused();
+    await page.keyboard.press('ArrowRight');
+    await expect(
+      treeRow1.getByRole('button', {
+        name: /Open the document options/i,
+      }),
+    ).toBeFocused();
+    await page.keyboard.press('Escape');
+    await expect(treeRow1).toBeFocused();
 
+    await page.keyboard.press('ArrowUp');
+    await expect(rootItem).toBeFocused();
+
+    // Check F2
+    await page.keyboard.press('F2');
     const rootActions = rootItem.locator('.doc-tree-root-item-actions');
     const rootMoreOptionsButton = rootActions.getByRole('button', {
       name: /Open the document options/i,
     });
-
-    await expect(rootMoreOptionsButton).toBeFocused();
-  });
-
-  test('Shift+Tab from resize handle returns focus to selected sub-doc', async ({
-    page,
-    browserName,
-  }) => {
-    await createDoc(page, 'doc-tree-shift-tab', browserName, 1);
-
-    const { name: docChild } = await createRootSubPage(
-      page,
-      browserName,
-      'doc-tree-shift-tab-child',
+    const rootAddDocButton = rootItem.getByTestId(
+      'doc-tree-item-actions-add-child',
     );
+    await expect(rootMoreOptionsButton).toBeFocused();
+    await page.keyboard.press('F2');
+    await expect(rootAddDocButton).toBeFocused();
+    await page.keyboard.press('F2');
+    await expect(rootMoreOptionsButton).toBeFocused();
+    await page.keyboard.press('ArrowRight');
+    await expect(rootAddDocButton).toBeFocused();
+    await page.keyboard.press('ArrowLeft');
+    await expect(rootMoreOptionsButton).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('menuitem', { name: /Copy Link/i }),
+    ).toBeVisible();
+    await page.waitForTimeout(500);
+    await page.keyboard.press('Escape');
+    await expect(rootMoreOptionsButton).toBeFocused();
 
-    const docTree = page.getByTestId('doc-tree');
-    const selectedSubDoc = await getTreeRow(page, docChild);
-    await expect(selectedSubDoc).toHaveAttribute('aria-selected', 'true');
-
-    await selectedSubDoc.focus();
-    await expect(selectedSubDoc).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(treeRow1).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(treeRow2).toBeFocused();
 
     await page.keyboard.press('Tab');
     await expect(page.getByLabel('Open user menu')).toBeFocused();
@@ -441,6 +428,9 @@ test.describe('Doc Tree', () => {
 
     await page.keyboard.press('Shift+Tab');
     await expect(docTree.getByLabel('Root document').first()).toBeFocused();
+
+    await page.keyboard.press('Enter');
+    await verifyDocName(page, docParent);
   });
 
   test('it updates the child icon from the tree', async ({

--- a/src/frontend/apps/e2e/__tests__/app-impress/presenter-mode.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/presenter-mode.spec.ts
@@ -2,12 +2,7 @@ import path from 'path';
 
 import { Locator, Page, expect, test } from '@playwright/test';
 
-import {
-  createDoc,
-  goToGridDoc,
-  mockedDocument,
-  saveContent,
-} from './utils-common';
+import { createDoc, mockedDocument, saveContent } from './utils-common';
 import {
   openSuggestionMenu,
   tryFocusEditorContent,
@@ -15,7 +10,7 @@ import {
 } from './utils-editor';
 
 const openPresenter = async (page: Page) => {
-  await page.getByLabel('Open the document options').click();
+  await page.getByLabel('Open the document options').first().click();
   await page.getByRole('menuitem', { name: 'Present' }).click();
 
   const overlay = page.getByRole('dialog', { name: 'Presenter mode' });
@@ -513,9 +508,9 @@ test.describe('Presenter Mode mobile', () => {
       },
     });
 
-    await goToGridDoc(page);
+    await page.goto('/');
 
-    await page.getByLabel('Open the document options').click();
+    await page.getByLabel('Open the document options').first().click();
     await expect(page.getByRole('menuitem', { name: 'Present' })).toBeHidden();
   });
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-common.ts
@@ -446,20 +446,20 @@ export const clickInEditorShareButton = async (page: Page) => {
 };
 
 export const clickInEditorMenu = async (page: Page, textButton: string) => {
-  await page
-    .getByTestId('floating-bar')
-    .getByRole('button', { name: 'Open the document options' })
-    .click();
-  await page.getByRole('menuitem', { name: textButton }).click();
+  await clickInDocOptionMenu(
+    page,
+    page.getByTestId('floating-bar'),
+    textButton,
+  );
 };
 
-export const clickInGridMenu = async (
+export const clickInDocOptionMenu = async (
   page: Page,
-  row: Locator,
+  selector: Locator,
   textButton: string,
 ) => {
-  await row
-    .getByRole('button', { name: /Open the menu of actions for the document/ })
+  await selector
+    .getByRole('button', { name: /Open the document options/ })
     .click();
   await page.getByRole('menuitem', { name: textButton }).click();
 };

--- a/src/frontend/apps/e2e/__tests__/app-impress/utils-sub-pages.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/utils-sub-pages.ts
@@ -46,11 +46,13 @@ export const createRootSubPage = async (
   }
 
   // Update sub page name
-  const randomDocs = randomName(docName, browserName, 1);
-  await updateDocTitle(page, randomDocs[0]);
+  const [randomDoc] = randomName(docName, browserName, 1);
+  await updateDocTitle(page, randomDoc);
+
+  await expect(docTree.getByText(randomDoc)).toBeVisible();
 
   // Return sub page data
-  return { name: randomDocs[0], docTreeItem: subPageItem, item: subPageJson };
+  return { name: randomDoc, docTreeItem: subPageItem, item: subPageJson };
 };
 
 export const clickOnAddRootSubPage = async (page: Page) => {

--- a/src/frontend/apps/impress/src/components/quick-search/QuickSearchInput.tsx
+++ b/src/frontend/apps/impress/src/components/quick-search/QuickSearchInput.tsx
@@ -1,11 +1,10 @@
 import { Command } from 'cmdk';
-import { PropsWithChildren, useEffect, useRef } from 'react';
+import { PropsWithChildren, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import SearchSVG from '@/assets/icons/ui-kit/zoom-rounded.svg';
 import { HorizontalSeparator } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
-import { useFocusStore } from '@/stores';
 
 import { Box } from '../Box';
 
@@ -27,11 +26,6 @@ export const QuickSearchInput = ({
   const { t } = useTranslation();
   const { spacingsTokens } = useCunninghamTheme();
   const inputRef = useRef<HTMLInputElement>(null);
-  const addLastFocus = useFocusStore((state) => state.addLastFocus);
-
-  useEffect(() => {
-    addLastFocus(inputRef.current);
-  }, [addLastFocus]);
 
   if (children) {
     return (

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertRestore.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/AlertRestore.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   VariantType,
   useToastProvider,
-  useTreeContext,
 } from '@gouvfr-lasuite/ui-components';
 import { useTranslation } from 'react-i18next';
 
@@ -15,12 +14,12 @@ import {
   KEY_LIST_FAVORITE_DOC,
   useRestoreDoc,
 } from '@/docs/doc-management';
+import { KEY_DOC_TREE } from '@/docs/doc-tree';
 import { KEY_LIST_DOC_TRASHBIN } from '@/docs/docs-grid';
 
 export const AlertRestore = ({ doc }: { doc: Doc }) => {
   const { t } = useTranslation();
   const { toast } = useToastProvider();
-  const treeContext = useTreeContext<Doc>();
   const { spacingsTokens } = useCunninghamTheme();
   const { mutate: restoreDoc, error } = useRestoreDoc({
     listInvalidQueries: [
@@ -28,12 +27,10 @@ export const AlertRestore = ({ doc }: { doc: Doc }) => {
       KEY_LIST_DOC_TRASHBIN,
       KEY_DOC,
       KEY_LIST_FAVORITE_DOC,
+      KEY_DOC_TREE,
     ],
     options: {
       onSuccess: (_data) => {
-        // It will force the tree to be reloaded
-        treeContext?.setRoot(undefined as unknown as Doc);
-
         toast(t('The document has been restored.'), VariantType.SUCCESS, {
           duration: 4000,
         });

--- a/src/frontend/apps/impress/src/features/docs/doc-header/components/DocFloatingBar.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-header/components/DocFloatingBar.tsx
@@ -24,7 +24,9 @@ export const DocFloatingBar = () => {
           {!isDeletedDoc && currentDoc && <DocShareButton doc={currentDoc} />}
           <CardFloatingBar>
             <RightPanelCollapseButton />
-            {!isDeletedDoc && currentDoc && <DocToolBox doc={currentDoc} />}
+            {!isDeletedDoc && currentDoc && (
+              <DocToolBox doc={currentDoc} isCurrentDoc={true} />
+            )}
           </CardFloatingBar>
         </Box>
       )}

--- a/src/frontend/apps/impress/src/features/docs/doc-management/api/useCreateFavoriteDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/api/useCreateFavoriteDoc.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
+import { syncDocInTree, useTreeContextOrNull } from '@/docs/doc-tree/utils';
 
 import { Doc } from '../types';
 
@@ -32,15 +33,18 @@ export function useCreateFavoriteDoc({
 }: CreateFavoriteDocProps) {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
+  const treeContext = useTreeContextOrNull();
 
   return useMutation<void, APIError, CreateFavoriteDocParams>({
     mutationFn: createFavoriteDoc,
-    onSuccess: () => {
+    onSuccess: (_data, { id }) => {
       listInvalidQueries?.forEach((queryKey) => {
         void queryClient.invalidateQueries({
           queryKey: [queryKey],
         });
       });
+
+      syncDocInTree(treeContext, id, { is_favorite: true });
 
       const message = t('Document starred successfully!');
       announce(message, 'polite');

--- a/src/frontend/apps/impress/src/features/docs/doc-management/api/useDeleteFavoriteDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/api/useDeleteFavoriteDoc.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
+import { syncDocInTree, useTreeContextOrNull } from '@/docs/doc-tree/utils';
 
 import { Doc } from '../types';
 
@@ -32,15 +33,18 @@ export function useDeleteFavoriteDoc({
 }: DeleteFavoriteDocProps) {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
+  const treeContext = useTreeContextOrNull();
 
   return useMutation<void, APIError, DeleteFavoriteDocParams>({
     mutationFn: deleteFavoriteDoc,
-    onSuccess: () => {
+    onSuccess: (_data, { id }) => {
       listInvalidQueries?.forEach((queryKey) => {
         void queryClient.invalidateQueries({
           queryKey: [queryKey],
         });
       });
+
+      syncDocInTree(treeContext, id, { is_favorite: false });
 
       const message = t('Document unstarred successfully!');
       announce(message, 'polite');

--- a/src/frontend/apps/impress/src/features/docs/doc-management/api/useMoveDoc.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/api/useMoveDoc.tsx
@@ -1,5 +1,9 @@
 import { TreeViewMoveModeEnum } from '@gouvfr-lasuite/ui-components';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  UseMutationOptions,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
 import { KEY_DOC_TREE } from '@/docs/doc-tree/api/useDocTree';
@@ -33,15 +37,22 @@ export const moveDoc = async ({
   return response.json() as Promise<void>;
 };
 
-export function useMoveDoc() {
+type UseMoveDocOptions = UseMutationOptions<void, APIError, MoveDocParam>;
+
+export function useMoveDoc(options?: UseMoveDocOptions) {
   const queryClient = useQueryClient();
 
   return useMutation<void, APIError, MoveDocParam>({
     mutationFn: moveDoc,
-    onSuccess() {
+    ...options,
+    onSuccess(data, variables, onMutateResult, context) {
       void queryClient.invalidateQueries({ queryKey: [KEY_LIST_DOC] });
       void queryClient.invalidateQueries({ queryKey: [KEY_DOC] });
       void queryClient.invalidateQueries({ queryKey: [KEY_DOC_TREE] });
+
+      if (options?.onSuccess) {
+        void options.onSuccess(data, variables, onMutateResult, context);
+      }
     },
   });
 }

--- a/src/frontend/apps/impress/src/features/docs/doc-management/components/DocToolBox.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/components/DocToolBox.tsx
@@ -1,14 +1,14 @@
 import {
   Button,
+  ButtonProps,
   DropdownMenu,
   DropdownMenuItem,
-  useTreeContext,
 } from '@gouvfr-lasuite/ui-components';
 import { Present } from '@gouvfr-lasuite/ui-components/icons';
 import { announce } from '@react-aria/live-announcer';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Text } from '@/components/Text';
@@ -17,15 +17,16 @@ import { getWordCount } from '@/docs/doc-editor/utils';
 import { printDocumentWithStyles } from '@/docs/doc-export/utils_print';
 import { usePresenterStore } from '@/docs/doc-presenter/stores';
 import { useDetachDoc } from '@/docs/doc-tree/api/useDetach';
+import { useTreeContextOrNull } from '@/docs/doc-tree/utils';
 import { useAuth } from '@/features/auth';
 import ContentCopyIcon from '@/icons/copy.svg';
 import DocMoveInIcon from '@/icons/doc-move-in.svg';
 import DocMoveOutIcon from '@/icons/doc-move-out.svg';
-import DownloadSVG from '@/icons/download.svg';
-import HistorySVG from '@/icons/history.svg';
-import LeaveSVG from '@/icons/leave.svg';
+import DownloadIcon from '@/icons/download.svg';
+import HistoryIcon from '@/icons/history.svg';
+import LeaveIcon from '@/icons/leave.svg';
 import LinkIcon from '@/icons/link.svg';
-import MoreSVG from '@/icons/more_horiz.svg';
+import MoreIcon from '@/icons/more_horiz.svg';
 import PrintIcon from '@/icons/print.svg';
 import SharedIcon from '@/icons/shared.svg';
 import StarSlashIcon from '@/icons/star-slash.svg';
@@ -41,7 +42,7 @@ import {
   useDeleteFavoriteDoc,
   useDuplicateDoc,
 } from '../api';
-import { useCopyDocLink } from '../hooks';
+import { useCopyDocLink, useTrans } from '../hooks';
 import { Doc, Role } from '../types';
 
 const DocMoveModal = dynamic(
@@ -96,13 +97,24 @@ const ModalExport = dynamic(
 
 interface DocToolBoxProps {
   doc: Doc;
+  isCurrentDoc: boolean;
+  buttonProps?: ButtonProps;
+  onOpenChange?: (isOpen: boolean) => void;
+  optionsDefault?: DropdownMenuItem[];
 }
 
-export const DocToolBox = ({ doc }: DocToolBoxProps) => {
+const DocToolBoxComponent = ({
+  buttonProps,
+  doc,
+  isCurrentDoc,
+  onOpenChange,
+  optionsDefault,
+}: DocToolBoxProps) => {
   const { t } = useTranslation();
-  const treeContext = useTreeContext<Doc | null>();
+  const { untitledDocument } = useTrans();
+  const treeContext = useTreeContextOrNull<Doc | null>();
   const router = useRouter();
-  const isTopParent = doc.id === treeContext?.root?.id; // it can be a child but not for the current user
+  const isTopParent = !treeContext || doc.id === treeContext?.root?.id; // it can be a child but not for the current user
   const { authenticated } = useAuth();
   const [openDropdown, setOpenDropdown] = useState(false);
   const [isModalRemoveOpen, setIsModalRemoveOpen] = useState(false);
@@ -111,17 +123,18 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
   const [isModalHistoryOpen, setIsModalHistoryOpen] = useState(false);
   const [isModalLeaveOpen, setIsModalLeaveOpen] = useState(false);
   const [isModalMoveOpen, setIsModalMoveOpen] = useState(false);
+  const { onClick: onButtonClick, ...buttonPropsLeft } = buttonProps || {};
 
-  const { editor } = useEditorStore();
+  const editor = useEditorStore((state) => state.editor);
   const wordCountLabel = useMemo(() => {
-    if (openDropdown) {
+    if (openDropdown && isCurrentDoc && editor) {
       return t('Word count: {{count}} words', {
         count: getWordCount(editor),
         description:
           'In the document options menu, showing the number of words in the document.',
       });
     }
-  }, [editor, openDropdown, t]);
+  }, [editor, isCurrentDoc, openDropdown, t]);
 
   useEffect(() => {
     if (wordCountLabel) {
@@ -131,8 +144,9 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
 
   const { mutate: detachDoc } = useDetachDoc();
 
-  const { restoreFocus, addLastFocus } = useFocusStore();
-  const { isMobile } = useResponsiveStore();
+  const restoreFocus = useFocusStore((state) => state.restoreFocus);
+  const addLastFocus = useFocusStore((state) => state.addLastFocus);
+  const isMobile = useResponsiveStore((state) => state.isMobile);
   const copyDocLink = useCopyDocLink(doc.id);
 
   const openPresenter = usePresenterStore((state) => state.open);
@@ -155,7 +169,10 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
         description: 'Dropdown menu item to copy the document link',
       }),
       icon: <LinkIcon width={18} height={18} aria-hidden="true" />,
-      callback: copyDocLink,
+      callback: () => {
+        copyDocLink();
+        restoreFocus();
+      },
     },
     {
       label: t('Share', {
@@ -166,8 +183,8 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
         setIsModalShareOpen(true);
       },
       isHidden: !authenticated,
+      showSeparator: isCurrentDoc,
     },
-    { type: 'separator' },
     {
       label: t('Present', {
         description:
@@ -177,17 +194,18 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
       callback: () => {
         openPresenter(0);
       },
-      isHidden: Boolean(doc.deleted_at) || isMobile,
+      isHidden: Boolean(doc.deleted_at) || isMobile || !isCurrentDoc,
       testId: `docs-actions-present-${doc.id}`,
     },
     {
       label: t('Download', {
         description: 'Dropdown menu item to download the document',
       }),
-      icon: <DownloadSVG width={18} height={18} aria-hidden="true" />,
+      icon: <DownloadIcon width={18} height={18} aria-hidden="true" />,
       callback: () => {
         setIsModalExportOpen(true);
       },
+      isHidden: !isCurrentDoc,
     },
     {
       label: t('Print', {
@@ -197,6 +215,7 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
       callback: () => {
         printDocumentWithStyles();
       },
+      isHidden: !isCurrentDoc,
     },
     { type: 'separator' },
     {
@@ -212,6 +231,8 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
         } else {
           makeFavoriteDoc.mutate({ id: doc.id });
         }
+
+        restoreFocus();
       },
       isHidden: !doc.abilities.favorite,
       testId: `docs-actions-${doc.is_favorite ? 'unstar' : 'star'}-${doc.id}`,
@@ -270,19 +291,19 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
       label: t('History', {
         description: 'Dropdown menu item to view the document history',
       }),
-      icon: <HistorySVG width={18} height={18} aria-hidden="true" />,
+      icon: <HistoryIcon width={18} height={18} aria-hidden="true" />,
       isDisabled: !doc.abilities.versions_list,
       callback: () => {
         setIsModalHistoryOpen(true);
       },
-      isHidden: isMobile || !doc.abilities.versions_list,
+      isHidden: isMobile || !doc.abilities.versions_list || !isCurrentDoc,
       showSeparator: true,
     },
     {
       label: t('Leave', {
         description: 'Dropdown menu item to leave the document',
       }),
-      icon: <LeaveSVG width={18} height={18} aria-hidden="true" />,
+      icon: <LeaveIcon width={18} height={18} aria-hidden="true" />,
       callback: () => {
         setIsModalLeaveOpen(true);
       },
@@ -302,35 +323,44 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
         setIsModalRemoveOpen(true);
       },
       isHidden: !doc.abilities.destroy,
-    },
-    {
-      type: 'separator',
+      showSeparator: isCurrentDoc,
     },
   ];
 
   return (
     <>
       <DropdownMenu
-        options={options}
+        options={optionsDefault ?? options}
         isOpen={openDropdown}
         shouldCloseOnInteractOutside={() => true}
-        onOpenChange={setOpenDropdown}
+        onOpenChange={(isOpen) => {
+          setOpenDropdown(isOpen);
+          onOpenChange?.(isOpen);
+        }}
         bottomMessage={
           wordCountLabel && <Text $variation="tertiary">{wordCountLabel}</Text>
         }
       >
         <Button
-          aria-label={t('Open the document options')}
+          aria-label={t('Open the document options: {{title}}', {
+            title: doc.title || untitledDocument,
+          })}
           size="small"
-          icon={<MoreSVG width={24} height={24} aria-hidden="true" />}
+          icon={<MoreIcon width={24} height={24} aria-hidden="true" />}
           color="neutral"
           variant="tertiary"
           onClick={(e) => {
             e.stopPropagation();
             e.preventDefault();
-            setOpenDropdown((o) => !o);
+            const isOpen = !openDropdown;
+            setOpenDropdown(isOpen);
+            onOpenChange?.(isOpen);
             addLastFocus(e.currentTarget);
+            onButtonClick?.(
+              e as React.MouseEvent<HTMLButtonElement, MouseEvent>,
+            );
           }}
+          {...buttonPropsLeft}
         />
       </DropdownMenu>
 
@@ -409,3 +439,5 @@ export const DocToolBox = ({ doc }: DocToolBoxProps) => {
     </>
   );
 };
+
+export const DocToolBox = memo(DocToolBoxComponent);

--- a/src/frontend/apps/impress/src/features/docs/doc-share/api/useLeaveDoc.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/api/useLeaveDoc.ts
@@ -5,7 +5,7 @@ import {
 } from '@tanstack/react-query';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
-import { KEY_LIST_DOC } from '@/docs/doc-management/api';
+import { KEY_LIST_DOC, KEY_LIST_FAVORITE_DOC } from '@/docs/doc-management/api';
 
 interface LeaveDocProps {
   docId: string;
@@ -35,6 +35,9 @@ export const useLeaveDoc = (options?: UseLeaveDocOptions) => {
     onSuccess: (data, variables, onMutateResult, context) => {
       void queryClient.invalidateQueries({
         queryKey: [KEY_LIST_DOC],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [KEY_LIST_FAVORITE_DOC],
       });
 
       if (options?.onSuccess) {

--- a/src/frontend/apps/impress/src/features/docs/doc-share/api/useUpdateDocAccess.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/api/useUpdateDocAccess.ts
@@ -6,6 +6,7 @@ import {
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
 import { Access, KEY_DOC, KEY_LIST_DOC, Role } from '@/docs/doc-management';
+import { KEY_DOC_TREE } from '@/docs/doc-tree/api/useDocTree';
 
 import { KEY_LIST_DOC_ACCESSES } from './useDocAccesses';
 
@@ -58,6 +59,10 @@ export const useUpdateDocAccess = (options?: UseUpdateDocAccessOptions) => {
 
       void queryClient.invalidateQueries({
         queryKey: [KEY_LIST_DOC],
+      });
+
+      void queryClient.invalidateQueries({
+        queryKey: [KEY_DOC_TREE],
       });
 
       if (options?.onSuccess) {

--- a/src/frontend/apps/impress/src/features/docs/doc-share/api/useUpdateDocLink.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-share/api/useUpdateDocLink.tsx
@@ -6,6 +6,7 @@ import {
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
 import { Doc, LinkReach, LinkRole } from '@/docs/doc-management';
+import { syncDocInTree, useTreeContextOrNull } from '@/docs/doc-tree/utils';
 
 export type UpdateDocLinkParams = Pick<Doc, 'id' | 'link_reach'> &
   Partial<Pick<Doc, 'link_role'>>;
@@ -43,6 +44,7 @@ type UseUpdateDocLinkOptions = UseMutationOptions<
 
 export function useUpdateDocLink(options?: UseUpdateDocLinkOptions) {
   const queryClient = useQueryClient();
+  const treeContext = useTreeContextOrNull();
 
   return useMutation<UpdateDocLinkResponse, APIError, UpdateDocLinkParams>({
     mutationFn: updateDocLink,
@@ -52,6 +54,17 @@ export function useUpdateDocLink(options?: UseUpdateDocLinkOptions) {
         void queryClient.invalidateQueries({
           queryKey: [queryKey],
         });
+      });
+
+      /**
+       * Can be loaded from the doc tree, we need to resync the doc tree
+       * in order to reflect the changes in the tree view.
+       */
+      syncDocInTree(treeContext, variables.id, {
+        link_reach: data.link_reach,
+        link_role: data.link_role,
+        computed_link_reach: data.link_reach,
+        computed_link_role: data.link_role,
       });
 
       options?.onSuccess?.(data, variables, onMutateResult, context);

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/api/useDetach.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/api/useDetach.tsx
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
-
-import { KEY_DOC, KEY_LIST_DOC } from '../../doc-management';
+import { KEY_DOC, KEY_LIST_DOC } from '@/docs/doc-management';
 
 export type DetachDocParam = {
   documentId: string;

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/api/useDocTree.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/api/useDocTree.tsx
@@ -1,8 +1,14 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import {
+  UseQueryOptions,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useEffect } from 'react';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
+import { Doc } from '@/docs/doc-management';
 
-import { Doc } from '../../doc-management';
+import { reloadTree, useTreeContextOrNull } from '../utils';
 
 export type DocsTreeParams = {
   docId: string;
@@ -27,6 +33,25 @@ export function useDocTree(
   params: DocsTreeParams,
   queryConfig?: UseQueryOptions<Doc, APIError, Doc>,
 ) {
+  const queryClient = useQueryClient();
+  const treeContext = useTreeContextOrNull<Doc | null>();
+
+  /**
+   * Bind the reloadTree function to the query cache subscription,
+   * so that when the doc tree query is invalidated, the tree is reloaded.
+   */
+  useEffect(() => {
+    return queryClient.getQueryCache().subscribe((event) => {
+      if (event.type !== 'updated' || event.action.type !== 'invalidate') {
+        return;
+      }
+      const queryKey = event.query.queryKey as readonly unknown[];
+      if (queryKey[0] === KEY_DOC_TREE) {
+        reloadTree(treeContext);
+      }
+    });
+  }, [queryClient, treeContext]);
+
   return useQuery<Doc, APIError, Doc>({
     queryKey: [KEY_DOC_TREE, params],
     queryFn: () => getDocTree(params),

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocSubPageItem.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocSubPageItem.tsx
@@ -1,5 +1,4 @@
 import {
-  ButtonElement,
   Spinner,
   TreeViewItem,
   TreeViewNodeProps,
@@ -7,7 +6,7 @@ import {
   useTreeContext,
 } from '@gouvfr-lasuite/ui-components';
 import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
@@ -21,6 +20,7 @@ import {
 import { useLeftPanelStore } from '@/features/left-panel';
 import { useResponsiveStore } from '@/stores';
 
+import { useTreeItemActions } from '../hooks/useTreeItemActions';
 import { isDocNode } from '../utils';
 
 import SubPageIcon from './../assets/sub-page-logo.svg';
@@ -103,14 +103,42 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
   const treeContext = useTreeContext<Doc>();
   const { untitledDocument } = useTrans();
   const { node } = props;
-  const { isLargeScreen, isMobile } = useResponsiveStore();
+  const { isMobile } = useResponsiveStore();
   const { t } = useTranslation();
-  const [menuOpen, setMenuOpen] = useState(false);
   const router = useRouter();
   const { closePanel } = useLeftPanelStore();
 
   const { emoji, titleWithoutEmoji } = getEmojiAndTitle(doc.title || '');
   const displayTitle = titleWithoutEmoji || untitledDocument;
+
+  const itemRef = useRef<HTMLAnchorElement>(null);
+
+  const focusRow = useCallback(() => {
+    // Keep react-arborist's notion of the focused node in sync…
+    node.focus();
+    /**
+     * …but move the DOM focus ourselves. The library only does it from an
+     * effect keyed on `isFocused` *changing*, and it is already true whenever
+     * focus sits on one of this row's own buttons — so `node.focus()` alone
+     * would leave focus right where it is.
+     */
+    itemRef.current?.closest<HTMLElement>('.c__tree-view--row')?.focus();
+  }, [node]);
+
+  /**
+   * F2 / arrows step through the item's actions (emoji button, then the toolbar
+   * buttons) and Escape leaves them; the very first F2 is handled by the
+   * ui-components row itself (row → emoji button).
+   */
+  const {
+    areActionsVisible,
+    onMenuOpenChange,
+    handleActionsKeyDown,
+    itemProps,
+  } = useTreeItemActions({
+    isActive: node.isFocused,
+    focusItem: focusRow,
+  });
 
   const afterCreate = (createdDoc: Doc) => {
     const actualChildren = node.data.children ?? [];
@@ -146,36 +174,11 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
 
   const isCurrentPage = router.query?.id === doc.id;
   const isDeleted = !!doc.deleted_at;
-  const actionsRef = useRef<HTMLDivElement>(null);
-  const buttonOptionRef = useRef<ButtonElement | null>(null);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    const target = e.target as HTMLElement | null;
-    const isInActions = !!target?.closest('.light-doc-item-actions');
-    const isOnEmojiButton = !!target?.closest('.--docs--doc-icon');
-
-    const shouldOpenActions =
-      !menuOpen && !isInActions && (node.isFocused || isOnEmojiButton);
-    if (e.key === 'F2' && shouldOpenActions) {
-      buttonOptionRef.current?.focus();
-      e.stopPropagation();
-      e.preventDefault();
-      return;
-    }
-  };
-
-  const handleActionsOpenChange = (isOpen: boolean) => {
-    setMenuOpen(isOpen);
-
-    // When the menu closes (via Escape or activating an option),
-    // return focus to the tree item so focus is not lost.
-    if (!isOpen) {
-      node.focus();
-    }
-  };
 
   return (
     <StyledLink
+      {...itemProps}
+      ref={itemRef}
       className="--docs-sub-page-item"
       /**
        * Conflict with the react-arborist DND.
@@ -191,7 +194,7 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
       }
       aria-current={isCurrentPage ? 'page' : undefined}
       data-testid={`doc-sub-page-item-${doc.id}`}
-      onKeyDown={handleKeyDown}
+      onKeyDown={handleActionsKeyDown}
       aria-disabled={isDeleted}
       onClick={(e) => {
         if (isDeleted) {
@@ -220,10 +223,6 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
         display: block;
         width: 100%;
         border-radius: var(--c--globals--spacings--st);
-        .light-doc-item-actions {
-          display: ${menuOpen || !isLargeScreen ? 'flex' : 'none'};
-          right: var(--c--globals--spacings--0);
-        }
         .c__tree-view--node {
           padding-right: var(--c--globals--spacings--xxxs);
           height: 32px;
@@ -231,12 +230,12 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
         .c__tree-view--node.isFocused {
           outline: none !important;
           border-radius: var(--c--globals--spacings--st);
-          .light-doc-item-actions {
-            display: flex;
-          }
         }
-        /* Remove visual focus from the tree item when focus is on actions or emoji button */
-        &:has(.light-doc-item-actions *:focus, .--docs--doc-icon:focus-visible)
+        /* Only one focus ring at a time: the toolbar and emoji draw their own. */
+        &:has(
+            .doc-tree-root-item-actions *:focus,
+            .--docs--doc-icon:focus-visible
+          )
           .c__tree-view--node.isFocused {
           box-shadow: none !important;
         }
@@ -244,14 +243,6 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
           background-color: var(
             --c--contextuals--background--semantic--gray--tertiary
           );
-          .light-doc-item-actions {
-            display: flex;
-          }
-        }
-        &:focus-within {
-          .light-doc-item-actions {
-            display: flex;
-          }
         }
         .row.preview & {
           background-color: inherit;
@@ -294,23 +285,13 @@ const DocSubPageItemContent = (props: TreeViewNodeProps<Doc>) => {
             {displayTitle}
           </Text>
         </Box>
-        <Box
-          $direction="row"
-          $align="center"
-          className="light-doc-item-actions actions"
-          role="toolbar"
-          aria-label={t('Actions for {{title}}', { title: displayTitle })}
-        >
+        {areActionsVisible && (
           <DocTreeItemActions
             doc={doc}
-            isOpen={menuOpen}
-            onOpenChange={handleActionsOpenChange}
-            parentId={node.data.parentKey}
+            onOpenChange={onMenuOpenChange}
             onCreateSuccess={afterCreate}
-            actionsRef={actionsRef}
-            buttonOptionRef={buttonOptionRef}
           />
-        </Box>
+        )}
       </TreeViewItem>
     </StyledLink>
   );

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
@@ -14,7 +14,7 @@ import { Doc } from '@/docs/doc-management';
 import { TreeSkeleton } from '@/features/skeletons/components/TreeSkeleton';
 
 import { KEY_DOC_TREE, useDocTree } from '../api/useDocTree';
-import { findIndexInTree } from '../utils';
+import { findIndexInTree, reloadTree } from '../utils';
 
 import { DocTreeRoot } from './DocTreeRoot';
 import { DocTreeSubpages } from './DocTreeSubpages';
@@ -44,7 +44,7 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
    * This function resets the tree states.
    */
   const resetStateTree = useCallback(() => {
-    treeContext?.setRoot(null);
+    reloadTree(treeContext);
     setInitialOpenState(undefined);
   }, [treeContext]);
 

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTree.tsx
@@ -1,66 +1,33 @@
+import { OpenMap, useTreeContext } from '@gouvfr-lasuite/ui-components';
 import {
-  ButtonElement,
-  OpenMap,
-  TreeDataItem,
-  TreeView,
-  TreeViewMoveResult,
-  useResponsive,
-  useTreeContext,
-} from '@gouvfr-lasuite/ui-components';
-import { useRouter } from 'next/router';
-import {
-  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
 } from 'react';
-import { NodeApi } from 'react-arborist';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
-import { Box, Overlayer, StyledLink } from '@/components';
-import { useCunninghamTheme } from '@/cunningham';
-import {
-  Doc,
-  SimpleDocItem,
-  useMoveDoc,
-  useTrans,
-} from '@/docs/doc-management';
-import { useLeftPanelStore } from '@/features/left-panel/stores/useLeftPanelStore';
+import { Box } from '@/components';
+import { Doc } from '@/docs/doc-management';
 import { TreeSkeleton } from '@/features/skeletons/components/TreeSkeleton';
-import { useResponsiveStore } from '@/stores/useResponsiveStore';
 
-import { CLASS_DOC_TITLE } from '../../doc-header';
 import { KEY_DOC_TREE, useDocTree } from '../api/useDocTree';
-import { findIndexInTree, isDocNode } from '../utils';
+import { findIndexInTree } from '../utils';
 
-import { DocSubPageItem } from './DocSubPageItem';
-import { DocTreeItemActions } from './DocTreeItemActions';
+import { DocTreeRoot } from './DocTreeRoot';
+import { DocTreeSubpages } from './DocTreeSubpages';
 
 type DocTreeProps = {
   currentDoc: Doc;
 };
 
 export const DocTree = ({ currentDoc }: DocTreeProps) => {
-  const { spacingsTokens } = useCunninghamTheme();
-  const { isMobile } = useResponsiveStore();
-  const { closePanel } = useLeftPanelStore();
-  const { untitledDocument } = useTrans();
   const [treeRoot, setTreeRoot] = useState<HTMLElement | null>(null);
   const treeContext = useTreeContext<Doc | null>();
-  const router = useRouter();
-  const [rootActionsOpen, setRootActionsOpen] = useState(false);
-  const rootIsSelected =
-    !!treeContext?.root?.id &&
-    treeContext?.treeData.selectedNode?.id === treeContext.root.id;
   const rootItemRef = useRef<HTMLDivElement>(null);
-  const rootActionsRef = useRef<HTMLDivElement>(null);
-  const rootButtonOptionRef = useRef<ButtonElement | null>(null);
-
   const { t } = useTranslation();
-
   const [initialOpenState, setInitialOpenState] = useState<OpenMap | undefined>(
     undefined,
   );
@@ -80,80 +47,6 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
     treeContext?.setRoot(null);
     setInitialOpenState(undefined);
   }, [treeContext]);
-
-  const selectRoot = useCallback(() => {
-    if (treeContext?.root) {
-      treeContext.treeData.setSelectedNode(treeContext.root);
-    }
-  }, [treeContext]);
-
-  const navigateToRoot = useCallback(() => {
-    const id = treeContext?.root?.id;
-    if (id) {
-      void router.push(`/docs/${id}`);
-    }
-  }, [router, treeContext?.root?.id]);
-
-  const handleRootFocus = useCallback(() => {
-    selectRoot();
-  }, [selectRoot]);
-
-  // Handle keyboard navigation for root item
-  const handleRootKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
-      const isInActions = !!target?.closest('.doc-tree-root-item-actions');
-      const isOnEmojiButton = !!target?.closest('.--docs--doc-icon');
-      const isOnRootItem = target === e.currentTarget;
-
-      if (e.key === 'F2' && !rootActionsOpen && !isInActions) {
-        if (
-          isOnEmojiButton ||
-          isOnRootItem ||
-          target?.classList.contains('c__tree-view--node')
-        ) {
-          e.preventDefault();
-          rootButtonOptionRef.current?.focus();
-        }
-        return;
-      }
-
-      if (isInActions) {
-        return;
-      }
-
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        if (currentDoc.id === treeContext?.root?.id) {
-          document.querySelector<HTMLElement>(`.${CLASS_DOC_TITLE}`)?.focus();
-        } else {
-          selectRoot();
-          navigateToRoot();
-        }
-      }
-    },
-    [
-      selectRoot,
-      navigateToRoot,
-      rootActionsOpen,
-      currentDoc.id,
-      treeContext?.root?.id,
-    ],
-  );
-
-  // Handle menu open/close for root item - mirrors DocSubPageItem behavior
-  const handleRootActionsOpenChange = useCallback((isOpen: boolean) => {
-    setRootActionsOpen(isOpen);
-
-    // When the menu closes, return focus to the root tree item
-    // (same behavior as DocSubPageItem for consistency)
-    // Use requestAnimationFrame for smoother focus transition without flickering
-    if (!isOpen) {
-      requestAnimationFrame(() => {
-        rootItemRef.current?.focus();
-      });
-    }
-  }, []);
 
   /**
    * This effect is used to reset the tree when a new document
@@ -314,7 +207,7 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
       {/* Keyboard instructions for screen readers */}
       <Box id="doc-tree-keyboard-instructions" className="sr-only">
         {t(
-          'Use arrow keys to navigate between documents. Press Enter to open a document. Press F2 to focus the emoji button when available, then press F2 again to access document actions.',
+          'Use the up and down arrow keys to move between documents, and Enter to open one. Press F2 to reach the actions of a document and to move between them, use Escape to go back to the document list.',
         )}
       </Box>
       <Box
@@ -323,229 +216,24 @@ export const DocTree = ({ currentDoc }: DocTreeProps) => {
           z-index: 2;
         `}
       >
-        <Box
-          ref={rootItemRef}
-          data-testid="doc-tree-root-item"
-          role="treeitem"
-          aria-label={`${t('Root document {{title}}', { title: treeContext.root?.title || untitledDocument })}`}
-          aria-selected={rootIsSelected}
-          tabIndex={0}
-          onFocus={handleRootFocus}
-          onKeyDown={handleRootKeyDown}
-          $css={css`
-            padding: ${spacingsTokens['2xs']};
-            border-radius: var(--c--globals--spacings--st);
-            width: 100%;
-            min-width: 200px;
-            background-color: ${
-              rootIsSelected || rootActionsOpen
-                ? 'var(--c--contextuals--background--semantic--contextual--primary)'
-                : 'transparent'
-            };
-
-            &:hover {
-              background-color: var(
-                --c--contextuals--background--semantic--contextual--primary
-              );
-            }
-
-            &:focus-visible {
-              outline: none !important;
-              box-shadow: 0 0 0 2px var(--c--globals--colors--brand-500) !important;
-              border-radius: var(--c--globals--spacings--st);
-            }
-
-            .doc-tree-root-item-actions {
-              opacity: ${rootActionsOpen ? '1' : '0'};
-              display: ${rootActionsOpen ? 'flex' : 'none'};
-
-              &:has(.isOpen) {
-                opacity: 1;
-              }
-            }
-            &:hover,
-            &:focus-visible,
-            &:focus-within {
-              .doc-tree-root-item-actions {
-                display: flex;
-                opacity: 1;
-              }
-            }
-            /* Remove visual focus from the root item when focus is on the actions */
-            &:has(.doc-tree-root-item-actions *:focus) {
-              box-shadow: none !important;
-            }
-          `}
-        >
-          <StyledLink
-            $css={css`
-              width: 100%;
-            `}
-            href={`/docs/${treeContext.root.id}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              treeContext.treeData.setSelectedNode(
-                treeContext.root ?? undefined,
-              );
-              void router.push(`/docs/${treeContext?.root?.id}`);
-            }}
-            aria-label={`${t('Open root document')}: ${treeContext.root?.title || untitledDocument}`}
-            tabIndex={-1} // avoid double tabstop
-          >
-            <Box $direction="row" $align="center" $width="100%">
-              <SimpleDocItem doc={treeContext.root} showDate={true} />
-              <DocTreeItemActions
-                doc={treeContext.root}
-                onCreateSuccess={(createdDoc) => {
-                  const newDoc = {
-                    ...createdDoc,
-                    children: [],
-                    childrenCount: 0,
-                    parentId: treeContext.root?.id ?? undefined,
-                  };
-                  treeContext?.treeData.addChild(null, newDoc);
-
-                  if (isMobile) {
-                    closePanel();
-                  }
-                }}
-                isOpen={rootActionsOpen}
-                isRoot={true}
-                onOpenChange={handleRootActionsOpenChange}
-                actionsRef={rootActionsRef}
-                buttonOptionRef={rootButtonOptionRef}
-              />
-            </Box>
-          </StyledLink>
-        </Box>
+        <DocTreeRoot
+          currentDoc={currentDoc}
+          rootItemRef={rootItemRef}
+          treeContext={treeContext}
+        />
       </Box>
 
       {initialOpenState &&
         treeContext.treeData.nodes.length > 0 &&
         treeRoot && (
-          <DocTreeView
+          <DocTreeSubpages
             doc={currentDoc}
             treeRoot={treeRoot}
             initialOpenState={initialOpenState}
             rootNodeId={treeContext.root.id}
-            rootItem={rootItemRef.current}
+            rootItemRef={rootItemRef}
           />
         )}
     </Box>
   );
 };
-
-interface DocTreeViewProps {
-  doc: Doc;
-  treeRoot: HTMLElement;
-  initialOpenState: OpenMap;
-  rootNodeId: string;
-  rootItem: HTMLDivElement | null;
-}
-
-const DocTreeView = memo(function DocTreeView({
-  doc,
-  treeRoot,
-  initialOpenState,
-  rootNodeId,
-  rootItem,
-}: DocTreeViewProps) {
-  const { isDesktop } = useResponsive();
-  const treeContext = useTreeContext<Doc | null>();
-  const { mutate: moveDoc } = useMoveDoc();
-  const { query } = useRouter();
-
-  const handleMove = useCallback(
-    (result: TreeViewMoveResult) => {
-      moveDoc({
-        sourceDocumentId: result.sourceId,
-        targetDocumentId: result.targetModeId,
-        position: result.mode,
-      });
-      treeContext?.treeData.handleMove(result);
-    },
-    [moveDoc, treeContext],
-  );
-
-  const canDrop = useCallback(
-    ({ parentNode }: { parentNode: NodeApi<TreeDataItem<Doc>> | null }) => {
-      const parentValue = parentNode?.data.value;
-      if (!parentValue || !isDocNode(parentValue)) {
-        return doc.abilities.move && isDesktop;
-      }
-      return parentValue.abilities.move && isDesktop;
-    },
-    [doc.abilities.move, isDesktop],
-  );
-
-  const canDrag = useCallback(
-    (node: TreeDataItem<Doc>) => {
-      if (!isDocNode(node.value)) {
-        return false;
-      }
-      return node.value.abilities.move && isDesktop;
-    },
-    [isDesktop],
-  );
-
-  const handleRowKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Tab' && e.shiftKey) {
-        e.preventDefault();
-        e.stopPropagation();
-        rootItem?.focus();
-        return;
-      }
-
-      if (e.key !== 'Enter') {
-        return;
-      }
-
-      const target = e.target as HTMLElement | null;
-      if (
-        !target ||
-        !(
-          target.classList.contains('c__tree-view--row') ||
-          target.classList.contains('c__tree-view--node')
-        )
-      ) {
-        return;
-      }
-
-      const treeItem = e.currentTarget.querySelector('[role="treeitem"]');
-      if (treeItem?.getAttribute('aria-selected') === 'true') {
-        e.preventDefault();
-        document.querySelector<HTMLElement>(`.${CLASS_DOC_TITLE}`)?.focus();
-        return;
-      }
-
-      e.currentTarget
-        .querySelector<HTMLDivElement>('.c__tree-view--node')
-        ?.click();
-    },
-    [rootItem],
-  );
-
-  return (
-    <Overlayer isOverlay={doc.deleted_at != null} inert>
-      <TreeView
-        dndRootElement={treeRoot}
-        initialOpenState={initialOpenState}
-        afterMove={handleMove}
-        selectedNodeId={
-          (query.id as string | undefined) ??
-          treeContext?.initialTargetId ??
-          undefined
-        }
-        canDrop={canDrop}
-        canDrag={canDrag}
-        rootNodeId={rootNodeId}
-        renderNode={DocSubPageItem}
-        rowProps={{
-          onKeyDown: handleRowKeyDown,
-        }}
-      />
-    </Overlayer>
-  );
-});

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeItemActions.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeItemActions.tsx
@@ -1,157 +1,39 @@
-import {
-  Button,
-  ButtonElement,
-  DropdownMenu,
-  DropdownMenuOption,
-  useArrowRoving,
-  useModal,
-  useTreeContext,
-} from '@gouvfr-lasuite/ui-components';
+import { Button, ButtonProps } from '@gouvfr-lasuite/ui-components';
 import { useRouter } from 'next/router';
-import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
 
 import AddSVG from '@/assets/icons/ui-kit/add.svg';
-import MoreHorizSVG from '@/assets/icons/ui-kit/more_horiz.svg';
 import { Box, Icon } from '@/components';
-import {
-  Doc,
-  ModalRemoveDoc,
-  Role,
-  getEmojiAndTitle,
-  useCopyDocLink,
-  useCreateChildDoc,
-  useDocTitleUpdate,
-} from '@/docs/doc-management';
-import { useDuplicateDoc } from '@/docs/doc-management/api';
-import DocMoveOutIcon from '@/icons/doc-move-out.svg';
+import { Doc, useCreateChildDoc, useTrans } from '@/docs/doc-management';
+import { DocToolBox } from '@/docs/doc-management/components/DocToolBox';
+import MoreIcon from '@/icons/more_horiz.svg';
 
-import { useDetachDoc } from '../api/useDetach';
+import { CLASS_TREE_ITEM_ACTIONS } from '../utils';
+
+// Module-level so the reference stays stable and the memoized `DocToolBox`
+// isn't forced to re-render on every parent render.
+const TOOLBOX_BUTTON_PROPS: ButtonProps = {
+  color: 'brand',
+  icon: <MoreIcon width={16} height={16} aria-hidden="true" />,
+  size: 'nano',
+  tabIndex: -1,
+};
 
 type DocTreeItemActionsProps = {
   doc: Doc;
-  isOpen?: boolean;
-  isRoot?: boolean;
   onCreateSuccess?: (newDoc: Doc) => void;
   onOpenChange?: (isOpen: boolean) => void;
-  parentId?: string | null;
-  actionsRef?: React.RefObject<HTMLDivElement | null>;
-  buttonOptionRef?: React.RefObject<ButtonElement | null>;
 };
 
 export const DocTreeItemActions = ({
   doc,
-  isOpen,
-  isRoot = false,
   onCreateSuccess,
   onOpenChange,
-  parentId,
-  actionsRef,
-  buttonOptionRef,
 }: DocTreeItemActionsProps) => {
-  const internalActionsRef = useRef<HTMLDivElement | null>(null);
-  const targetActionsRef = actionsRef ?? internalActionsRef;
-  const internalButtonRef = useRef<ButtonElement | null>(null);
-  const targetButtonRef = buttonOptionRef ?? internalButtonRef;
   const router = useRouter();
   const { t } = useTranslation();
-  const deleteModal = useModal();
-  const copyLink = useCopyDocLink(doc.id);
-  const { mutate: detachDoc } = useDetachDoc();
-  const treeContext = useTreeContext<Doc | null>();
-
-  // Keyboard navigation inside the actions toolbar (ArrowLeft / ArrowRight).
-  useArrowRoving(targetActionsRef.current);
-
-  const { mutate: duplicateDoc } = useDuplicateDoc({
-    onSuccess: (duplicatedDoc) => {
-      // Reset the tree context root will reset the full tree view.
-      treeContext?.setRoot(null);
-      void router.push(`/docs/${duplicatedDoc.id}`);
-    },
-  });
-
-  // Emoji Management
-  const { emoji } = getEmojiAndTitle(doc.title ?? '');
-  const { updateDocEmoji } = useDocTitleUpdate();
-  const removeEmoji = () => {
-    updateDocEmoji(doc.id, doc.title ?? '', '');
-  };
-
-  const handleDetachDoc = () => {
-    if (!treeContext?.root) {
-      return;
-    }
-
-    detachDoc(
-      { documentId: doc.id, rootId: treeContext.root.id },
-      {
-        onSuccess: () => {
-          if (treeContext.root) {
-            treeContext.treeData.setSelectedNode(treeContext.root);
-            void router.push(`/docs/${treeContext.root.id}`).then(() => {
-              setTimeout(() => {
-                treeContext?.treeData.deleteNode(doc.id);
-              }, 100);
-            });
-          }
-        },
-      },
-    );
-  };
-
-  const options: DropdownMenuOption[] = [
-    {
-      label: t('Copy link'),
-      icon: <Icon iconName="link" $size="24px" />,
-      callback: copyLink,
-    },
-    ...(!isRoot
-      ? [
-          ...(emoji && doc.abilities.partial_update
-            ? [
-                {
-                  label: t('Remove emoji'),
-                  icon: <Icon iconName="emoji_emotions" $size="24px" />,
-                  callback: removeEmoji,
-                },
-              ]
-            : []),
-          {
-            label: t('Move to my docs'),
-            isDisabled: doc.user_role !== Role.OWNER,
-            icon: (
-              <DocMoveOutIcon
-                width={24}
-                height={24}
-                aria-hidden="true"
-                color="var(--c--contextuals--content--semantic--neutral--primary)"
-              />
-            ),
-            callback: handleDetachDoc,
-          },
-        ]
-      : []),
-    {
-      label: t('Duplicate'),
-      icon: <Icon iconName="content_copy" />,
-      isDisabled: !doc.abilities.duplicate,
-      callback: () => {
-        duplicateDoc({
-          docId: doc.id,
-          with_accesses: false,
-          canSave: doc.abilities.partial_update,
-        });
-      },
-    },
-    {
-      label: t('Delete'),
-      isDisabled: !doc.abilities.destroy,
-      icon: <Icon iconName="delete" $size="24px" />,
-      callback: deleteModal.open,
-    },
-  ];
+  const { untitledDocument } = useTrans();
 
   const { mutate: createChildDoc } = useCreateChildDoc({
     onSuccess: (newDoc) => {
@@ -160,97 +42,56 @@ export const DocTreeItemActions = ({
     },
   });
 
-  const onSuccessDelete = () => {
-    const isTopParent = doc.id === treeContext?.root?.id && !parentId;
-    const parentIdComputed = parentId || treeContext?.root?.id;
-
-    if (isTopParent) {
-      void router.push(`/`);
-    } else if (parentIdComputed) {
-      void router.push(`/docs/${parentIdComputed}`).then(() => {
-        setTimeout(() => {
-          treeContext?.treeData.deleteNode(doc.id);
-        }, 100);
-      });
-    }
-  };
-
   return (
-    <Box className="doc-tree-root-item-actions actions">
-      <Box
-        ref={targetActionsRef}
-        $direction="row"
-        $align="center"
-        className="--docs--doc-tree-item-actions"
-        $gap="4xs"
-        tabIndex={-1}
-        $css={css`
-          & button {
-            height: 24px;
-            width: 24px;
-            padding: 0;
-            justify-content: center;
-            &:focus-visible {
-              box-shadow: 0 0 0 2px
-                var(--c--contextuals--border--semantic--brand--primary);
-            }
+    <Box
+      $direction="row"
+      $align="center"
+      $gap="4xs"
+      className={`${CLASS_TREE_ITEM_ACTIONS} --docs--doc-tree-item-actions actions`}
+      role="toolbar"
+      aria-label={t('Actions for {{title}}', {
+        title: doc.title || untitledDocument,
+      })}
+      tabIndex={-1}
+      $css={css`
+        & button {
+          height: 24px;
+          width: 24px;
+          padding: 0;
+          justify-content: center;
+          &:focus-visible {
+            box-shadow: 0 0 0 2px
+              var(--c--contextuals--border--semantic--brand--primary);
           }
-        `}
-      >
-        <DropdownMenu
-          options={options}
-          isOpen={isOpen}
-          onOpenChange={onOpenChange}
-        >
-          <Button
-            ref={targetButtonRef}
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              onOpenChange?.(!isOpen);
-            }}
-            aria-label={t('More options')}
-            tabIndex={-1}
-            color="brand"
-            variant="tertiary"
-            size="small"
-          >
-            <Icon
-              $color="inherit"
-              icon={<MoreHorizSVG width={16} height={16} aria-hidden="true" />}
-            />
-          </Button>
-        </DropdownMenu>
-        {doc.abilities.children_create && (
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
+        }
+      `}
+    >
+      <DocToolBox
+        doc={doc}
+        isCurrentDoc={doc.id === router.query.id}
+        onOpenChange={onOpenChange}
+        buttonProps={TOOLBOX_BUTTON_PROPS}
+      />
+      {doc.abilities.children_create && (
+        <Button
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
 
-              createChildDoc({
-                parentId: doc.id,
-              });
-            }}
-            aria-label={t('Add a sub page')}
-            data-testid="doc-tree-item-actions-add-child"
-            tabIndex={-1}
-            color="brand"
-            variant="tertiary"
-            size="small"
-          >
-            <Icon
-              $color="inherit"
-              icon={<AddSVG width={16} height={16} aria-hidden="true" />}
-            />
-          </Button>
-        )}
-      </Box>
-      {deleteModal.isOpen && (
-        <ModalRemoveDoc
-          onClose={deleteModal.onClose}
-          doc={doc}
-          onSuccess={onSuccessDelete}
-        />
+            createChildDoc({ parentId: doc.id });
+          }}
+          aria-label={t('Add a sub page')}
+          data-testid="doc-tree-item-actions-add-child"
+          tabIndex={-1}
+          color="brand"
+          variant="tertiary"
+          size="small"
+        >
+          <Icon
+            $color="inherit"
+            icon={<AddSVG width={16} height={16} aria-hidden="true" />}
+          />
+        </Button>
       )}
     </Box>
   );

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeRoot.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeRoot.tsx
@@ -1,0 +1,208 @@
+import { TreeContextType } from '@gouvfr-lasuite/ui-components';
+import { useRouter } from 'next/router';
+import { RefObject, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { css } from 'styled-components';
+
+import { Box, StyledLink } from '@/components';
+import { Doc, SimpleDocItem, useTrans } from '@/docs/doc-management';
+import { useLeftPanelStore } from '@/features/left-panel/stores/useLeftPanelStore';
+import { useResponsiveStore } from '@/stores/useResponsiveStore';
+
+import { CLASS_DOC_TITLE } from '../../doc-header';
+import { useTreeItemActions } from '../hooks/useTreeItemActions';
+import { isWithinTreeItemActions } from '../utils';
+
+import { DocTreeItemActions } from './DocTreeItemActions';
+
+type DocTreeRootProps = {
+  currentDoc: Doc;
+  rootItemRef: RefObject<HTMLDivElement | null>;
+  treeContext: TreeContextType<Doc | null>;
+};
+
+export const DocTreeRoot = ({
+  currentDoc,
+  rootItemRef,
+  treeContext,
+}: DocTreeRootProps) => {
+  const { isMobile } = useResponsiveStore();
+  const { closePanel } = useLeftPanelStore();
+  const { untitledDocument } = useTrans();
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  const root = treeContext.root;
+  const treeApiRef = treeContext.treeApiRef;
+  const isSelected =
+    !!root?.id && treeContext.treeData.selectedNode?.id === root.id;
+
+  const selectRoot = useCallback(() => {
+    if (root) {
+      treeContext.treeData.setSelectedNode(root);
+    }
+  }, [treeContext.treeData, root]);
+
+  const focusRootItem = useCallback(() => {
+    rootItemRef.current?.focus();
+  }, [rootItemRef]);
+
+  const {
+    areActionsVisible,
+    isMenuOpen,
+    onMenuOpenChange,
+    handleActionsKeyDown,
+    itemProps,
+  } = useTreeItemActions({
+    focusItem: focusRootItem,
+  });
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      // F2 / ArrowLeft / ArrowRight / Escape rove within the actions group.
+      if (handleActionsKeyDown(event)) {
+        return;
+      }
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        // ArrowDown enters the sub pages at the first row — from the item
+        // itself or from one of its actions, the same as the sub page rows.
+        // ArrowUp has nowhere to go (the root is the top) but must not scroll
+        // the panel.
+        const api = treeApiRef.current;
+        const firstNode = api?.firstNode;
+        if (event.key === 'ArrowDown' && api && firstNode) {
+          api.focus(firstNode);
+          // react-arborist only moves DOM focus from the effect that fires
+          // when a row's `isFocused` flips to true. When it already considers
+          // the first row focused that effect never runs, so move the focus
+          // ourselves, the way `focusRow` does in `DocSubPageItem`.
+          rootItemRef.current
+            ?.closest('[data-testid="doc-tree"]')
+            ?.querySelector<HTMLElement>(
+              `[data-testid="doc-sub-page-item-${firstNode.id}"]`,
+            )
+            ?.closest<HTMLElement>('.c__tree-view--row')
+            ?.focus();
+        }
+        return;
+      }
+
+      // The remaining keys act on the item itself, never on its focused actions.
+      if (isWithinTreeItemActions(event)) {
+        return;
+      }
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+
+        // Already on this document: move on to its title rather than reloading.
+        if (currentDoc.id === root?.id) {
+          document.querySelector<HTMLElement>(`.${CLASS_DOC_TITLE}`)?.focus();
+        } else if (root) {
+          selectRoot();
+          void router.push(`/docs/${root.id}`);
+        }
+      }
+    },
+    [
+      handleActionsKeyDown,
+      selectRoot,
+      router,
+      currentDoc.id,
+      root,
+      treeApiRef,
+      rootItemRef,
+    ],
+  );
+
+  if (!root) {
+    return null;
+  }
+
+  const title = root.title || untitledDocument;
+
+  return (
+    <Box
+      {...itemProps}
+      ref={rootItemRef}
+      data-testid="doc-tree-root-item"
+      role="treeitem"
+      aria-label={t('Root document {{title}}', { title })}
+      aria-selected={isSelected}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      $css={css`
+        padding: var(--c--globals--spacings--2xs);
+        border-radius: var(--c--globals--spacings--st);
+        width: 100%;
+        min-width: 200px;
+        background-color: ${
+          isSelected || isMenuOpen
+            ? 'var(--c--contextuals--background--semantic--contextual--primary)'
+            : 'transparent'
+        };
+
+        &:hover {
+          background-color: var(
+            --c--contextuals--background--semantic--contextual--primary
+          );
+        }
+
+        &:focus-visible {
+          outline: none !important;
+          box-shadow: 0 0 0 2px var(--c--globals--colors--brand-500) !important;
+          border-radius: var(--c--globals--spacings--st);
+        }
+
+        /* Only one focus ring at a time: the toolbar draws its own. */
+        &:has(.doc-tree-root-item-actions *:focus) {
+          box-shadow: none !important;
+        }
+      `}
+    >
+      <StyledLink
+        $css={css`
+          width: 100%;
+        `}
+        href={`/docs/${root.id}`}
+        onClick={(e) => {
+          if (!e.currentTarget.contains(e.target as Node)) {
+            e.preventDefault();
+            return;
+          }
+          e.stopPropagation();
+          e.preventDefault();
+          selectRoot();
+          void router.push(`/docs/${root.id}`);
+        }}
+        aria-label={`${t('Open root document')}: ${title}`}
+        tabIndex={-1} // the item itself is the tab stop
+      >
+        <Box $direction="row" $align="center" $width="100%">
+          <SimpleDocItem doc={root} showDate={true} />
+          {areActionsVisible && (
+            <DocTreeItemActions
+              doc={root}
+              onOpenChange={onMenuOpenChange}
+              onCreateSuccess={(createdDoc) => {
+                const newDoc = {
+                  ...createdDoc,
+                  children: [],
+                  childrenCount: 0,
+                  parentId: root.id,
+                };
+                treeContext.treeData.addChild(null, newDoc);
+
+                if (isMobile) {
+                  closePanel();
+                }
+              }}
+            />
+          )}
+        </Box>
+      </StyledLink>
+    </Box>
+  );
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeSubpages.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/components/DocTreeSubpages.tsx
@@ -1,0 +1,164 @@
+import {
+  OpenMap,
+  TreeDataItem,
+  TreeView,
+  TreeViewMoveResult,
+  useResponsive,
+  useTreeContext,
+} from '@gouvfr-lasuite/ui-components';
+import { useRouter } from 'next/router';
+import { RefObject, memo, useCallback, useEffect } from 'react';
+import { NodeApi } from 'react-arborist';
+
+import { Overlayer } from '@/components';
+import { CLASS_DOC_TITLE } from '@/docs/doc-header';
+import { Doc, useMoveDoc } from '@/docs/doc-management';
+
+import { isDocNode, isWithinTreeItemActions } from '../utils';
+
+import { DocSubPageItem } from './DocSubPageItem';
+
+interface DocTreeSubPagesProps {
+  doc: Doc;
+  treeRoot: HTMLElement;
+  initialOpenState: OpenMap;
+  rootNodeId: string;
+  rootItemRef: RefObject<HTMLDivElement | null>;
+}
+
+export const DocTreeSubpages = memo(function DocTreeSubpages({
+  doc,
+  treeRoot,
+  initialOpenState,
+  rootNodeId,
+  rootItemRef,
+}: DocTreeSubPagesProps) {
+  const { isDesktop } = useResponsive();
+  const treeContext = useTreeContext<Doc | null>();
+  const { mutateAsync: moveDoc } = useMoveDoc();
+  const { query } = useRouter();
+
+  /**
+   * The root item is the tree's only Tab stop; the sub pages are reached from
+   * it with the arrow keys. react-arborist hardcodes `tabIndex=0` on its
+   * container and `ui-components` does not forward `renderContainer`, so the
+   * attribute is corrected here. React leaves it alone afterwards: it only
+   * writes an attribute when the rendered prop value changes, and this one
+   * stays `0` for the lifetime of the container.
+   */
+  useEffect(() => {
+    treeRoot
+      .querySelector<HTMLElement>('.c__tree-view--container [role="tree"]')
+      ?.setAttribute('tabindex', '-1');
+  }, [treeRoot]);
+
+  const handleMove = useCallback(
+    async (result: TreeViewMoveResult) => {
+      await moveDoc({
+        sourceDocumentId: result.sourceId,
+        targetDocumentId: result.targetModeId,
+        position: result.mode,
+      });
+
+      treeContext?.treeData.handleMove(result);
+    },
+    [moveDoc, treeContext?.treeData],
+  );
+
+  const canDrop = useCallback(
+    ({ parentNode }: { parentNode: NodeApi<TreeDataItem<Doc>> | null }) => {
+      const parentValue = parentNode?.data.value;
+      if (!parentValue || !isDocNode(parentValue)) {
+        return doc.abilities.move && isDesktop;
+      }
+      return parentValue.abilities.move && isDesktop;
+    },
+    [doc.abilities.move, isDesktop],
+  );
+
+  const canDrag = useCallback(
+    (node: TreeDataItem<Doc>) => {
+      if (!isDocNode(node.value)) {
+        return false;
+      }
+      return node.value.abilities.move && isDesktop;
+    },
+    [isDesktop],
+  );
+
+  const handleRowKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        e.stopPropagation();
+        if (e.shiftKey) {
+          e.preventDefault();
+          rootItemRef.current?.focus();
+        }
+        return;
+      }
+
+      // ArrowUp on the first row leaves the sub pages for the root item;
+      // deeper rows fall through to the tree's own row-to-row navigation.
+      if (e.key === 'ArrowUp' && !isWithinTreeItemActions(e)) {
+        const api = treeContext?.treeApiRef.current;
+        if (api && !api.prevNode) {
+          e.preventDefault();
+          e.stopPropagation();
+          rootItemRef.current?.focus();
+        }
+        return;
+      }
+
+      if (e.key !== 'Enter') {
+        return;
+      }
+
+      // Classes rendered by the `ui-components` TreeView / TreeViewItem.
+      const target = e.target as HTMLElement | null;
+      if (
+        !target ||
+        !(
+          target.classList.contains('c__tree-view--row') ||
+          target.classList.contains('c__tree-view--node')
+        )
+      ) {
+        return;
+      }
+
+      // Already on this document: move on to its title rather than reloading.
+      const treeItem = e.currentTarget.querySelector('[role="treeitem"]');
+      if (treeItem?.getAttribute('aria-selected') === 'true') {
+        e.preventDefault();
+        document.querySelector<HTMLElement>(`.${CLASS_DOC_TITLE}`)?.focus();
+        return;
+      }
+
+      e.currentTarget
+        .querySelector<HTMLDivElement>('.c__tree-view--node')
+        ?.click();
+    },
+    [rootItemRef, treeContext],
+  );
+
+  return (
+    <Overlayer isOverlay={doc.deleted_at != null} inert>
+      <TreeView
+        dndRootElement={treeRoot}
+        initialOpenState={initialOpenState}
+        afterMove={handleMove}
+        selectedNodeId={
+          (query.id as string | undefined) ??
+          treeContext?.initialTargetId ??
+          undefined
+        }
+        canDrop={canDrop}
+        canDrag={canDrag}
+        rootNodeId={rootNodeId}
+        renderNode={DocSubPageItem}
+        rowProps={{
+          onKeyDown: handleRowKeyDown,
+        }}
+      />
+    </Overlayer>
+  );
+});

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/hooks/useTreeItemActions.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/hooks/useTreeItemActions.ts
@@ -1,0 +1,148 @@
+import {
+  FocusEvent,
+  HTMLAttributes,
+  KeyboardEvent,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+
+import { useResponsiveStore } from '@/stores';
+
+import { isWithinTreeItemActions } from '../utils';
+
+type UseTreeItemActionsProps = {
+  isActive?: boolean;
+  onFocus?: () => void;
+  focusItem: () => void;
+};
+
+type UseTreeItemActionsReturn = {
+  /** Whether `DocTreeItemActions` should be rendered for this item. */
+  areActionsVisible: boolean;
+  isMenuOpen: boolean;
+  onMenuOpenChange: (isOpen: boolean) => void;
+  /**
+   * Keyboard access to the actions, to run first in the item's `onKeyDown`.
+   * They form a single roving group — the emoji button then the toolbar
+   * buttons, in DOM order:
+   * - F2 enters the group / steps to the next button, wrapping;
+   * - ArrowLeft / ArrowRight move within it once a button is focused;
+   * - Escape leaves it for the item.
+   *
+   * Returns whether the event was handled, so the caller can stop there.
+   */
+  handleActionsKeyDown: (event: KeyboardEvent<HTMLElement>) => boolean;
+  /** Spread on the element wrapping the item and its actions. */
+  itemProps: Required<
+    Pick<
+      HTMLAttributes<HTMLElement>,
+      'onMouseEnter' | 'onMouseLeave' | 'onFocus' | 'onBlur'
+    >
+  >;
+};
+
+/** Focusable action buttons inside `container`, in DOM order. */
+const getActionButtons = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLButtonElement>('button')).filter(
+    (button) =>
+      !button.disabled && button.getAttribute('aria-disabled') !== 'true',
+  );
+
+/**
+ * Drives how a tree item reveals its actions, across every input method:
+ * pointer (hover), keyboard (focus, then F2 / arrows to step through them) and
+ * touch (always visible, since there is no hover).
+ *
+ * Visibility is React state rather than `:hover` / `:focus-within` CSS, so the
+ * actions — and the fairly heavy dropdown menu they mount — only exist for the
+ * one item the user is interacting with instead of for every row in the tree.
+ */
+export const useTreeItemActions = ({
+  isActive = false,
+  onFocus,
+  focusItem,
+}: UseTreeItemActionsProps): UseTreeItemActionsReturn => {
+  const { isMobile } = useResponsiveStore();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isPointerOver, setIsPointerOver] = useState(false);
+  const [hasFocusWithin, setHasFocusWithin] = useState(false);
+
+  const onMenuOpenChange = useCallback((isOpen: boolean) => {
+    setIsMenuOpen(isOpen);
+  }, []);
+
+  const handleActionsKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      // While the menu is open the keyboard belongs to it: Escape closes it and
+      // `onMenuOpenChange` restores focus from there.
+      if (isMenuOpen) {
+        return false;
+      }
+
+      const buttons = getActionButtons(event.currentTarget);
+      const current = buttons.indexOf(
+        document.activeElement as HTMLButtonElement,
+      );
+
+      // F2 enters the group (or steps forward once inside).
+      if (event.key === 'F2' && buttons.length > 0) {
+        event.preventDefault();
+        // Keep the TreeView row from re-focusing the emoji button behind us.
+        event.stopPropagation();
+        buttons[(current + 1) % buttons.length].focus();
+        return true;
+      }
+
+      // Arrows only rove once focus is already on one of the buttons, so that
+      // an arrow on the bare tree item still reaches the tree's own handler.
+      if (
+        (event.key === 'ArrowRight' || event.key === 'ArrowLeft') &&
+        current !== -1
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        const delta = event.key === 'ArrowRight' ? 1 : -1;
+        buttons[(current + delta + buttons.length) % buttons.length].focus();
+        return true;
+      }
+
+      if (event.key === 'Escape' && isWithinTreeItemActions(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        focusItem();
+        return true;
+      }
+
+      return false;
+    },
+    [isMenuOpen, focusItem],
+  );
+
+  const itemProps = useMemo(
+    () => ({
+      onMouseEnter: () => setIsPointerOver(true),
+      onMouseLeave: () => setIsPointerOver(false),
+      onFocus: () => {
+        setHasFocusWithin(true);
+        onFocus?.();
+      },
+      onBlur: (event: FocusEvent<HTMLElement>) => {
+        // Focus moving between the item and its own actions is not a blur.
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setHasFocusWithin(false);
+        }
+      },
+    }),
+    [onFocus],
+  );
+
+  return {
+    areActionsVisible:
+      isMobile || isMenuOpen || isPointerOver || hasFocusWithin || isActive,
+    isMenuOpen,
+    onMenuOpenChange,
+    handleActionsKeyDown,
+    itemProps,
+  };
+};

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/utils.ts
@@ -9,6 +9,13 @@ import { useContext } from 'react';
 
 import { Doc } from '../doc-management';
 
+export const CLASS_TREE_ITEM_ACTIONS = 'doc-tree-root-item-actions';
+
+export const isWithinTreeItemActions = (event: React.SyntheticEvent) =>
+  !!(event.target as HTMLElement | null)?.closest(
+    `.${CLASS_TREE_ITEM_ACTIONS}`,
+  );
+
 /**
  * Type guard to check if a tree node value is a Doc (as opposed to a
  * ui-kit synthetic node like VIEW_MORE, SEPARATOR, TITLE, or SIMPLE_NODE).
@@ -54,6 +61,8 @@ export const syncDocInTree = (
   } else if (treeContext.treeData.getNode(docId)) {
     treeContext.treeData.updateNode(docId, data);
   }
+
+  treeContext.treeApiRef.current?.focus(docId);
 };
 
 export const findIndexInTree = (

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/utils.ts
@@ -1,8 +1,11 @@
 import {
+  TreeContext,
+  TreeContextType,
   TreeDataItem,
   TreeViewDataType,
   TreeViewNodeTypeEnum,
 } from '@gouvfr-lasuite/ui-components';
+import { useContext } from 'react';
 
 import { Doc } from '../doc-management';
 
@@ -22,6 +25,35 @@ export const subPageToTree = (children: Doc[]): TreeViewDataType<Doc>[] => {
     subPageToTree(child.children ?? []);
   });
   return children;
+};
+
+export const useTreeContextOrNull = <T = Doc>(): TreeContextType<T> | null =>
+  useContext(TreeContext);
+
+/**
+ * The doc tree keeps its own copy of each doc (`treeContext.treeData` /
+ * `treeContext.root`), which react-query cache invalidations don't reach. Code
+ * mutating a doc from a tree item must sync the changed fields into the tree by
+ * hand, otherwise the tree UI stays stale until it is reloaded.
+ *
+ * No-op when there is no tree context (e.g. the doc grid or the doc header),
+ * where the react-query cache is the single source of truth.
+ */
+export const syncDocInTree = (
+  treeContext: TreeContextType<Doc> | null,
+  docId: string,
+  data: Partial<Doc>,
+) => {
+  if (!treeContext) {
+    return;
+  }
+
+  const { root } = treeContext;
+  if (root && root.id === docId) {
+    treeContext.setRoot({ ...root, ...data });
+  } else if (treeContext.treeData.getNode(docId)) {
+    treeContext.treeData.updateNode(docId, data);
+  }
 };
 
 export const findIndexInTree = (

--- a/src/frontend/apps/impress/src/features/docs/doc-tree/utils.ts
+++ b/src/frontend/apps/impress/src/features/docs/doc-tree/utils.ts
@@ -65,6 +65,10 @@ export const syncDocInTree = (
   treeContext.treeApiRef.current?.focus(docId);
 };
 
+export const reloadTree = (treeContext: TreeContextType<Doc | null> | null) => {
+  treeContext?.setRoot(null);
+};
+
 export const findIndexInTree = (
   nodes: TreeDataItem<TreeViewDataType<Doc>>[],
   key: string,

--- a/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridActions.tsx
+++ b/src/frontend/apps/impress/src/features/docs/docs-grid/components/DocsGridActions.tsx
@@ -1,12 +1,9 @@
 import {
-  Button,
-  DropdownMenu,
+  ButtonProps,
   DropdownMenuItem,
   VariantType,
   useToastProvider,
 } from '@gouvfr-lasuite/ui-components';
-import dynamic from 'next/dynamic';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Icon } from '@/components/Icon';
@@ -14,63 +11,22 @@ import {
   type Doc,
   KEY_LIST_DOC,
   KEY_LIST_FAVORITE_DOC,
-  useCreateFavoriteDoc,
-  useDeleteFavoriteDoc,
-  useDuplicateDoc,
   useRestoreDoc,
-  useTrans,
 } from '@/docs/doc-management';
-import ContentCopyIcon from '@/icons/content_copy.svg';
-import DeleteIcon from '@/icons/delete.svg';
-import DocMoveInIcon from '@/icons/doc-move-in.svg';
-import GroupIcon from '@/icons/group.svg';
-import LeaveIcon from '@/icons/leave.svg';
+import { DocToolBox } from '@/docs/doc-management/components/DocToolBox';
 import MoreIcon from '@/icons/more_horiz.svg';
-import StarSlashIcon from '@/icons/star-slash.svg';
-import StarIcon from '@/icons/star.svg';
-import { focusMainContentStart } from '@/layouts/utils';
-import { useFocusStore } from '@/stores';
 
 import { KEY_LIST_DOC_TRASHBIN } from '../api';
-
-const DocMoveModal = dynamic(
-  () =>
-    import('@/docs/doc-management/components/DocMoveModal').then((mod) => ({
-      default: mod.DocMoveModal,
-    })),
-  { ssr: false },
-);
-
-const DocShareModal = dynamic(
-  () =>
-    import('@/docs/doc-share/components/DocShareModal').then((mod) => ({
-      default: mod.DocShareModal,
-    })),
-  { ssr: false },
-);
-
-const ModalRemoveDoc = dynamic(
-  () =>
-    import('@/docs/doc-management/components/ModalRemoveDoc').then((mod) => ({
-      default: mod.ModalRemoveDoc,
-    })),
-  { ssr: false },
-);
-
-const ConfirmationLeaveModal = dynamic(
-  () =>
-    import('@/docs/doc-share/components/ConfirmationLeaveModal').then(
-      (mod) => ({
-        default: mod.ConfirmationLeaveModal,
-      }),
-    ),
-  { ssr: false },
-);
 
 interface DocsGridActionsProps {
   doc: Doc;
   isInTrashbin?: boolean;
 }
+
+const TOOLBOX_BUTTON_PROPS: ButtonProps = {
+  icon: <MoreIcon width={16} height={16} aria-hidden="true" />,
+  size: 'nano',
+};
 
 export const DocsGridActions = ({
   doc,
@@ -79,141 +35,11 @@ export const DocsGridActions = ({
   return isInTrashbin ? (
     <DocsGridTrashbinActions doc={doc} />
   ) : (
-    <DocsGridActionsGlobal doc={doc} />
-  );
-};
-
-const DocsGridActionsGlobal = ({ doc }: { doc: Doc }) => {
-  const { t } = useTranslation();
-  const { restoreFocus } = useFocusStore();
-  const [isModalRemoveOpen, setIsModalRemoveOpen] = useState(false);
-  const [isModalLeaveOpen, setIsModalLeaveOpen] = useState(false);
-  const [isModalShareOpen, setIsModalShareOpen] = useState(false);
-  const [isModalMoveOpen, setIsModalMoveOpen] = useState(false);
-
-  const { mutate: duplicateDoc } = useDuplicateDoc({
-    onSuccess: () => {
-      requestAnimationFrame(() => {
-        focusMainContentStart({ preventScroll: true });
-      });
-    },
-  });
-
-  const removeFavoriteDoc = useDeleteFavoriteDoc({
-    listInvalidQueries: [KEY_LIST_DOC, KEY_LIST_FAVORITE_DOC],
-  });
-  const makeFavoriteDoc = useCreateFavoriteDoc({
-    listInvalidQueries: [KEY_LIST_DOC, KEY_LIST_FAVORITE_DOC],
-  });
-
-  const options: DropdownMenuItem[] = [
-    {
-      label: doc.is_favorite ? t('Unstar') : t('Star'),
-      icon: doc.is_favorite ? (
-        <StarSlashIcon width={18} height={18} aria-hidden="true" />
-      ) : (
-        <StarIcon width={18} height={18} aria-hidden="true" />
-      ),
-      callback: () => {
-        if (doc.is_favorite) {
-          removeFavoriteDoc.mutate({ id: doc.id });
-        } else {
-          makeFavoriteDoc.mutate({ id: doc.id });
-        }
-      },
-      testId: `docs-grid-actions-${doc.is_favorite ? 'unstar' : 'star'}-${doc.id}`,
-      showSeparator: true,
-    },
-    {
-      label: t('Share'),
-      icon: <GroupIcon width={18} height={18} aria-hidden="true" />,
-      callback: () => {
-        setIsModalShareOpen(true);
-      },
-
-      testId: `docs-grid-actions-share-${doc.id}`,
-    },
-    {
-      label: t('Move into a doc'),
-      icon: <DocMoveInIcon width={18} height={18} aria-hidden="true" />,
-      callback: () => {
-        setIsModalMoveOpen(true);
-      },
-      testId: `docs-grid-actions-move-${doc.id}`,
-      isHidden: !doc.abilities.move,
-    },
-    {
-      label: t('Duplicate'),
-      icon: <ContentCopyIcon width={18} height={18} aria-hidden="true" />,
-      isDisabled: !doc.abilities.duplicate,
-      callback: () => {
-        duplicateDoc({
-          docId: doc.id,
-          with_accesses: false,
-          canSave: false,
-        });
-      },
-      showSeparator: true,
-    },
-    {
-      label: t('Leave'),
-      icon: <LeaveIcon width={18} height={18} aria-hidden="true" />,
-      callback: () => {
-        setIsModalLeaveOpen(true);
-      },
-    },
-    {
-      label: t('Delete'),
-      icon: <DeleteIcon width={18} height={18} aria-hidden="true" />,
-      callback: () => {
-        setIsModalRemoveOpen(true);
-      },
-      isHidden: !doc.abilities.destroy,
-      testId: `docs-grid-actions-remove-${doc.id}`,
-    },
-  ];
-
-  return (
-    <>
-      <DocsGridDropdown doc={doc} options={options} />
-      {isModalRemoveOpen && (
-        <ModalRemoveDoc
-          onClose={() => {
-            setIsModalRemoveOpen(false);
-            restoreFocus();
-          }}
-          doc={doc}
-        />
-      )}
-      {isModalShareOpen && (
-        <DocShareModal
-          doc={doc}
-          onClose={() => {
-            setIsModalShareOpen(false);
-            restoreFocus();
-          }}
-        />
-      )}
-      {isModalLeaveOpen && (
-        <ConfirmationLeaveModal
-          onClose={() => {
-            setIsModalLeaveOpen(false);
-            restoreFocus();
-          }}
-          doc={doc}
-        />
-      )}
-      {isModalMoveOpen && (
-        <DocMoveModal
-          doc={doc}
-          onClose={() => {
-            setIsModalMoveOpen(false);
-            restoreFocus();
-          }}
-          isOpen={isModalMoveOpen}
-        />
-      )}
-    </>
+    <DocToolBox
+      doc={doc}
+      isCurrentDoc={false}
+      buttonProps={TOOLBOX_BUTTON_PROPS}
+    />
   );
 };
 
@@ -276,43 +102,12 @@ export const DocsGridTrashbinActions = ({
     },
   ];
 
-  return <DocsGridDropdown doc={doc} options={options} />;
-};
-
-interface DocsGridDropdownProps {
-  doc: Doc;
-  options: DropdownMenuItem[];
-}
-
-const DocsGridDropdown = ({ doc, options }: DocsGridDropdownProps) => {
-  const { t } = useTranslation();
-  const [openDropdown, setOpenDropdown] = useState(false);
-  const { addLastFocus } = useFocusStore();
-  const { untitledDocument } = useTrans();
-
   return (
-    <DropdownMenu
-      options={options}
-      isOpen={openDropdown}
-      shouldCloseOnInteractOutside={() => true}
-      onOpenChange={setOpenDropdown}
-    >
-      <Button
-        data-testid={`docs-grid-actions-button-${doc.id}`}
-        aria-label={t('Open the menu of actions for the document: {{title}}', {
-          title: doc.title || untitledDocument,
-        })}
-        size="nano"
-        icon={<MoreIcon width={16} height={16} aria-hidden="true" />}
-        color="neutral"
-        variant="tertiary"
-        onClick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          setOpenDropdown((o) => !o);
-          addLastFocus(e.currentTarget);
-        }}
-      />
-    </DropdownMenu>
+    <DocToolBox
+      doc={doc}
+      isCurrentDoc={false}
+      buttonProps={TOOLBOX_BUTTON_PROPS}
+      optionsDefault={options}
+    />
   );
 };

--- a/src/frontend/apps/impress/src/i18n/translations.json
+++ b/src/frontend/apps/impress/src/i18n/translations.json
@@ -1523,6 +1523,7 @@
       "Open new document options": "Ouvrir les options de nouveau document",
       "Open root document": "Ouvrir le document racine",
       "Open the document options": "Ouvrir les options du document",
+      "Open the document options: {{title}}": "Ouvrir les options du document: {{title}}",
       "Open the menu of actions for the document: {{title}}": "Ouvrir le menu des actions du document : {{title}}",
       "Open the sharing settings for the document": "Ouvrir les paramètres de partage pour le document",
       "Organize": "Organiser",


### PR DESCRIPTION
## Purpose

Depend the part of the app, we had different implementations of the toolbox menu. 
This commit unifies the implementation and uses the same component for both the docs grid, the doc tree and the doc header. It will make it easier to maintain and add new features to the toolbox menu.

Adding the toolbox in the tree highlighted some problems, we refactorized the accessibility of the tree to work correctly with the new component.

## Proposal

<img width="1312" height="633" alt="image" src="https://github.com/user-attachments/assets/2a2285ec-2d9c-43e2-aafd-12c43e22abce" />
