### PR TITLE
🐛(backend) skip session creation for the liveness probe

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ __pycache__
 **/*.pyc
 venv
 .venv
+**/.venv
+**/venv
 
 # System-specific files
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) skip session creation for the liveness probe
 - 🐛(frontend) preserve page titles when adding an emoji #2586
 
 ## [v5.6.1] - 2026-09-04

--- a/src/backend/core/middleware.py
+++ b/src/backend/core/middleware.py
@@ -2,6 +2,12 @@
 
 from django.utils.deprecation import MiddlewareMixin
 
+# Paths that must never touch the session store. The liveness probe is called
+# by the kubelet every few seconds and has to keep answering even when the
+# session backend (Redis) is slow or down, otherwise every backend container
+# gets killed and restarted in a loop as soon as Redis hangs.
+SESSION_EXEMPT_PATHS = ("/__lbheartbeat__",)
+
 
 class ForceSessionMiddleware(MiddlewareMixin):
     """
@@ -11,6 +17,11 @@ class ForceSessionMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """Force session creation for unauthenticated users."""
+        # Check the path before touching `request.user`: evaluating it loads
+        # the session from the cache backend.
+        if request.path.rstrip("/") in SESSION_EXEMPT_PATHS:
+            return
+
         if not request.user.is_authenticated and request.session.session_key is None:
             request.session.create()
 

--- a/src/backend/core/tests/test_middleware.py
+++ b/src/backend/core/tests/test_middleware.py
@@ -1,0 +1,81 @@
+"""
+Test the ForceSessionMiddleware of the Impress core app.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.backends.cache import SessionStore
+from django.test import RequestFactory
+
+import pytest
+from rest_framework.test import APIClient
+
+from core import factories
+from core.middleware import ForceSessionMiddleware
+
+pytestmark = pytest.mark.django_db
+
+
+def _process(path, user):
+    """Run the middleware on a request for `path` and return the request."""
+    request = RequestFactory().get(path)
+    request.user = user
+    request.session = SessionStore()
+    ForceSessionMiddleware(lambda req: None).process_request(request)
+    return request
+
+
+def test_middleware_force_session_anonymous_creates_session():
+    """An anonymous request on a regular path gets a session created."""
+    request = _process("/api/v1.0/config/", AnonymousUser())
+    assert request.session.session_key is not None
+
+
+def test_middleware_force_session_authenticated_does_not_create_session():
+    """An authenticated request does not get a new session forced on it."""
+    request = _process("/api/v1.0/config/", factories.UserFactory())
+    assert request.session.session_key is None
+
+
+@pytest.mark.parametrize("path", ["/__lbheartbeat__", "/__lbheartbeat__/"])
+def test_middleware_force_session_liveness_probe_skips_session(path):
+    """
+    The liveness probe must never create a session nor load one: it has to keep
+    answering when the session backend is unavailable.
+    """
+    with (
+        patch.object(SessionStore, "create") as mock_create,
+        patch.object(SessionStore, "load") as mock_load,
+    ):
+        request = _process(path, AnonymousUser())
+
+    mock_create.assert_not_called()
+    mock_load.assert_not_called()
+    assert request.session.session_key is None
+
+
+def test_middleware_force_session_liveness_probe_end_to_end():
+    """A liveness probe request answers 200 without touching the session store."""
+    client = APIClient()
+
+    with (
+        patch.object(SessionStore, "create") as mock_create,
+        patch.object(SessionStore, "load") as mock_load,
+    ):
+        response = client.get("/__lbheartbeat__")
+
+    assert response.status_code == 200
+    mock_create.assert_not_called()
+    mock_load.assert_not_called()
+    assert "docs_sessionid" not in response.cookies
+
+
+def test_middleware_force_session_anonymous_end_to_end_still_gets_cookie():
+    """A regular anonymous request still receives a session cookie."""
+    client = APIClient()
+
+    response = client.get("/api/v1.0/config/")
+
+    assert response.status_code == 200
+    assert "docs_sessionid" in response.cookies


### PR DESCRIPTION
## Purpose

The ForceSessionMiddleware force the session creation, we wanto to
ignore it when the request is the liveness probe. The liveness probe
must not check if redis is available, this is the readiness probe job

## Proposal

* [x] 🐛(backend) skip session creation for the liveness probe
* [x] 🙈(docker) ignore **/.venv files