### PR TITLE
🐛(frontend) hide the selection highlight on presenter images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 - 🐛(backend) skip session creation for the liveness probe
 - 🐛(frontend) preserve page titles when adding an emoji #2586
+- 🐛(frontend) hide the selection highlight on presenter images #2665
 
 ## [v5.6.1] - 2026-09-04
 
@@ -57,7 +58,7 @@ and this project adheres to
 - 🐛(backend) fix duplicating a document that has no content #2609
 - 📄(frontend) allowed partially export when MIT #2551
 - 🐛(backend) manage async support for Docs custom middleware #2619
-- 🐛(frontend) save the doc with a keepalive 
+- 🐛(frontend) save the doc with a keepalive
   request when leaving the page #2619
 - 🐛(frontend) export any raster image supported by the browser to a PDF #2530
 

--- a/src/frontend/apps/e2e/__tests__/app-impress/presenter-mode.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-impress/presenter-mode.spec.ts
@@ -225,7 +225,7 @@ test.describe('Presenter Mode', () => {
     const presenterImage = overlay.locator('img.bn-visual-media').first();
     await expect(presenterImage).toBeAttached({ timeout: 10000 });
 
-    const outline = await presenterImage.evaluate((img) => {
+    const selectionChrome = await presenterImage.evaluate((img) => {
       const blockContent = img.closest('.bn-block-content');
       blockContent?.classList.add('ProseMirror-selectednode');
 
@@ -237,12 +237,16 @@ test.describe('Presenter Mode', () => {
       return {
         outlineStyle: style.outlineStyle,
         outlineWidth: style.outlineWidth,
+        // BlockNote also paints the selection as an ::after overlay, which
+        // an outline reset alone leaves visible.
+        overlayContent: getComputedStyle(outlinedElement, '::after').content,
       };
     });
 
-    expect(outline).toEqual({
+    expect(selectionChrome).toEqual({
       outlineStyle: 'none',
       outlineWidth: '0px',
+      overlayContent: 'none',
     });
   });
 

--- a/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterSlideContent.tsx
+++ b/src/frontend/apps/impress/src/features/docs/doc-presenter/components/PresenterSlideContent.tsx
@@ -28,6 +28,16 @@ const slideContentCss = css`
     outline: 0 !important;
   }
 
+  /* BlockNote 0.54 draws the node selection as an ::after overlay
+     (translucent fill + inset ring), so zeroing the outline above is not
+     enough to hide it. */
+  .bn-block-content.ProseMirror-selectednode > *::after,
+  .ProseMirror-selectednode > .bn-block-content > *::after,
+  .bn-block-content .ProseMirror-selectednode::after,
+  .bn-inline-content .ProseMirror-selectednode::after {
+    content: none !important;
+  }
+
   .bn-block-content[data-content-type='divider'] {
     display: none;
   }


### PR DESCRIPTION
## Purpose

Opening presenter mode paints a blue frame and tint on a slide that starts
with an image, which reads as keyboard focus even though nothing is focused.

It is BlockNote's node selection: it is drawn as an `::after`
overlay, and the presenter only reset `outline`. The same component renders
the PDF export, so the halo was also printed into exported slides.

Reported as "focus is put on image of the presentation with no reason".
The actual focus handling in presenter mode is a separate change that is handle in [this ](https://github.com/suitenumerique/docs/pull/2533)PR.



**BEFORE :** 

https://github.com/user-attachments/assets/2935ec7c-c8f4-4569-b594-9c6530ce7e6f

**AFTER :** 

https://github.com/user-attachments/assets/bdd54d7b-1875-45c5-a38a-dedd13688c42



## Proposal

* [x] Hide BlockNote's `::after` selection overlay in presenter slides
* [x] Extend the existing e2e test to assert on the overlay, not just `outline`
* [x] no regression: images stay selectable (blue chrome) outside presenter mode