### PR TITLE
🐛(frontend) hide leave option when unauthenticated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(frontend) hide Leave in the doc menu when not logged in #2626
+
 ## [v5.6.0] - 2026-09-03
 
 ### Added

--- a/src/frontend/apps/e2e/__tests__/app-impress/doc-visibility.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/doc-visibility.spec.ts
@@ -247,6 +247,13 @@ test.describe('Doc Visibility: Public', () => {
     await writeInEditor({ page, text: 'Can you see it ?' });
     await expect(otherEditor.getByText('Can you see it ?')).toBeVisible();
 
+    await otherPage
+      .getByRole('button', { name: 'Open the document options' })
+      .click();
+    await expect(
+      otherPage.getByRole('menuitem', { name: 'Leave' }),
+    ).toBeHidden();
+
     await cleanup();
   });
 

--- a/src/frontend/apps/impress/src/features/docs/doc-management/components/DocToolBox.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-management/components/DocToolBox.tsx
@@ -311,8 +311,9 @@ const DocToolBoxComponent = ({
        * A user can only leave a top parent because we cannot
        * leave a child if the parent is not left.
        * ⚠️ This doc can still be a child for other users.
+       * Unauthenticated visitors also cannot leave.
        */
-      isHidden: !isTopParent,
+      isHidden: !isTopParent || !authenticated,
     },
     {
       label: t('Delete', {


### PR DESCRIPTION
## Purpose

The document options menu showed **Leave** to people who were not logged in. Anonymous visitors cannot leave a document, so that item should not appear.

## Proposal

* Hide Leave unless this is a top-level doc **and** `doc.abilities.leave` is true (backend already requires an authenticated user).
* Changelog note under Unreleased.

Fixes #2626

## External contributions

Thank you for your contribution! 🎉

Please ensure the following items are checked before submitting your pull request:

### General requirements

* [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/docs/blob/main/CONTRIBUTING.md)
* [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/docs/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added corresponding tests for new features or bug fixes (if applicable)

*Skip the checkbox below 👇 if you're fixing an issue or adding documentation*
* [ ] Before submitting a PR for a new feature I made sure to contact the product manager

### CI requirements

* [ ] I made sure that all existing tests are passing
* [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
* [ ] I have signed my commits with my SSH or GPG key (`git commit -S`)
* [x] My commit messages follow the required format: `<gitmoji>(type) title description`
* [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)

### AI requirements

*Skip the checkboxes below 👇 If you didn't use AI for your contribution*

* [ ] I used AI assistance to produce part or all of this contribution
* [ ] I have read, reviewed, understood and can explain the code I am submitting
* [ ] I can jump in a call or a chat to explain my work to a maintainer
